### PR TITLE
Pagination

### DIFF
--- a/packages/wix-ui-core/src/components/Pagination/PageStrip.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/PageStrip.tsx
@@ -7,10 +7,6 @@ import {
   createResponsiveLayoutTemplate
 } from './page-strip-layout';
 
-function canUseDOM(): boolean {
-  return typeof window !== 'undefined' && Boolean(window.document && window.document.createElement);
-}
-
 export interface PageStripClasses {
   pageStrip: string;
   pageButton: string;
@@ -32,20 +28,35 @@ export interface PageStripProps {
   pageUrl?: (pageNumber: number) => string;
 }
 
+// When using responsive layout we initially want to render identical tree
+// on the server and in the browser so that React doesn't freak out.
+// But on subsequent renders we can skip ahead to the responsive template,
+// see componentWillReceiveProps.
+export enum ResponsiveLayoutPhase {
+  Initial,
+  Template,
+  Final
+}
+
 export interface PageStripState {
-  responsiveLayout?: PageStripLayout;
+  responsiveLayout: PageStripLayout;
+  responsiveLayoutPhase: ResponsiveLayoutPhase;
 }
 
 export class PageStrip extends React.Component<PageStripProps, PageStripState> {
   constructor() {
     super();
     this.state = {
-      responsiveLayout: null
+      responsiveLayout: null,
+      responsiveLayoutPhase: ResponsiveLayoutPhase.Initial
     };
   }
 
   public componentWillReceiveProps() {
-    this.setState({responsiveLayout: null});
+    this.setState({
+      responsiveLayout: null,
+      responsiveLayoutPhase: ResponsiveLayoutPhase.Template
+    });
   }
 
   public componentDidMount() {
@@ -119,31 +130,38 @@ export class PageStrip extends React.Component<PageStripProps, PageStripState> {
   }
 
   private getLayout(): PageStripLayout {
-    if (this.isResponsive()) {
-      if (this.state.responsiveLayout) {
-        return this.state.responsiveLayout;
-      } else if (canUseDOM()) {
-        return createResponsiveLayoutTemplate(this.props);
-      }
-      return [this.props.currentPage];
+    if (!this.isResponsive()) {
+      return createStaticLayout(this.props);
     }
-    return createStaticLayout(this.props);
+
+    if (this.state.responsiveLayoutPhase === ResponsiveLayoutPhase.Template) {
+      return createResponsiveLayoutTemplate(this.props);
+    }
+
+    if (this.state.responsiveLayoutPhase === ResponsiveLayoutPhase.Final) {
+      return this.state.responsiveLayout;
+    }
+
+    return [this.props.currentPage];
   }
 
   private updateLayoutIfNeeded(): void {
-    const {totalPages, currentPage, maxPagesToShow, showFirstPage, showLastPage} = this.props;
-
-    if (this.isResponsive() && !this.state.responsiveLayout) {
-      this.setState({
-        responsiveLayout: createResponsiveLayout({
-          container: ReactDOM.findDOMNode(this),
-          totalPages,
-          currentPage,
-          maxPagesToShow,
-          showFirstPage,
-          showLastPage
-        })
-      });
+    if (this.isResponsive()) {
+      if (this.state.responsiveLayoutPhase === ResponsiveLayoutPhase.Initial) {
+        this.setState({responsiveLayoutPhase: ResponsiveLayoutPhase.Template});
+      } else if (this.state.responsiveLayoutPhase === ResponsiveLayoutPhase.Template) {
+        this.setState({
+          responsiveLayout: createResponsiveLayout({
+            container: ReactDOM.findDOMNode(this),
+            totalPages: this.props.totalPages,
+            currentPage: this.props.currentPage,
+            maxPagesToShow: this.props.maxPagesToShow,
+            showFirstPage: this.props.showFirstPage,
+            showLastPage: this.props.showLastPage
+          }),
+          responsiveLayoutPhase: ResponsiveLayoutPhase.Final
+        });
+      }
     }
   }
 }

--- a/packages/wix-ui-core/src/components/Pagination/PageStrip.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/PageStrip.tsx
@@ -27,7 +27,8 @@ export interface PageStripProps {
   responsive: boolean;
   id?: string;
   classes: PageStripClasses;
-  onPageSelect: (event: React.SyntheticEvent<Element>, page: number) => void;
+  onPageClick: (event: React.MouseEvent<Element>, page: number) => void;
+  onPageKeyDown: (event: React.KeyboardEvent<Element>, page: number) => void;
   pageUrl?: (pageNumber: number) => string;
 }
 
@@ -103,8 +104,8 @@ export class PageStrip extends React.Component<PageStripProps, PageStripState> {
           aria-label={`Page ${pageNumber}`}
           className={classes.pageButton}
           tabIndex={pageUrl ? null : 0}
-          onClick={e => this.handleClick(e, pageNumber)}
-          onKeyDown={e => this.handleKeyDown(e, pageNumber)}
+          onClick={e => this.props.onPageClick(e, pageNumber)}
+          onKeyDown={e => this.props.onPageKeyDown(e, pageNumber)}
           href={pageUrl ? pageUrl(pageNumber) : null}
         >
           {pageNumber}
@@ -143,17 +144,6 @@ export class PageStrip extends React.Component<PageStripProps, PageStripState> {
           showLastPage
         })
       });
-    }
-  }
-
-  private handleClick(event: React.MouseEvent<Element>, page: number) {
-    this.props.onPageSelect(event, page);
-  }
-
-  private handleKeyDown(event: React.KeyboardEvent<Element>, page: number) {
-    // Enter or Space
-    if (event.keyCode === 13 || event.keyCode === 32) {
-      this.props.onPageSelect(event, page);
     }
   }
 }

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.driver.ts
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.driver.ts
@@ -28,7 +28,9 @@ export const paginationDriverFactory = ({element: root, eventTrigger}: {element:
     /** Returns the element for the navigation button - acceptable values are 'first', 'last', 'previous' or 'next' */
     getNavButton: (btnName: NavButtonNames): Element => getNavButtonElement(btnName),
     /** Simulates clicking a page in "pages" mode */
-    click: (element: Element): void => eventTrigger.click(element),
+    click: (element: Element, eventData = {}): void => eventTrigger.click(element, eventData),
+    /** Simulates keyDown on an element */
+    keydown: (element: Element, eventData = {}): void => eventTrigger.keyDown(element, eventData),
     /** Simulates clicking a navigation button - acceptable values are 'first', 'last', 'previous' or 'next' */
     clickOnNavButton: (btnName: string): void => eventTrigger.click(getNavButtonElement(btnName)),
     /** Returns the page input element in "input" mode */
@@ -41,8 +43,6 @@ export const paginationDriverFactory = ({element: root, eventTrigger}: {element:
       input.value = newValue;
       eventTrigger.change(input);
     },
-    /** Simulates keyDown on an element */
-    keydown: (element: Element, eventData): void => eventTrigger.keyDown(element, eventData),
     /** Simulates keyDown on the input field in "input" mode */
     inputKeyDown: (keyCode: number): void => eventTrigger.keyDown(getInput(), {keyCode}),
     /** Simulates blur in the input field in "input" mode */

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.driver.ts
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.driver.ts
@@ -1,12 +1,21 @@
-type NavButtonNames = 'first' | 'previous' | 'next' | 'last';
+import {Simulate} from 'react-dom/test-utils';
 
-export const paginationDriverFactory = ({element: root, eventTrigger}: {element: HTMLElement, eventTrigger: any}) => {
+type NavButtonName = 'first' | 'previous' | 'next' | 'last';
+
+export const paginationDriverFactory = ({element: root}: {element: Element}) => {
   const pageStrip: Element = root.querySelector('[data-hook="page-strip"]');
 
-  const getNavButtonElement = (btnName: string): HTMLButtonElement => (
-      <HTMLButtonElement> root.querySelector('[data-hook="' + btnName + '"]')
+  const getNavButton = (name: NavButtonName): Element | null => (
+    root.querySelector(`[data-hook=${name}]`)
   );
-  const getInput = (): HTMLInputElement | null => (<HTMLInputElement> root.querySelector('[data-hook="page-input"]'));
+
+  const getInput = (): HTMLInputElement | null => (
+    <HTMLInputElement> root.querySelector('[data-hook="page-input"]')
+  );
+
+  const getPageByNumber = (n: number): Element | null => (
+    pageStrip.querySelector(`[data-hook~=page-${n}]`)
+  );
 
   return {
     /** Returns the root element*/
@@ -22,30 +31,28 @@ export const paginationDriverFactory = ({element: root, eventTrigger}: {element:
     /** Returns the page element given its index in the page strip */
     getPageByIndex: (idx?: number): Element | null => (idx < pageStrip.children.length) ? pageStrip.children[idx] : null,
     /** Returns the page element given page number */
-    getPageByNumber: (n: number): Element | null => pageStrip.querySelector(`[data-hook~=page-${n}]`),
+    getPageByNumber,
     /** Returns the page element currently selected */
     getCurrentPage: (): Element | null => root.querySelector('[data-hook~="current-page"]'),
     /** Returns the element for the navigation button - acceptable values are 'first', 'last', 'previous' or 'next' */
-    getNavButton: (btnName: NavButtonNames): Element => getNavButtonElement(btnName),
-    /** Simulates clicking a page in "pages" mode */
-    click: (element: Element, eventData = {}): void => eventTrigger.click(element, eventData),
-    /** Simulates keyDown on an element */
-    keydown: (element: Element, eventData = {}): void => eventTrigger.keyDown(element, eventData),
-    /** Simulates clicking a navigation button - acceptable values are 'first', 'last', 'previous' or 'next' */
-    clickOnNavButton: (btnName: string): void => eventTrigger.click(getNavButtonElement(btnName)),
+    getNavButton,
     /** Returns the page input element in "input" mode */
     getPageInput: getInput,
     /** Returns the total amount of pages displayed in "input" mode */
     getTotalPagesField: (): Element | null => root.querySelector('[data-hook="total-pages"]'),
+    /** Simulates clicking a nav button */
+    clickNavButton: (name: NavButtonName): void => Simulate.click(getNavButton(name), {button: 0}),
+    /** Simulates clicking a page in "pages" mode */
+    clickPage: (page: number): void => Simulate.click(getPageByNumber(page), {button: 0}),
     /** Simulates changing the value of the input field in "input" mode */
     changeInput: (newValue: string): void => {
       const input = getInput();
       input.value = newValue;
-      eventTrigger.change(input);
+      Simulate.change(input);
     },
-    /** Simulates keyDown on the input field in "input" mode */
-    inputKeyDown: (keyCode: number): void => eventTrigger.keyDown(getInput(), {keyCode}),
+    /** Simulates committing the input field value in "input" mode */
+    commitInput: (): void => Simulate.keyDown(getInput(), {keyCode: 13}),
     /** Simulates blur in the input field in "input" mode */
-    inputBlur: (): void => eventTrigger.blur(getInput())
+    blurInput: (): void => Simulate.blur(getInput())
   };
 };

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
@@ -261,25 +261,59 @@ describe('Pagination', () => {
     });
   });
 
-  describe('Keyboard Navigation', () => {
-    it('calls onChange when Enter or Space is pressed on a nav button', () => {
+  describe('Keyboard and mouse handling', () => {
+    it('calls onChange when Enter or Space is pressed on a button', async () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={3} currentPage={2} onChange={onChange} />);
 
       pagination.keydown(pagination.getNavButton('previous'), {keyCode: 13});
+      expect(onChange).toBeCalled();
+      onChange.mockClear();
+
       pagination.keydown(pagination.getNavButton('previous'), {keyCode: 32});
+      expect(onChange).toBeCalled();
+      onChange.mockClear();
+
       pagination.keydown(pagination.getNavButton('previous'), {});
-      expect(onChange).toHaveBeenCalledTimes(2);
+      await sleep(10);
+      expect(onChange).not.toBeCalled();
+      onChange.mockClear();
+
+      pagination.keydown(pagination.getPageByNumber(1), {keyCode: 13});
+      expect(onChange).toBeCalled();
+      onChange.mockClear();
+
+      pagination.keydown(pagination.getPageByNumber(1), {keyCode: 32});
+      expect(onChange).toBeCalled();
+      onChange.mockClear();
+
+      pagination.keydown(pagination.getPageByNumber(1), {});
+      await sleep(10);
+      expect(onChange).not.toBeCalled();
+      onChange.mockClear();
     });
 
-    it('calls onChange when Enter or Space is pressed on a page button', () => {
+    it('calls onChange when the left mouse button is pressed', async () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={3} currentPage={2} onChange={onChange} />);
 
-      pagination.keydown(pagination.getPageByNumber(1), {keyCode: 13});
-      pagination.keydown(pagination.getPageByNumber(1), {keyCode: 32});
-      pagination.keydown(pagination.getPageByNumber(1), {});
-      expect(onChange).toHaveBeenCalledTimes(2);
+      pagination.click(pagination.getNavButton('previous'), {button: 0});
+      expect(onChange).toBeCalled();
+      onChange.mockClear();
+
+      pagination.keydown(pagination.getNavButton('previous'), {button: 1});
+      await sleep(10);
+      expect(onChange).not.toBeCalled();
+      onChange.mockClear();
+
+      pagination.keydown(pagination.getPageByNumber(1), {button: 0});
+      expect(onChange).toBeCalled();
+      onChange.mockClear();
+
+      pagination.keydown(pagination.getPageByNumber(1), {button: 1});
+      await sleep(10);
+      expect(onChange).not.toBeCalled();
+      onChange.mockClear();
     });
   });
 

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
@@ -6,6 +6,7 @@ import {sleep} from 'wix-ui-test-utils';
 import {paginationTestkitFactory} from '../../testkit';
 import {paginationTestkitFactory as enzymePaginationTestkitFactory} from '../../testkit/enzyme';
 import {mount} from 'enzyme';
+import {Simulate} from 'react-dom/test-utils';
 
 describe('Pagination', () => {
   const createDriver = createDriverFactory(paginationDriverFactory);
@@ -63,12 +64,12 @@ describe('Pagination', () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={10} maxPagesToShow={10} onChange={onChange}/>);
 
-      pagination.click(pagination.getPageByNumber(3));
+      pagination.clickPage(3);
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({page: 3}));
       onChange.mockClear();
 
-      pagination.click(pagination.getPageByNumber(9));
+      pagination.clickPage(9);
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({page: 9}));
     });
@@ -77,8 +78,7 @@ describe('Pagination', () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={15}  maxPagesToShow={15} currentPage={8} onChange={onChange}/>);
 
-      pagination.click(pagination.getCurrentPage());
-
+      pagination.clickPage(8);
       await sleep(10);
       expect(onChange).not.toBeCalled();
     });
@@ -117,7 +117,7 @@ describe('Pagination', () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination paginationMode={'input'} totalPages={15} onChange={onChange}/>);
       pagination.changeInput('5');
-      pagination.inputKeyDown(13);
+      pagination.commitInput();
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({page: 5}));
     });
@@ -126,7 +126,7 @@ describe('Pagination', () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination paginationMode={'input'} totalPages={15} currentPage={8} onChange={onChange}/>);
       pagination.changeInput('');
-      pagination.inputKeyDown(13);
+      pagination.commitInput();
 
       return sleep(10).then(() => {
         expect(onChange).not.toBeCalled();
@@ -137,7 +137,7 @@ describe('Pagination', () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination paginationMode={'input'} totalPages={15} onChange={onChange}/>);
       pagination.changeInput('16');
-      pagination.inputKeyDown(13);
+      pagination.commitInput();
       return sleep(10).then(() => {
         expect(onChange).not.toBeCalled();
       });
@@ -147,7 +147,7 @@ describe('Pagination', () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination paginationMode={'input'} totalPages={15} currentPage={8} onChange={onChange}/>);
       pagination.changeInput('8');
-      pagination.inputKeyDown(13);
+      pagination.commitInput();
 
       return sleep(10).then(() => {
         expect(onChange).not.toBeCalled();
@@ -191,7 +191,7 @@ describe('Pagination', () => {
       const pagination = createDriver(<Pagination totalPages={5} currentPage={3} showFirstLastNavButtons onChange={onChange}/>);
 
       for (const [button, page] of [['first', 1], ['previous', 2], ['next', 4], ['last', 5]]) {
-        pagination.clickOnNavButton(button);
+        pagination.clickNavButton(button);
         expect(onChange).toBeCalledWith(expect.objectContaining({page}));
         onChange.mockClear();
       }
@@ -201,12 +201,12 @@ describe('Pagination', () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={3} currentPage={1} showFirstLastNavButtons onChange={onChange}/>);
 
-      pagination.clickOnNavButton('first');
+      pagination.clickNavButton('first');
       await sleep(10);
       expect(onChange).not.toBeCalled();
       onChange.mockClear();
 
-      pagination.clickOnNavButton('previous');
+      pagination.clickNavButton('previous');
       await sleep(10);
       expect(onChange).not.toBeCalled();
     });
@@ -215,12 +215,12 @@ describe('Pagination', () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={3} currentPage={3} showFirstLastNavButtons onChange={onChange}/>);
 
-      pagination.clickOnNavButton('last');
+      pagination.clickNavButton('last');
       await sleep(10);
       expect(onChange).not.toBeCalled();
       onChange.mockClear();
 
-      pagination.clickOnNavButton('next');
+      pagination.clickNavButton('next');
       await sleep(10);
       expect(onChange).not.toBeCalled();
     });
@@ -261,65 +261,75 @@ describe('Pagination', () => {
     });
   });
 
-  describe('Keyboard and mouse handling', () => {
+  describe('Keyboard and mouse interaction', () => {
     it('calls onChange when Enter or Space is pressed on a button', async () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={3} currentPage={2} onChange={onChange} />);
 
-      pagination.keydown(pagination.getNavButton('previous'), {keyCode: 13});
+      Simulate.keyDown(pagination.getNavButton('previous'), {keyCode: 13});
       expect(onChange).toBeCalled();
       onChange.mockClear();
 
-      pagination.keydown(pagination.getNavButton('previous'), {keyCode: 32});
+      Simulate.keyDown(pagination.getNavButton('previous'), {keyCode: 32});
       expect(onChange).toBeCalled();
       onChange.mockClear();
 
-      pagination.keydown(pagination.getNavButton('previous'), {});
+      Simulate.keyDown(pagination.getNavButton('previous'), {});
       await sleep(10);
       expect(onChange).not.toBeCalled();
       onChange.mockClear();
 
-      pagination.keydown(pagination.getPageByNumber(1), {keyCode: 13});
+      Simulate.keyDown(pagination.getPageByNumber(1), {keyCode: 13});
       expect(onChange).toBeCalled();
       onChange.mockClear();
 
-      pagination.keydown(pagination.getPageByNumber(1), {keyCode: 32});
+      Simulate.keyDown(pagination.getPageByNumber(1), {keyCode: 32});
       expect(onChange).toBeCalled();
       onChange.mockClear();
 
-      pagination.keydown(pagination.getPageByNumber(1), {});
+      Simulate.keyDown(pagination.getPageByNumber(1), {});
       await sleep(10);
       expect(onChange).not.toBeCalled();
       onChange.mockClear();
     });
 
-    it('calls onChange when the left mouse button is pressed', async () => {
+    it('calls onChange only when the left mouse button is pressed', async () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={3} currentPage={2} onChange={onChange} />);
 
-      pagination.click(pagination.getNavButton('previous'), {button: 0});
+      Simulate.click(pagination.getNavButton('previous'), {button: 0});
       expect(onChange).toBeCalled();
       onChange.mockClear();
 
-      pagination.keydown(pagination.getNavButton('previous'), {button: 1});
+      Simulate.click(pagination.getNavButton('previous'), {button: 1});
       await sleep(10);
       expect(onChange).not.toBeCalled();
       onChange.mockClear();
 
-      pagination.keydown(pagination.getPageByNumber(1), {button: 0});
+      Simulate.click(pagination.getPageByNumber(1), {button: 0});
       expect(onChange).toBeCalled();
       onChange.mockClear();
 
-      pagination.keydown(pagination.getPageByNumber(1), {button: 1});
+      Simulate.click(pagination.getPageByNumber(1), {button: 1});
       await sleep(10);
       expect(onChange).not.toBeCalled();
       onChange.mockClear();
     });
   });
 
-  it('adds ID to the root if provided', () => {
-    const pagination = createDriver(<Pagination id="beet" totalPages={3} />);
-    expect(pagination.root.getAttribute('id')).toBe('beetroot');
+  it('adds IDs to the elements if ID prefix is provided', () => {
+    const pagination = createDriver(<Pagination id="$" totalPages={3} showFirstLastNavButtons />);
+    expect(pagination.root.getAttribute('id')).toBe('$root');
+    expect(pagination.getNavButton('first').getAttribute('id')).toBe('$navButtonFirst');
+    expect(pagination.getNavButton('previous').getAttribute('id')).toBe('$navButtonPrevious');
+    expect(pagination.getNavButton('next').getAttribute('id')).toBe('$navButtonNext');
+    expect(pagination.getNavButton('last').getAttribute('id')).toBe('$navButtonLast');
+    expect(pagination.getPageStrip().getAttribute('id')).toBe('$pageStrip');
+  });
+
+  it('does not add ID to the root if ID prefix is not provided', () => {
+    const pagination = createDriver(<Pagination totalPages={3} />);
+    expect(pagination.root.getAttribute('id')).toBe(null);
   });
 
   it('adds URLs to the pages according to desired format', () => {
@@ -339,11 +349,6 @@ describe('Pagination', () => {
     expect(pagination.getPageByNumber(1).getAttribute('href')).toEqual(null);
     expect(pagination.getPageByNumber(2).getAttribute('href')).toEqual('https://example.com/2/');
     expect(pagination.getPageByNumber(3).getAttribute('href')).toEqual('https://example.com/3/');
-  });
-
-  it('does not add ID to the root if not provided', () => {
-    const pagination = createDriver(<Pagination totalPages={3} />);
-    expect(pagination.root.getAttribute('id')).toBe(null);
   });
 
   describe('testkit', () => {

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
@@ -4,6 +4,8 @@ import * as PropTypes from 'prop-types';
 import * as classNames from 'classnames';
 import {PageStrip} from './PageStrip';
 
+const upperCaseFirst = (str: string): string => str[0].toUpperCase() + str.slice(1);
+
 enum ButtonType {
   Prev = 'previous',
   Next = 'next',
@@ -148,6 +150,7 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
   private renderPageStrip(): JSX.Element {
     return (
       <PageStrip
+        id={this.props.id}
         totalPages={this.props.totalPages}
         currentPage={this.props.currentPage}
         maxPagesToShow={this.maxPagesToShow}
@@ -236,7 +239,7 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     return (
       <a
         data-hook={type}
-        id={this.getId(type + 'Page')}
+        id={this.getId('navButton' + upperCaseFirst(type))}
         className={classNames(classes.navButton, btnClass, {[classes.disabled]: disabled})}
         aria-label={type[0].toUpperCase() + type.slice(1) + ' Page'}
         tabIndex={disabled || pageUrl ? null : 0}

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
@@ -145,10 +145,6 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     pageInputValue: String(this.props.currentPage)
   };
 
-  private handlePageSelect = (event: React.SyntheticEvent<Element>, page: number): void => {
-    this.props.onChange({event, page});
-  }
-
   private renderPageStrip(): JSX.Element {
     return (
       <PageStrip
@@ -159,8 +155,9 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
         showLastPage={this.props.showLastPage}
         responsive={this.props.responsive}
         classes={this.props.classes}
-        onPageSelect={this.handlePageSelect}
         pageUrl={this.props.pageUrl}
+        onPageClick={this.handlePageClick}
+        onPageKeyDown={this.handlePageKeyDown}
       />
     );
   }
@@ -183,10 +180,16 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     }
   }
 
-  private handleNavButtonKeyDown = (event: React.KeyboardEvent<Element>, page: number): void => {
+  private handlePageClick = (event: React.MouseEvent<Element>, page: number): void => {
+    if (event.button === 0) {
+      this.props.onChange({event, page});
+    }
+  }
+
+  private handlePageKeyDown = (event: React.KeyboardEvent<Element>, page: number): void => {
     // Enter or Space
     if (event.keyCode === 13 || event.keyCode === 32) {
-      this.handlePageSelect(event, page);
+      this.props.onChange({event, page});
     }
   }
 
@@ -237,8 +240,8 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
         className={classNames(classes.navButton, btnClass, {[classes.disabled]: disabled})}
         aria-label={type[0].toUpperCase() + type.slice(1) + ' Page'}
         tabIndex={disabled || pageUrl ? null : 0}
-        onClick={disabled ? null : event => this.handlePageSelect(event, page)}
-        onKeyDown={disabled ? null : event => this.handleNavButtonKeyDown(event, page)}
+        onClick={disabled ? null : event => this.handlePageClick(event, page)}
+        onKeyDown={disabled ? null : event => this.handlePageKeyDown(event, page)}
         href={!disabled && pageUrl ? pageUrl(page) : null}
       >
         {this.props.replaceArrowsWithText ? text : symbol}


### PR DESCRIPTION
* The server and the client initially render the same tree, because React can freak out otherwise.
* Added IDs to more sub-elements and added tests to check those.
* Changed in the test driver things related to keyboard and mouse handling.

The way I see it, the driver should provide an interface for interacting with the component without exposing low-level details, such as what button needs to pressed to commit the input, or what mouse event the page buttons actually respond to. Therefore I've added `clickPage(n)` and `commitInput()`.

On the other hand, the component's own unit tests need to be able to simulate arbitrary events to make sure that component correctly handles click vs mousedown or left vs right mouse button. For such tests I don't see any value in re-exporting standard react test utilities (i.e. Simulate) from the driver. Unit tests should be able to use Simulate directly, they're tied to low-level implementation details and that's ok.

In the driver itself I had to change `eventTrigger` to a direct import of Simulate, because right now eventTrigger has no ability to handle custom event data. We can change this back when it does. Although I'm not even sure if it's useful to have this extra layer of indirection.

**UPD:** Lior B. says that eventTrigger is a workaround for Lerna - it doesn't like when react test utils are imported from multiple node_modules folders, I'll need to check this with Shlomi, maybe we can simply re-export Simulate from wix-ui-test-utils instead of creating a wrapper for it.