### PR TITLE
wix-ui-core: changing createHOC to use hoist-non-react-methods

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "hoist-non-react-statics": "^2.3.1",
+    "hoist-non-react-methods": "^1.1.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-onclickoutside": "^6.7.0",

--- a/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
+++ b/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
@@ -1,37 +1,63 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import {createHOC} from './';
-import {mount} from 'enzyme';
+import { renderIntoDocument, findRenderedComponentWithType } from 'react-dom/test-utils'
 
 describe('createHOC function', () => {
 
   type ComponentProps = {
-    children?: any,
+    id?: string,
     dataClass?: string,
     dataHook?: string
   };
 
-  const Component: React.SFC<ComponentProps> = ({children}) => React.createElement('div', {children});
+  class ChildComponent extends React.Component<ComponentProps> {
+    constructor(props) {
+      super(props);
+      this.state = {id : props.id};
+      this.boundMethod = this.boundMethod.bind(this);
+    }
 
-  const HOCComponent = createHOC(Component);
+    static staticVariable = 'staticVariable';
+    static staticMethod() { return 'staticMethod'; }
+    unboundMethod() { return 'unboundMethod'; }
+    boundMethod() { return this.state.id; }
+    render() { return <div>Hello</div>; }
+  };
 
-  const render = (Comp: any) => mount(Comp, {attachTo: document.createElement('div')});
-
-  let wrapper;
-
-  afterEach(() => wrapper.detach());
+  const HOCComponent = createHOC(ChildComponent);
 
   it('should render the wrapped component', () => {
-    wrapper = render(<HOCComponent>Hello</HOCComponent>);
-    expect(wrapper.html()).toBe('<div>Hello</div>');
+    const wrapper = renderIntoDocument(<HOCComponent/>);
+    expect(findRenderedComponentWithType(wrapper, ChildComponent)).toBeTruthy();;
   });
 
   it('should place data-hook on the root of the component', () => {
-    wrapper = render(<HOCComponent dataHook="my-data">Hello</HOCComponent>);
-    expect(wrapper.getDOMNode().getAttribute('data-hook')).toBe('my-data');
+    const wrapper = renderIntoDocument(<HOCComponent dataHook='my-data-hook'/>);
+    expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-hook')).toBe('my-data-hook');
+  });
+  
+  it('should place data-class on the root of the component', () => {
+    const wrapper = renderIntoDocument(<HOCComponent dataClass='my-data-class'/>);
+    expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
   });
 
-  it('should place data-class on the root of the component', () => {
-    wrapper = render(<HOCComponent dataClass="my-data">Hello</HOCComponent>);
-    expect(wrapper.getDOMNode().getAttribute('data-class')).toBe('my-data');
-  });
+  describe('hoisting', () => {
+    it('should hoist static methods', () => {
+      expect(HOCComponent.staticMethod).toBeDefined();
+      expect(HOCComponent.staticMethod()).toEqual('staticMethod');
+    });
+    
+    it('should hoist static variables', () => {
+      expect(HOCComponent.staticVariable).toEqual('staticVariable');
+    });
+    
+    it('should hoist prototype methods from child to HOC and bind them', () => {
+      const wrapper = renderIntoDocument(<HOCComponent id='some_id'/>);
+      expect(wrapper.unboundMethod).toBeDefined();
+      expect(wrapper.unboundMethod()).toEqual('unboundMethod');
+      expect(wrapper.boundMethod).toBeDefined();
+      expect(wrapper.boundMethod()).toEqual('some_id');
+    });
+  })
 });

--- a/packages/wix-ui-core/src/createHOC/index.tsx
+++ b/packages/wix-ui-core/src/createHOC/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {string} from 'prop-types';
-const hoistNonReactStatics = require('hoist-non-react-statics');
+import hoistNonReactMethods from 'hoist-non-react-methods';
 
 export interface WixComponentProps {
   dataHook?: string;
@@ -30,9 +30,9 @@ export const createHOC = Component => {
     }
 
     render() {
-      return <Component {...this.props}/>;
+      return <Component ref='wrappedComponent' {...this.props}/>;
     }
   }
 
-  return hoistNonReactStatics(WixComponent, Component, {inner: true});
+  return hoistNonReactMethods(WixComponent, Component, {delegateTo: c => c.refs.wrappedComponent, hoistStatics: true});
 };


### PR DESCRIPTION
This will hoist methods on the component itself, not just static methods on the class.
Added tests for the hoisting. 