### PR TITLE
wix-storybook-utils(package.json): expose all `src`

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -5,9 +5,9 @@
   "author": "Arijus Šukys <argshook@gmail.com> (http://arijus.net)",
   "license": "MIT",
   "files": [
+    "src",
     "dist",
-    "*.js",
-    "src/AutoExample/protractor.driver.js"
+    "*.js"
   ],
   "bugs": {
     "url": "https://github.com/wix/wix-ui/issues"


### PR DESCRIPTION
this is a temporary measure so that `story` and `AutoExample`
documentations work in wix-style-react.

Related https://github.com/wix/wix-style-react/issues/1267