### PR TITLE
ToggleSwitch - Adding rootWidth and rootHeight properties to theme

### DIFF
--- a/packages/wix-ui-core/src/components/ToggleSwitch/styles.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/styles.ts
@@ -7,6 +7,8 @@ export const styles = (theme: ToggleSwitchTheme) => {
   return {
     root: {
       display: 'inline-block',
+      width: theme.rootWidth,
+      height: theme.rootHeight,
 
       '& input[type=checkbox]': {
         display: 'none'

--- a/packages/wix-ui-core/src/components/ToggleSwitch/theme.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/theme.ts
@@ -1,6 +1,9 @@
 import {palette} from '../../palette';
 
 export type ToggleSwitchTheme = {
+  rootWidth?: string;
+  rootHeight?: string;
+
   transitionSpeed?: string;
   borderRadius?: string;
   labelMovementRange?: string;
@@ -29,6 +32,9 @@ export type ToggleSwitchTheme = {
 };
 
 export const core: ToggleSwitchTheme = {
+  rootWidth: 'auto',
+  rootHeight: 'auto',
+
   transitionSpeed: '.3s',
   borderRadius: '50px',
   labelMovementRange: '23px',

--- a/packages/wix-ui-core/src/components/ToggleSwitch/theme.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/theme.ts
@@ -32,8 +32,8 @@ export type ToggleSwitchTheme = {
 };
 
 export const core: ToggleSwitchTheme = {
-  rootWidth: 'auto',
-  rootHeight: 'auto',
+  rootWidth: 'initial',
+  rootHeight: 'initial',
 
   transitionSpeed: '.3s',
   borderRadius: '50px',


### PR DESCRIPTION
Should not affect the component by default, lets us use percentage sizing inside other platforms (such as santa)