### PR TITLE
AutoTestKit: Spread property support

### DIFF
--- a/packages/wix-storybook-utils/src/AutoTestKit/DriverParser.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/DriverParser.js
@@ -13,7 +13,6 @@ class DriverParser {
    */
   constructor(files) {
     this.files = files;
-
     const fileContents = files[files.entry];
     this.ast = parse(fileContents);
   }
@@ -52,6 +51,10 @@ class DriverParser {
 
     if (comments) {
       returnValue.description = this._commentsToDescription(comments);
+    }
+
+    if (this.files.origin !== this.files.entry) {
+      returnValue.origin = this.files.entry;
     }
 
     return returnValue;

--- a/packages/wix-storybook-utils/src/AutoTestKit/DriverParser.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/DriverParser.js
@@ -1,6 +1,6 @@
 const FunctionScope = require('./FunctionScope');
 const GlobalScope = require('./GlobalScope');
-const parse = require('recast').parse;
+const parse = require('../Parser').parse;
 
 class DriverParser {
   /**
@@ -13,15 +13,13 @@ class DriverParser {
    */
   constructor(files) {
     this.files = files;
+
     const fileContents = files[files.entry];
-    this.recastedDriver = parse(fileContents);
+    this.ast = parse(fileContents);
   }
 
   parse() {
-    const topParentScope = new GlobalScope(this.recastedDriver.program.body, this.files);
-
-    // We only case about what this file exports..
-    //TODO: Parse non-default exports
+    const topParentScope = new GlobalScope(this.ast.program.body, this.files);
     return this.parseDefaultExport(topParentScope);
   }
 
@@ -66,7 +64,7 @@ class DriverParser {
      * Maybe we should parse it in the future and add them to the result of the parse output
      */
     const isValidComment = comment => {
-      return comment.type === 'Block' && comment.value.indexOf('*') === 0;
+      return comment.type === 'CommentBlock' && comment.value.indexOf('*') === 0;
     };
 
     const parseCommentValue = commentValue => {
@@ -99,8 +97,17 @@ class DriverParser {
     const returnObject = {};
 
     properties.forEach(property => {
-      const {key: {name}, value, comments} = property;
-      returnObject[name] = this._parseDeclaration(scope, value, comments);
+      switch (property.type) {
+        case 'Property':
+          returnObject[property.key.name] =
+            this._parseDeclaration(scope, property.value, property.leadingComments);
+          break;
+        case 'SpreadProperty':
+          // TODO: handle property spread
+          console.log(property);
+          break;
+        default: break;
+      }
     });
 
     return returnObject;
@@ -108,7 +115,8 @@ class DriverParser {
 
   parseDefaultExport(scope) {
     const exportDeclaration = scope.getDefaultExportStatement();
-    return this._parseDeclaration(scope, exportDeclaration.declaration);
+    return exportDeclaration ?
+      this._parseDeclaration(scope, exportDeclaration.declaration) : null;
   }
 }
 

--- a/packages/wix-storybook-utils/src/AutoTestKit/DriverParser.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/DriverParser.js
@@ -107,7 +107,6 @@ class DriverParser {
           break;
         case 'SpreadProperty':
           // TODO: handle property spread
-          console.log(property);
           break;
         default: break;
       }

--- a/packages/wix-storybook-utils/src/AutoTestKit/GlobalScope.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/GlobalScope.js
@@ -1,5 +1,5 @@
 const Scope = require('./Scope');
-const parse = require('recast').parse;
+const parse = require('../Parser').parse;
 
 class GlobalScope extends Scope {
   constructor(globalScope, files) {

--- a/packages/wix-storybook-utils/src/AutoTestKit/GlobalScope.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/GlobalScope.js
@@ -11,10 +11,11 @@ class GlobalScope extends Scope {
     if (declaration.specifiers.some(specifier => specifier.local.name === name)) {
       const fileContents = this.files[declaration.source.value];
       const recastedContent = parse(fileContents);
+      const files = Object.assign({}, this.files, {entry: declaration.source.value});
       // We return a new scope because we return a new file contents which has its own scope
       return {
         identifierValue: this._getDefaultExportStatement(recastedContent.program.body).declaration,
-        scope: new GlobalScope(recastedContent.program.body, this.files)
+        scope: new GlobalScope(recastedContent.program.body, files)
       };
     }
   }

--- a/packages/wix-storybook-utils/src/AutoTestKit/Scope.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/Scope.js
@@ -5,20 +5,10 @@ class Scope {
   }
 
   _getIdentifierValueFromCurrentScope(name) {
-    let identifierValue = null;
-    const allDeclarations = this.scope.filter(value => {
-      return value.type.endsWith('Declaration');
-    });
-    if (Array.isArray(allDeclarations) && allDeclarations.length) {
-      for (let index = 0; index < allDeclarations.length; index++) {
-        const declaration = allDeclarations[index];
-        identifierValue = this._getIdentifierValueFromDeclaration(name, declaration);
-        if (identifierValue) {
-          break;
-        }
-      }
-    }
-    return identifierValue;
+    const identifierValues = this.scope.filter(value => value.type.endsWith('Declaration'))
+      .map(declaration => this._getIdentifierValueFromDeclaration(name, declaration))
+      .filter(identifierValue => !!identifierValue);
+    return identifierValues.length > 0 ? identifierValues[0] : null;
   }
 
   getIdentifierValue(name) {

--- a/packages/wix-storybook-utils/src/AutoTestKit/Scope.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/Scope.js
@@ -37,6 +37,8 @@ class Scope {
       case 'ImportDeclaration':
         identifierValue = this._getIdentifierValueFromImport(name, declaration);
         break;
+      case 'ExportDefaultDeclaration':
+        break;
       default:
         throw new Error(`Unknown declaration ${type}`);
     }

--- a/packages/wix-storybook-utils/src/AutoTestKit/index.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/index.js
@@ -62,7 +62,7 @@ export default class AutoTestKit extends Component {
             <td>{this.getParams(flatMethods[methodName].params)}</td>
             <td>{flatMethods[methodName].returnType}</td>
             <td data-hook="description">{flatMethods[methodName].description}</td>
-            {hasOrigin ? <td data-hook="origin">{path.basename(flatMethods[methodName].origin)}</td> : null}
+            {hasOrigin ? <td data-hook="origin">{flatMethods[methodName].origin ? path.basename(flatMethods[methodName].origin) : null}</td> : null}
           </tr>)}
       </tbody>
     );

--- a/packages/wix-storybook-utils/src/AutoTestKit/index.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/index.js
@@ -8,7 +8,7 @@ export default class AutoTestKit extends Component {
     source: PropTypes.object.isRequired
   };
 
-  isFunction = data => data.type && data.type === 'function';
+  isFunction = data => data && isPlainObject(data) && data.type && data.type === 'function';
 
   isMethodContainer = data =>
     !this.isFunction(data) && isPlainObject(data) &&

--- a/packages/wix-storybook-utils/src/AutoTestKit/index.spec.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/index.spec.js
@@ -23,15 +23,18 @@ const getFakeTestKitFile = fileName =>
 const getFiles = () => ({
   '../InputWithOptions/InputWithOptions.driver': getFakeTestKitFile(fakeTestKitsPaths.InputWithOptions),
   './Input.driver': getFakeTestKitFile(fakeTestKitsPaths.Input),
-  '../DropdownLayout/DropdownLayout.driver': getFakeTestKitFile(fakeTestKitsPaths.DropdownLayout)
+  '../DropdownLayout.driver': getFakeTestKitFile(fakeTestKitsPaths.DropdownLayout)
 });
 
+const fileContent = getFiles();
+
 const parseTestKit = testKit => {
+
   const entryTestKitFile = getFakeTestKitFile(testKit);
   const files = {
     entry: testKit,
     origin: testKit,
-    ...getFiles,
+    ...fileContent,
     [testKit]: entryTestKitFile
   };
   return new DriverParser(files).parse();
@@ -77,30 +80,17 @@ describe('AutoTestKit', () => {
   });
 
   describe('IconWithOptions testKit', () => {
-    it('should have seven nested methods', () => {
+    it('should have fourty two nested methods', () => {
       const driver = createDriver(render(fakeTestKitsPaths.IconWithOptions));
-      expect(driver.getMethodsCount()).toEqual(7);
+      expect(driver.getMethodsCount()).toEqual(42);
       expect(driver.getMethodAt(2).getName()).toEqual('driver.mouseLeave');
-      expect(driver.getMethodAt(6).getName()).toEqual('dropdownLayoutDriver.isDropDirectionUp');
+      expect(driver.getMethodAt(41).getName()).toEqual('dropdownLayoutDriver.isDropDirectionUp');
     });
 
-    it('should have proper origin', () => {
-      const parseIconWithOptionsTestKit = () => {
-        const files = {
-          entry: fakeTestKitsPaths.IconWithOptions,
-          origin: fakeTestKitsPaths.LanguagePicker,
-          ...getFiles,
-          [fakeTestKitsPaths.IconWithOptions]: getFakeTestKitFile(fakeTestKitsPaths.IconWithOptions)
-        };
-        return new DriverParser(files).parse();
-      };
-
-      const render = () => {
-        return mount(<AutoTestKit source={parseIconWithOptionsTestKit()}/>);
-      };
-
+    it('should have imported methods with correct origin', () => {
       const driver = createDriver(render(fakeTestKitsPaths.IconWithOptions));
-      expect(driver.getMethodAt(2).getOrigin()).toEqual('IconWithOptions.driver.txt');
+      expect(driver.getMethodAt(40).getName()).toEqual('dropdownLayoutDriver.optionByHook');
+      expect(driver.getMethodAt(40).getOrigin()).toEqual('DropdownLayout.driver');
     });
   });
 
@@ -110,5 +100,4 @@ describe('AutoTestKit', () => {
     });
   });
 });
-
 

--- a/packages/wix-storybook-utils/src/AutoTestKit/index.spec.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/index.spec.js
@@ -83,6 +83,25 @@ describe('AutoTestKit', () => {
       expect(driver.getMethodAt(2).getName()).toEqual('driver.mouseLeave');
       expect(driver.getMethodAt(6).getName()).toEqual('dropdownLayoutDriver.isDropDirectionUp');
     });
+
+    it('should have proper origin', () => {
+      const parseIconWithOptionsTestKit = () => {
+        const files = {
+          entry: fakeTestKitsPaths.IconWithOptions,
+          origin: fakeTestKitsPaths.LanguagePicker,
+          ...getFiles,
+          [fakeTestKitsPaths.IconWithOptions]: getFakeTestKitFile(fakeTestKitsPaths.IconWithOptions)
+        };
+        return new DriverParser(files).parse();
+      };
+
+      const render = () => {
+        return mount(<AutoTestKit source={parseIconWithOptionsTestKit()}/>);
+      };
+
+      const driver = createDriver(render(fakeTestKitsPaths.IconWithOptions));
+      expect(driver.getMethodAt(2).getOrigin()).toEqual('IconWithOptions.driver.txt');
+    });
   });
 
   describe('parsing', () => {

--- a/packages/wix-storybook-utils/src/AutoTestKit/index.spec.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/index.spec.js
@@ -9,6 +9,8 @@ import AutoTestKit from './index';
 
 const fakeTestKitsPaths = {
   InputWithOptions: 'mock-testkits/InputWithOptions.driver.txt',
+  IconWithOptions: 'mock-testkits/IconWithOptions.driver.txt',
+  LanguagePicker: 'mock-testkits/LanguagePicker.driver.txt',
   Input: 'mock-testkits/Input.driver.txt',
   DropdownLayout: 'mock-testkits/DropdownLayout.driver.txt',
   Badge: 'mock-testkits/Badge.driver.txt',
@@ -28,6 +30,7 @@ const parseTestKit = testKit => {
   const entryTestKitFile = getFakeTestKitFile(testKit);
   const files = {
     entry: testKit,
+    origin: testKit,
     ...getFiles,
     [testKit]: entryTestKitFile
   };
@@ -48,7 +51,8 @@ const createDriver = wrapper => {
       const method = byHook(wrapper, 'method').at(index);
       return {
         getName: () => byHook(method, 'name').text(),
-        getDescription: () => byHook(method, 'description').text()
+        getDescription: () => byHook(method, 'description').text(),
+        getOrigin: () => byHook(method, 'origin').text()
       };
     }
   };
@@ -69,6 +73,15 @@ describe('AutoTestKit', () => {
       const driver = createDriver(render(fakeTestKitsPaths.Input));
       expect(driver.getMethodsCount()).toEqual(50);
       expect(driver.getMethodAt(2).getName()).toEqual('blur');
+    });
+  });
+
+  describe('IconWithOptions testKit', () => {
+    it('should have seven nested methods', () => {
+      const driver = createDriver(render(fakeTestKitsPaths.IconWithOptions));
+      expect(driver.getMethodsCount()).toEqual(7);
+      expect(driver.getMethodAt(2).getName()).toEqual('driver.mouseLeave');
+      expect(driver.getMethodAt(6).getName()).toEqual('dropdownLayoutDriver.isDropDirectionUp');
     });
   });
 

--- a/packages/wix-storybook-utils/src/AutoTestKit/mock-testkits/IconWithOptions.driver.txt
+++ b/packages/wix-storybook-utils/src/AutoTestKit/mock-testkits/IconWithOptions.driver.txt
@@ -1,3 +1,5 @@
+import dropdownLayoutDriverFactory from '../DropdownLayout.driver'
+
 const IconWithOptionsDriverFactory = ({element, wrapper}) => {
   const iconWrapper = element.querySelector('[data-hook=icon-wrapper]');
   const dropdownLayoutWrapper = element.querySelector('[data-hook=iconWithOptions-dropdownLayout-wrapper]');

--- a/packages/wix-storybook-utils/src/AutoTestKit/mock-testkits/IconWithOptions.driver.txt
+++ b/packages/wix-storybook-utils/src/AutoTestKit/mock-testkits/IconWithOptions.driver.txt
@@ -1,0 +1,25 @@
+const IconWithOptionsDriverFactory = ({element, wrapper}) => {
+  const iconWrapper = element.querySelector('[data-hook=icon-wrapper]');
+  const dropdownLayoutWrapper = element.querySelector('[data-hook=iconWithOptions-dropdownLayout-wrapper]');
+  const dropdownLayout = element.querySelector('[data-hook=iconWithOptions-dropdownLayout]');
+  const dropdownLayoutDriver = dropdownLayoutDriverFactory({element: dropdownLayout, wrapper});
+
+  const driver = {
+    exists: () => !!element,
+    mouseEnter: () => ReactTestUtils.Simulate.mouseEnter(iconWrapper),
+    mouseLeave: () => ReactTestUtils.Simulate.mouseLeave(element),
+    isIconBlue: () => isClassExists(element, 'hover'),
+    iconWrapper: () => iconWrapper,
+    element: () => element
+  };
+
+  return {
+    driver,
+    dropdownLayoutDriver: {
+      ...dropdownLayoutDriver,
+      isDropDirectionUp: () => dropdownLayoutDriver.isUp() && isClassExists(dropdownLayoutWrapper, 'dropDirectionUp')
+    }
+  };
+};
+
+export default IconWithOptionsDriverFactory;

--- a/packages/wix-storybook-utils/src/AutoTestKit/mock-testkits/LanguagePicker.driver.txt
+++ b/packages/wix-storybook-utils/src/AutoTestKit/mock-testkits/LanguagePicker.driver.txt
@@ -1,0 +1,1 @@
+export {default} from './IconWithOptions.driver.txt';

--- a/packages/wix-storybook-utils/src/AutoTestKit/run-with-node.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/run-with-node.js
@@ -9,7 +9,10 @@ const readFile = filePath => {
   });
 };
 
-const files = {entry: './mock-testkits/IconWithOptions.driver'};
+const files = {
+  entry: './mock-testkits/Badge.driver',
+  origin: './mock-testkits/Badge.driver'
+};
 
 const getFileContent = filePath => {
   if (filePath.includes('scss')) {

--- a/packages/wix-storybook-utils/src/AutoTestKit/run-with-node.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/run-with-node.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const SuperParse = require('./DriverParser').DriverParser;
-const parse = require('recast').parse;
+const parse = require('../Parser').parse;
 
 const readFile = filePath => {
   return new Promise(resolve => {
@@ -9,7 +9,7 @@ const readFile = filePath => {
   });
 };
 
-const files = {entry: './mock-testkits/Badge.driver'};
+const files = {entry: './mock-testkits/IconWithOptions.driver'};
 
 const getFileContent = filePath => {
   if (filePath.includes('scss')) {

--- a/packages/wix-storybook-utils/src/ComponentMetaInfoGetter/index.js
+++ b/packages/wix-storybook-utils/src/ComponentMetaInfoGetter/index.js
@@ -234,11 +234,11 @@ export default class ComponentMetaInfoGetter extends React.PureComponent {
     };
 
     return getFileContent(path.basename(filePath), path.dirname(filePath), filePath)
-      .then(() => new DriverParser(files).parse());
-      // .catch(() => {
-      //   // TODO remove this if you want to see all failing cases
-      //   return null;
-      // });
+      .then(() => new DriverParser(files).parse())
+      .catch(() => {
+        // TODO remove this if you want to see all failing cases
+        return null;
+      });
   }
 
   getTestKitFilePromise(path) {

--- a/packages/wix-storybook-utils/src/ComponentMetaInfoGetter/index.js
+++ b/packages/wix-storybook-utils/src/ComponentMetaInfoGetter/index.js
@@ -151,7 +151,7 @@ export default class ComponentMetaInfoGetter extends React.PureComponent {
    */
   getTestkitSource() {
     const {componentSrcFolder, storyName} = this.props;
-    let filePath = path.join(`./${componentSrcFolder}`, `${storyName}.driver.js`);
+    let filePath = path.join(`./${componentSrcFolder}`, `${componentSrcFolder}.driver.js`);
     filePath = '.' + path.resolve(filePath);
     const files = {entry: filePath};
 
@@ -181,7 +181,7 @@ export default class ComponentMetaInfoGetter extends React.PureComponent {
       });
     };
 
-    return getFileContent(`${storyName}.driver.js`, `./${componentSrcFolder}`, filePath)
+    return getFileContent(`${componentSrcFolder}.driver.js`, `./${componentSrcFolder}`, filePath)
       .then(() => {
         return new DriverParser(files).parse();
       })

--- a/packages/wix-storybook-utils/src/ComponentMetaInfoGetter/index.js
+++ b/packages/wix-storybook-utils/src/ComponentMetaInfoGetter/index.js
@@ -150,7 +150,7 @@ export default class ComponentMetaInfoGetter extends React.PureComponent {
    * Then if will try to parse them to build an auto generated doc
    */
   getTestkitSource() {
-    const {componentSrcFolder, storyName} = this.props;
+    const {componentSrcFolder} = this.props;
     let filePath = path.join(`./${componentSrcFolder}`, `${componentSrcFolder}.driver.js`);
     filePath = '.' + path.resolve(filePath);
     const files = {entry: filePath};

--- a/packages/wix-storybook-utils/src/ComponentMetaInfoGetter/index.js
+++ b/packages/wix-storybook-utils/src/ComponentMetaInfoGetter/index.js
@@ -217,7 +217,7 @@ export default class ComponentMetaInfoGetter extends React.PureComponent {
 
             // Remove the file that contains a single export line from files
             const {[originalPath]: val, ...rest} = files;
-            console.log(val, ' removed'); // val unused
+            console.log(val, ' removed'); // linter barks on unused val
             files = rest;
 
             // Replace the entry by the export target

--- a/packages/wix-storybook-utils/src/Parser.js
+++ b/packages/wix-storybook-utils/src/Parser.js
@@ -1,5 +1,4 @@
 const recastParse = require('recast').parse;
-const recastVisit = require('recast').visit;
 const babylonParse = require('babylon').parse;
 
 const _parser = {
@@ -29,8 +28,5 @@ module.exports = {
     return recastParse(code, {
       parser: _parser
     });
-  },
-  visit(ast, visitors) {
-    return recastVisit(ast, visitors);
   }
 };

--- a/packages/wix-storybook-utils/src/Parser.js
+++ b/packages/wix-storybook-utils/src/Parser.js
@@ -1,0 +1,36 @@
+const recastParse = require('recast').parse;
+const recastVisit = require('recast').visit;
+const babylonParse = require('babylon').parse;
+
+const _parser = {
+  parse(code) {
+    return babylonParse(code, {
+      sourceType: 'module',
+      plugins: [
+        'jsx',
+        'flow',
+        'estree',
+        'doExpressions',
+        'objectRestSpread',
+        'decorators',
+        'classProperties',
+        'exportExtensions',
+        'asyncGenerators',
+        'functionBind',
+        'functionSent',
+        'dynamicImport',
+        'templateInvalidEscapes'
+      ]});
+  }
+};
+
+module.exports = {
+  parse(code) {
+    return recastParse(code, {
+      parser: _parser
+    });
+  },
+  visit(ast, visitors) {
+    return recastVisit(ast, visitors);
+  }
+};

--- a/packages/wix-storybook-utils/src/Story/index.js
+++ b/packages/wix-storybook-utils/src/Story/index.js
@@ -110,7 +110,7 @@ function Story(props) {
           const tabs = [
             'Usage',
             'API',
-            ...(actualReadmeTestKit ? ['Testkit'] : []),
+            ...(actualReadmeTestKit || testkitSource ? ['Testkit'] : []),
             ...(actualReadmeAccessibility ? ['Accessibility'] : [])
           ];
 


### PR DESCRIPTION
This PR contains spread property support for TestKit automation. The spread property example can be found in IconWithOptions.driver. 
Currently, the spread property is tracked back in attempt to get to its definition. If tracking leads to another driver file import, then the imported methods are attached to the method container that contains the spread property. 
The tracking is limited -- it looks for the property identifier in imports, variables and function names. At the moment, it won't look on the function arguments, logical expressions, etc.