### PR TITLE
ToggleSwitch - Changing inner structure

### DIFF
--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -51,16 +51,15 @@ class ToggleSwitch extends React.PureComponent<ToggleSwitchProps> {
     return (
       <div className={classes.root}>
         <input type="checkbox" id={id} checked={checked} disabled={disabled} onChange={e => !disabled && onChange(e)}/>
-        <label htmlFor={id} className={classes.outerLabel}>
-          <label htmlFor={id} className={classes.innerLabel}>
-            <svg className={classes.toggleActive} viewBox="0 0 41 32">
-              <path
+        <label htmlFor={id} className={classes.outerLabel}/>
+        <label htmlFor={id} className={classes.innerLabel}>
+          <svg className={classes.toggleActive} viewBox="0 0 41 32">
+            <path
                 d="M0.169 17.815c0.169 1.098 0.76 2.111 1.689 2.871l14.269 10.385c1.942 1.435 4.644 1.013 6.079-0.844l18.069-23.303c1.435-1.858 1.098-4.559-0.844-5.995s-4.644-1.098-6.164 0.844l-15.367 19.842-10.723-7.852c-1.942-1.435-4.644-1.013-6.164 0.844-0.76 0.929-1.013 2.111-0.844 3.208z"/>
-            </svg>
-            <svg className={classes.toggleInactive} viewBox="0 0 143 32">
-              <path d="M0 0h142.545v32h-142.545v-32z"/>
-            </svg>
-          </label>
+          </svg>
+          <svg className={classes.toggleInactive} viewBox="0 0 143 32">
+            <path d="M0 0h142.545v32h-142.545v-32z"/>
+          </svg>
         </label>
       </div>
     );

--- a/packages/wix-ui-core/src/components/ToggleSwitch/styles.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/styles.ts
@@ -6,9 +6,12 @@ export const styles = (theme: ToggleSwitchTheme) => {
 
   return {
     root: {
-      display: 'inline-block',
+      display: 'inline-flex',
+      flexDirection: 'row',
       width: theme.rootWidth,
       height: theme.rootHeight,
+      alignItems: 'center',
+      position: 'relative',
 
       '& input[type=checkbox]': {
         display: 'none'
@@ -30,16 +33,16 @@ export const styles = (theme: ToggleSwitchTheme) => {
       '& input[type=checkbox]:checked + $outerLabel': {
         background: theme.backgroundColorChecked,
 
-        '& $innerLabel': {
-          left: theme.labelMovementRange,
+        '& + $innerLabel': {
+            left: theme.labelMovementRange,
 
-          '& $toggleActive': {
-            display: theme.toggleIconDisplay
-          },
+            '& $toggleActive': {
+                display: theme.toggleIconDisplay
+            },
 
-          '& $toggleInactive': {
-            display: 'none'
-          }
+            '& $toggleInactive': {
+                display: 'none'
+            }
         }
       },
 
@@ -63,7 +66,7 @@ export const styles = (theme: ToggleSwitchTheme) => {
         background: theme.backgroundColorDisabled,
         cursor: 'default',
 
-        '& $innerLabel': {
+        '& + $innerLabel': {
           cursor: 'default',
 
           '& $toggleActive': {
@@ -96,11 +99,12 @@ export const styles = (theme: ToggleSwitchTheme) => {
       height: theme.innerLabelHeight,
       background: theme.innerLabelBackgroundColor,
       position: 'absolute',
-      top: '1px',
       left: '1px',
       zIndex: '1',
       textAlign: 'center',
       cursor: 'pointer',
+      top: '50%',
+      transform: 'translate(0, -50%)',
 
       justifyContent: 'center',
       alignItems: 'center',


### PR DESCRIPTION
Changed the inner structure of ToggleSwitch in order for it to be more customizable (with mainly resize in mind). All changes should be 100% transparent to all current consumers of this component.

Now it is supported for the knob to not be the same height as track - it can be smaller or even larger (needed to implement iOS style toggle switches)