### PR TITLE
wix-ui-backoffice(chore): expose src folder in npm module

### DIFF
--- a/packages/wix-ui-backoffice/package.json
+++ b/packages/wix-ui-backoffice/package.json
@@ -10,6 +10,7 @@
   "main": "./dist/src/index.js",
   "files": [
     "dist",
+    "src",
     "*.js",
     "!wallaby.js",
     "!protractor.conf.js"


### PR DESCRIPTION
@lbelinsk this is needed if we want https://github.com/wix/wix-style-react/pull/1242 to work with run-time autodocs thingy