### PR TITLE
wix-ui-core: add rtl support for components

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -32,6 +32,7 @@
     "babel-runtime": "^6.22.0",
     "jss": "^9.3.3",
     "jss-preset-default": "^4.0.1",
+    "jss-rtl": "^0.2.1",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/packages/wix-ui-core/src/createHOC.js
+++ b/packages/wix-ui-core/src/createHOC.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {string} from 'prop-types';
-import ReactDOM from 'react-dom';
-
+import {findDOMNode} from 'react-dom';
 
 export const createHOC = Component => {
   class WixComponent extends React.PureComponent {
@@ -10,7 +9,7 @@ export const createHOC = Component => {
     componentDidMount() {
       const {dataHook} = this.props;
       if (dataHook) {
-        const domNode = ReactDOM.findDOMNode(this);
+        const domNode = findDOMNode(this);
         if (domNode) {
           domNode.setAttribute('data-hook', dataHook);
         }

--- a/packages/wix-ui-core/src/theme/DOMStyleRenderer.js
+++ b/packages/wix-ui-core/src/theme/DOMStyleRenderer.js
@@ -1,12 +1,15 @@
 import {create, SheetsManager} from 'jss';
 import preset from 'jss-preset-default';
+import rtl from 'jss-rtl';
 
 const jss = create(preset());
+jss.use(rtl());
+
 const sheetManager = new SheetsManager();
 const sheetMapper = {};
 
-const atachStyleSheetToDom = (styles, componentId) => {
-  const newSheet = jss.createStyleSheet(styles);
+const atachStyleSheetToDom = ({styles, componentId, rtl}) => {
+  const newSheet = jss.createStyleSheet(styles, {flip: rtl});
 
   if (sheetMapper[componentId]) {
     sheetManager.unmanage(sheetMapper[componentId]);
@@ -20,8 +23,8 @@ const atachStyleSheetToDom = (styles, componentId) => {
   return newSheet;
 };
 
-export const generateClasses = (styles, componentId) => {
-  const {classes} = atachStyleSheetToDom(styles, componentId);
+export const generateClasses = ({styles, componentId, rtl}) => {
+  const {classes} = atachStyleSheetToDom({styles, componentId, rtl});
   return classes;
 };
 

--- a/packages/wix-ui-core/src/theme/withClasses.js
+++ b/packages/wix-ui-core/src/theme/withClasses.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {findDOMNode} from 'react-dom';
 import {object} from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
 import {generateClasses, detachStyleSheetFromDom} from './DOMStyleRenderer';
@@ -13,12 +14,43 @@ export function withClasses(CoreComponent, styles) {
     constructor(props) {
       super(props);
       this.id = uniqueId();
-      this.state = {classes: generateClasses(styles(props.theme), this.id)};
+      this.state = {
+        rtl: false,
+        classes: generateClasses({
+          styles: styles(props.theme),
+          componentId: this.id,
+          rtl: false
+        })
+      };
+    }
+
+    componentDidMount() {
+      let domNode = findDOMNode(this);
+      while (domNode) {
+        if (isContainingRtlClass(domNode)) {
+          this.setState({
+            rtl: true,
+            classes: generateClasses({
+              styles: styles(this.props.theme),
+              componentId: this.id,
+              rtl: true
+            })
+          });
+          return;
+        }
+        domNode = domNode.parentElement;
+      }
     }
 
     componentWillReceiveProps(nextProps) {
       if (this.props.theme !== nextProps.theme) {
-        this.setState({classes: generateClasses(styles(nextProps.theme), this.id)});
+        this.setState({
+          classes: generateClasses({
+            styles: styles(nextProps.theme),
+            componentId: this.id,
+            rtl: this.state.rtl
+          })
+        });
       }
     }
 
@@ -36,4 +68,9 @@ export function withClasses(CoreComponent, styles) {
   }
 
   return ThemedComponent;
+}
+
+function isContainingRtlClass(domNode) {
+  const className = domNode.getAttribute('class');
+  return !!className && className.split(' ').indexOf('rtl') !== -1;
 }


### PR DESCRIPTION
Added rtl support for **all** core components.
One thing which is not solved here is when the user changes the global rtl class (remove or add) the component won't get updated.

One possible solution is for such applications to allow passing an `rtl` prop to the component. This is not added to this pr, if it sounds reasonable I can easily add it.

If it is a concern we want to handle, I can add it as a task to think of a better solution. I am sure there is one.

IMO the best performance wise solution would be adding a provider that wraps the whole app, and all it does is simply getting an rtl as a prop (the default value can be doing the lookup like I just implemented, but the good thing is that it will only happen once instead of the amount of the rendered components)