### PR TITLE
Pagination: native RTL, labels are ReactNodes

### DIFF
--- a/packages/wix-ui-core/src/components/Pagination/PageStrip.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/PageStrip.tsx
@@ -11,21 +11,22 @@ export interface PageStripClasses {
   pageStrip: string;
   pageButton: string;
   currentPage: string;
-  ellipsis: string;
+  gap: string;
 }
 
 export interface PageStripProps {
+  id?: string;
+  classes: PageStripClasses;
   totalPages: number;
   currentPage: number;
   maxPagesToShow: number;
   showFirstPage: boolean;
   showLastPage: boolean;
   responsive: boolean;
-  id?: string;
-  classes: PageStripClasses;
+  pageUrl?: (pageNumber: number) => string;
+  gapLabel: React.ReactNode;
   onPageClick: (event: React.MouseEvent<Element>, page: number) => void;
   onPageKeyDown: (event: React.KeyboardEvent<Element>, page: number) => void;
-  pageUrl?: (pageNumber: number) => string;
 }
 
 export enum ResponsiveLayoutPhase {
@@ -93,8 +94,8 @@ export class PageStrip extends React.Component<PageStripProps, PageStripState> {
     return layout.map((pageNumber, index) => {
       if (!pageNumber) {
         return (
-          <span key={index} className={classes.ellipsis}>
-            ...
+          <span key={index} className={classes.gap}>
+            {this.props.gapLabel}
           </span>
         );
       }

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
@@ -239,10 +239,10 @@ describe('Pagination', () => {
           totalPages={3}
           showFirstLastNavButtons
           replaceArrowsWithText
-          firstText="oh"
-          previousText="my"
-          nextText="god"
-          lastText="!!!"/>
+          firstLabel="oh"
+          previousLabel="my"
+          nextLabel="god"
+          lastLabel="!!!"/>
       );
       expect(pagination.getNavButton('first').textContent).toEqual('oh');
       expect(pagination.getNavButton('previous').textContent).toEqual('my');
@@ -320,6 +320,13 @@ describe('Pagination', () => {
   it('does not add ID to the root if ID prefix is not provided', () => {
     const pagination = createDriver(<Pagination totalPages={3} />);
     expect(pagination.root.getAttribute('id')).toBe(null);
+  });
+
+  it('allows to customize gap text', () => {
+    const pagination = createDriver(
+      <Pagination totalPages={5} maxPagesToShow={4} showLastPage gapLabel={<em>*</em>} />
+    );
+    expect(pagination.getPageLabels()).toBe(['1', '2', '*', '5']);
   });
 
   it('adds URLs to the pages according to desired format', () => {

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.spec.tsx
@@ -326,7 +326,7 @@ describe('Pagination', () => {
     const pagination = createDriver(
       <Pagination totalPages={5} maxPagesToShow={4} showLastPage gapLabel={<em>*</em>} />
     );
-    expect(pagination.getPageLabels()).toBe(['1', '2', '*', '5']);
+    expect(pagination.getPageLabels()).toEqual(['1', '2', '*', '5']);
   });
 
   it('adds URLs to the pages according to desired format', () => {

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import {createHOC} from '../../createHOC';
-import {number, func, oneOf, bool, string, object} from 'prop-types';
+import {number, func, oneOf, bool, string, object, node} from 'prop-types';
 import {PageStrip} from './PageStrip';
 
 const upperCaseFirst = (str: string): string => str[0].toUpperCase() + str.slice(1);
@@ -87,13 +87,15 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     /** Allows replacing navigation arrows with textual buttons */
     replaceArrowsWithText: bool,
     /** Text to appear for the 'first' navigation button when prop 'replaceArrowsWithText' is true */
-    firstLabel: string,
+    firstLabel: node,
     /** Text to appear for the 'previous' navigation button when prop 'replaceArrowsWithText' is true */
-    previousLabel: string,
+    previousLabel: node,
     /** Text to appear for the 'next' navigation button when prop 'replaceArrowsWithText' is true */
-    nextLabel: string,
+    nextLabel: node,
     /** Text to appear for the 'last' navigation button when prop 'replaceArrowsWithText' is true */
-    lastLabel: string,
+    lastLabel: node,
+    /** Text to appear in the gap between page numbers */
+    gapLabel: node,
     /**  Whether the component layout is right to left */
     rtl: bool,
     /** The pixel width the component will render in  */

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
@@ -28,7 +28,7 @@ export interface PaginationClasses {
   pageStrip: string;
   pageButton: string;
   currentPage: string;
-  ellipsis: string;
+  gap: string;
 
   // Mode: input
   pageForm: string;
@@ -49,10 +49,11 @@ export interface PaginationProps {
   paginationMode?: 'pages' | 'input';
   showFirstLastNavButtons?: boolean;
   replaceArrowsWithText?: boolean;
-  firstText?: string;
-  previousText?: string;
-  nextText?: string;
-  lastText?: string;
+  firstLabel?: React.ReactNode;
+  previousLabel?: React.ReactNode;
+  nextLabel?: React.ReactNode;
+  lastLabel?: React.ReactNode;
+  gapLabel?: React.ReactNode;
   rtl?: boolean;
   width?: number;
   showFirstPage?: boolean;
@@ -86,13 +87,13 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     /** Allows replacing navigation arrows with textual buttons */
     replaceArrowsWithText: bool,
     /** Text to appear for the 'first' navigation button when prop 'replaceArrowsWithText' is true */
-    firstText: string,
+    firstLabel: string,
     /** Text to appear for the 'previous' navigation button when prop 'replaceArrowsWithText' is true */
-    previousText: string,
+    previousLabel: string,
     /** Text to appear for the 'next' navigation button when prop 'replaceArrowsWithText' is true */
-    nextText: string,
+    nextLabel: string,
     /** Text to appear for the 'last' navigation button when prop 'replaceArrowsWithText' is true */
-    lastText: string,
+    lastLabel: string,
     /**  Whether the component layout is right to left */
     rtl: bool,
     /** The pixel width the component will render in  */
@@ -122,10 +123,11 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     responsive: false,
     paginationMode: 'pages',
     showInputModeTotalPages: false,
-    firstText: 'First',
-    lastText: 'Last',
-    previousText: 'Previous',
-    nextText: 'Next'
+    firstLabel: 'First',
+    lastLabel: 'Last',
+    previousLabel: 'Previous',
+    nextLabel: 'Next',
+    gapLabel: '...'
   };
 
   private getId(elementName: string = ''): string | null {
@@ -150,14 +152,15 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     return (
       <PageStrip
         id={this.props.id}
+        classes={this.props.classes}
         totalPages={this.props.totalPages}
         currentPage={this.props.currentPage}
         maxPagesToShow={this.maxPagesToShow}
         showFirstPage={this.props.showFirstPage}
         showLastPage={this.props.showLastPage}
         responsive={this.props.responsive}
-        classes={this.props.classes}
         pageUrl={this.props.pageUrl}
+        gapLabel={this.props.gapLabel}
         onPageClick={this.handlePageClick}
         onPageKeyDown={this.handlePageKeyDown}
       />
@@ -229,11 +232,11 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     // dir="rtl" automatically flips the direction of less-than and more-than signs.
     // If we decide to use different characters we need to add conditional logic here.
 
-    const [btnClass, text, symbol, page] = {
-      [ButtonType.Prev]:  [classes.navButtonPrevious, this.props.previousText, '<',  currentPage - 1],
-      [ButtonType.Next]:  [classes.navButtonNext,     this.props.nextText,     '>',  currentPage + 1],
-      [ButtonType.First]: [classes.navButtonFirst,    this.props.firstText,    '<<', 1],
-      [ButtonType.Last]:  [classes.navButtonLast,     this.props.lastText,     '>>', totalPages]
+    const [btnClass, label, symbol, page] = {
+      [ButtonType.Prev]:  [classes.navButtonPrevious, this.props.previousLabel, '<',  currentPage - 1],
+      [ButtonType.Next]:  [classes.navButtonNext,     this.props.nextLabel,     '>',  currentPage + 1],
+      [ButtonType.First]: [classes.navButtonFirst,    this.props.firstLabel,    '<<', 1],
+      [ButtonType.Last]:  [classes.navButtonLast,     this.props.lastLabel,     '>>', totalPages]
     }[type] as [string, string, string, number];
 
     return (
@@ -241,13 +244,13 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
         data-hook={type}
         id={this.getId('navButton' + upperCaseFirst(type))}
         className={classNames(classes.navButton, btnClass, {[classes.disabled]: disabled})}
-        aria-label={type[0].toUpperCase() + type.slice(1) + ' Page'}
+        aria-label={upperCaseFirst(type) + ' Page'}
         tabIndex={disabled || pageUrl ? null : 0}
         onClick={disabled ? null : event => this.handlePageClick(event, page)}
         onKeyDown={disabled ? null : event => this.handlePageKeyDown(event, page)}
         href={!disabled && pageUrl ? pageUrl(page) : null}
       >
-        {this.props.replaceArrowsWithText ? text : symbol}
+        {this.props.replaceArrowsWithText ? label : symbol}
       </a>
     );
   }

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
@@ -36,7 +36,6 @@ export interface PaginationClasses {
   totalPages: string;
 
   // Modifiers
-  rtl: string;
   disabled: string;
 }
 
@@ -198,7 +197,7 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     const {classes} = this.props;
 
     return (
-      <div data-hook="page-form" id={this.getId('pageForm')} className={classes.pageForm}>
+      <div data-hook="page-form" id={this.getId('pageForm')} className={classes.pageForm} dir="ltr">
         <input
           data-hook="page-input"
           type="number"
@@ -220,18 +219,21 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
   }
 
   private renderNavButton(type: ButtonType): JSX.Element {
-    const {classes, rtl, currentPage, totalPages, pageUrl} = this.props;
+    const {classes, currentPage, totalPages, pageUrl} = this.props;
 
     const disabled = (
       ((type === ButtonType.First || type === ButtonType.Prev) && currentPage <= 1) ||
       ((type === ButtonType.Last  || type === ButtonType.Next) && currentPage >= totalPages)
     );
 
+    // dir="rtl" automatically flips the direction of less-than and more-than signs.
+    // If we decide to use different characters we need to add conditional logic here.
+
     const [btnClass, text, symbol, page] = {
-      [ButtonType.Prev]:  [classes.navButtonPrevious, this.props.previousText, rtl ? '>'  :  '<', currentPage - 1],
-      [ButtonType.Next]:  [classes.navButtonNext,     this.props.nextText,     rtl ? '<'  :  '>', currentPage + 1],
-      [ButtonType.First]: [classes.navButtonFirst,    this.props.firstText,    rtl ? '>>' : '<<', 1],
-      [ButtonType.Last]:  [classes.navButtonLast,     this.props.lastText,     rtl ? '<<' : '>>', totalPages]
+      [ButtonType.Prev]:  [classes.navButtonPrevious, this.props.previousText, '<',  currentPage - 1],
+      [ButtonType.Next]:  [classes.navButtonNext,     this.props.nextText,     '>',  currentPage + 1],
+      [ButtonType.First]: [classes.navButtonFirst,    this.props.firstText,    '<<', 1],
+      [ButtonType.Last]:  [classes.navButtonLast,     this.props.lastText,     '>>', totalPages]
     }[type] as [string, string, string, number];
 
     return (
@@ -264,7 +266,8 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
         id={this.getId('root')}
         role="navigation"
         aria-label="Pagination Navigation"
-        className={classNames(classes.root, {[classes.rtl]: this.props.rtl})}
+        className={classes.root}
+        dir={this.props.rtl ? 'rtl' : null}
         style={width ? {width} : null}
       >
         {this.renderNavButton(ButtonType.Next)}

--- a/packages/wix-ui-core/src/components/Pagination/page-strip-layout.ts
+++ b/packages/wix-ui-core/src/components/Pagination/page-strip-layout.ts
@@ -209,21 +209,21 @@ function createLayout({
 
     // Apparently, no. Let's prioritize showing the previous and the next page,
     // then the first and the last page if requested, then the rest.
-    // Also let's try to show ellipsis only on one side.
+    // Also let's try to have a gap only on one side.
 
-    // Cut off only at the end.
-    (showFirstPage && lowerBound === 1) &&
-    expand(lowerBound, nextOrUpperBound, false, showLastPage) ||
+    // Gap only before the last page.
+    (showLastPage && lowerBound === 1) &&
+    expand(lowerBound, nextOrUpperBound, false, true) ||
 
-    // Cut off only at the beginning.
-    (showLastPage && upperBound === totalPages) &&
-    expand(prevOrLowerBound, upperBound, showFirstPage, false) ||
+    // Gap only after the first page.
+    (showFirstPage && upperBound === totalPages) &&
+    expand(prevOrLowerBound, upperBound, true, false) ||
 
-    // Cut off on both sides, add ellipses.
+    // Gap after the first page and before the last.
     (showFirstPage && showLastPage) &&
     expand(prevOrLowerBound, nextOrUpperBound, true, true) ||
 
-    // Cut off on both sides, no ellipses.
+    // Cut off both sides, don't show the first and last page.
     expand(prevOrLowerBound, nextOrUpperBound, false, false) ||
 
     // Oh well.

--- a/packages/wix-ui-core/src/components/Pagination/theme.ts
+++ b/packages/wix-ui-core/src/components/Pagination/theme.ts
@@ -12,7 +12,7 @@ export type PaginationTheme = {
   pageStrip: React.CSSProperties,
   pageButton: React.CSSProperties,
   currentPage: React.CSSProperties,
-  ellipsis: React.CSSProperties,
+  gap: React.CSSProperties,
 
   // Mode: input
   pageForm: React.CSSProperties,
@@ -55,7 +55,7 @@ export const core: PaginationTheme = {
     display: 'inline-flex',
     flexShrink: 0
   },
-  ellipsis: {
+  gap: {
     display: 'inline-flex',
     flexShrink: 0
   },

--- a/packages/wix-ui-core/src/components/Pagination/theme.ts
+++ b/packages/wix-ui-core/src/components/Pagination/theme.ts
@@ -20,7 +20,6 @@ export type PaginationTheme = {
   totalPages: React.CSSProperties,
 
   // Modifiers
-  rtl: React.CSSProperties,
   disabled: React.CSSProperties
 };
 
@@ -28,10 +27,7 @@ export type PaginationTheme = {
 export const core: PaginationTheme = {
   root: {
     display: 'inline-flex',
-    userSelect: 'none',
-    '&$rtl': {
-      flexDirection: 'row-reverse'
-    }
+    userSelect: 'none'
   },
   navButton: {
     display: 'inline-flex',
@@ -48,11 +44,7 @@ export const core: PaginationTheme = {
     display: 'flex',
     order: 3,
     justifyContent: 'center',
-    overflow: 'hidden',
-
-    '$rtl > &': {
-      flexDirection: 'row-reverse'
-    }
+    overflow: 'hidden'
   },
   pageButton: {
     display: 'inline-flex',
@@ -73,6 +65,5 @@ export const core: PaginationTheme = {
   },
   pageInput: {},
   totalPages: {},
-  rtl: {},
   disabled: {}
 };

--- a/packages/wix-ui-core/stories/Pagination/pagination-story-theme.ts
+++ b/packages/wix-ui-core/stories/Pagination/pagination-story-theme.ts
@@ -30,7 +30,7 @@ export const theme = {
     backgroundColor: '#455A64',
     color: '#CFD8DC'
   },
-  ellipsis: {
+  gap: {
     ...button,
     backgroundColor: '#CFD8DC'
   },


### PR DESCRIPTION
* Added dir="rtl" to the root, right-to-left now magically works without CSS or conditionals.
* Fixed a bug in numbering logic.
* Buttons, in addition to text, can now accept react elements. Renamed previousText/nextText to previousLabel/nextLabel.
* Ellipsis label also can be customized.