### PR TITLE
chore(wix-storybook-utils/AutoExample): use jsxToString

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -47,7 +47,6 @@
     "highlight.js": "^9.12.0",
     "import-path": "0.0.13",
     "react-docgen": "^2.20.0",
-    "react-element-to-jsx-string": "^13.1.0",
     "react-remarkable": "^1.1.3",
     "wix-style-react": "^1.1.4264",
     "wix-ui-test-utils": "latest"
@@ -60,6 +59,7 @@
     "enzyme": "~2.9.0",
     "haste-preset-yoshi": "latest",
     "identity-obj-proxy": "^3.0.0",
+    "jsx-to-string": "^1.3.0",
     "prop-types": "~15.6.0",
     "react": "15.6.1",
     "react-dom": "15.6.1",

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import reactElementToJSXString from 'react-element-to-jsx-string';
+import jsxToString from 'jsx-to-string';
 import styles from './styles.scss';
 import componentParser from '../AutoDocs/parser';
 
@@ -213,7 +213,14 @@ export default class extends Component {
   }
 
   componentToString = component =>
-    reactElementToJSXString(component, {showDefaultProps: false, showFunctions: true})
+    jsxToString(
+      component,
+      {
+        useFunctionCode: true,
+        functionNameOnly: false,
+        shortBooleanSyntax: true
+      }
+    );
 
   render() {
     const component = this.props.component;

--- a/packages/wix-ui-backoffice/package.json
+++ b/packages/wix-ui-backoffice/package.json
@@ -39,14 +39,11 @@
     "wix-ui-theme": "^1.0.16"
   },
   "devDependencies": {
-    "@storybook/addon-options": "3.2.13",
-    "@storybook/react": "~3.1.0",
-    "@storybook/storybook-deployer": "~2.0.0",
+    "@storybook/addon-options": "^3.2.13",
+    "@storybook/react": "^3.2.13",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-runtime": "^6.22.0",
-    "babel-preset-env": "^1.5.2",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-3": "^6.5.0",
+    "babel-preset-wix": "^1.0.2",
     "enzyme": "^2.3.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-react": "^6.8.0",

--- a/packages/wix-ui-backoffice/stories/create-story.js
+++ b/packages/wix-ui-backoffice/stories/create-story.js
@@ -1,5 +1,5 @@
 import {storiesOf} from '@storybook/react';
-import story from 'wix-storybook-utils/dist/src/Story';
+import story from 'wix-storybook-utils/Story';
 
 // yes, there is duplication
 // no, you can't DRY it, webpack parses `require.context` as-is, meaning no dynamic parts allowed


### PR DESCRIPTION
instead of `react-element-to-jsx-string`, because this one uses
`stringify-object` which is not es5 and uglify chokes on it.

currently wix-ui-backoffice build is failing because of non transpilled `stringify-object`