### PR TITLE
separate test in watch mode from start command

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "pretest": "haste lint && haste build && build-storybook",
     "test": "haste test --jest && haste test --protractor",
-    "start": "haste start & npm run storybook",
+    "test:watch": "haste test --jest --watch",
+    "start": "haste start --no-test & npm run storybook",
     "release": "haste release",
     "build": "haste build && import-path --path src",
     "storybook": "start-storybook -p 6006"

--- a/packages/wix-ui-backoffice/package.json
+++ b/packages/wix-ui-backoffice/package.json
@@ -23,8 +23,9 @@
     "precommit": "haste lint",
     "pretest": "npm run build && build-storybook",
     "test": "haste test --jest && haste test --protractor",
+    "test:watch": "haste test --jest --watch",
     "posttest": "haste lint",
-    "start": "haste start & npm run storybook",
+    "start": "haste start --no-test & npm run storybook",
     "release": "haste release && gh-pages-auto-release --dist=storybook-static",
     "storybook": "start-storybook -p 6006"
   },

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -23,7 +23,8 @@
     "pretest": "haste build && build-storybook",
     "test": "haste test --jest && haste test --protractor",
     "posttest": "haste lint",
-    "start": "haste start & npm run storybook",
+    "test:watch": "haste test --jest --watch",
+    "start": "haste start --no-test & npm run storybook",
     "release": "haste release && gh-pages-auto-release --dist=storybook-static",
     "storybook": "start-storybook -p 6006"
   },

--- a/packages/wix-ui-santa/package.json
+++ b/packages/wix-ui-santa/package.json
@@ -24,7 +24,8 @@
     "pretest": "npm run build && build-storybook",
     "test": "haste test --jest && haste test --protractor",
     "posttest": "haste lint",
-    "start": "haste start & npm run storybook",
+    "test:watch": "haste test --jest --watch",
+    "start": "haste start --no-test & npm run storybook",
     "release": "haste release && gh-pages-auto-release --dist=storybook-static",
     "storybook": "start-storybook -p 6006"
   },

--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -19,10 +19,11 @@
     "url": "git+ssh://git@github.com/wix/wix-ui.git"
   },
   "scripts": {
-    "start": "haste start",
     "build": ":",
     "pretest": "haste build",
     "test": "haste test --jest && haste test --protractor",
+    "test:watch": "haste test --jest --watch",
+    "start": "haste start --no-test",
     "posttest": "haste lint",
     "release": "haste release"
   },

--- a/packages/wix-ui-theme/package.json
+++ b/packages/wix-ui-theme/package.json
@@ -20,9 +20,10 @@
     "url": "git+ssh://git@github.com/wix/wix-ui.git"
   },
   "scripts": {
-    "start": "haste start",
     "pretest": "haste build",
     "test": "haste test --jest",
+    "test:watch": "haste test --jest --watch",
+    "start": "haste start --no-test",
     "release": "haste release",
     "lint": "haste lint"
   },

--- a/packages/wix-ui-tpa/package.json
+++ b/packages/wix-ui-tpa/package.json
@@ -22,7 +22,8 @@
     "build": "haste build && import-path --path src/components",
     "pretest": "npm run build && build-storybook",
     "test": "haste test --jest && haste test --protractor",
-    "start": "haste start & npm run storybook",
+    "test:watch": "haste test --jest --watch",
+    "start": "haste start --no-test & npm run storybook",
     "release": "haste release && gh-pages-auto-release --dist=storybook-static",
     "storybook": "start-storybook -p 6006",
     "lint": "haste lint"


### PR DESCRIPTION
add `test:watch` command to npm scripts, which runs the tests in watch mode.