### PR TITLE
Click event is fired only when the primary button is pressed

### DIFF
--- a/packages/wix-ui-core/src/components/Pagination/Pagination.driver.ts
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.driver.ts
@@ -41,9 +41,9 @@ export const paginationDriverFactory = ({element: root}: {element: Element}) => 
     /** Returns the total amount of pages displayed in "input" mode */
     getTotalPagesField: (): Element | null => root.querySelector('[data-hook="total-pages"]'),
     /** Simulates clicking a nav button */
-    clickNavButton: (name: NavButtonName): void => Simulate.click(getNavButton(name), {button: 0}),
+    clickNavButton: (name: NavButtonName): void => Simulate.click(getNavButton(name)),
     /** Simulates clicking a page in "pages" mode */
-    clickPage: (page: number): void => Simulate.click(getPageByNumber(page), {button: 0}),
+    clickPage: (page: number): void => Simulate.click(getPageByNumber(page)),
     /** Simulates changing the value of the input field in "input" mode */
     changeInput: (newValue: string): void => {
       const input = getInput();

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
@@ -293,26 +293,16 @@ describe('Pagination', () => {
       onChange.mockClear();
     });
 
-    it('calls onChange only when the left mouse button is pressed', async () => {
+    it('calls onChange when the left mouse button is pressed', async () => {
       const onChange = jest.fn();
       const pagination = createDriver(<Pagination totalPages={3} currentPage={2} onChange={onChange} />);
 
-      Simulate.click(pagination.getNavButton('previous'), {button: 0});
+      Simulate.click(pagination.getNavButton('previous'));
       expect(onChange).toBeCalled();
       onChange.mockClear();
 
-      Simulate.click(pagination.getNavButton('previous'), {button: 1});
-      await sleep(10);
-      expect(onChange).not.toBeCalled();
-      onChange.mockClear();
-
-      Simulate.click(pagination.getPageByNumber(1), {button: 0});
+      Simulate.click(pagination.getPageByNumber(1));
       expect(onChange).toBeCalled();
-      onChange.mockClear();
-
-      Simulate.click(pagination.getPageByNumber(1), {button: 1});
-      await sleep(10);
-      expect(onChange).not.toBeCalled();
       onChange.mockClear();
     });
   });

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
@@ -184,9 +184,7 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
   }
 
   private handlePageClick = (event: React.MouseEvent<Element>, page: number): void => {
-    if (event.button === 0) {
-      this.props.onChange({event, page});
-    }
+    this.props.onChange({event, page});
   }
 
   private handlePageKeyDown = (event: React.KeyboardEvent<Element>, page: number): void => {


### PR DESCRIPTION
We don't need to check the mouse button because clicking right or middle button doesn't fire the click event.