### PR TITLE
Hoist methods instead of hoist statics

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "hoist-non-react-statics": "^2.3.1",
+    "hoist-non-react-methods": "^1.1.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-onclickoutside": "^6.7.0",

--- a/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
+++ b/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import {createHOC} from './';
 import {mount} from 'enzyme';
 

--- a/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
+++ b/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
@@ -11,7 +11,7 @@ describe('createHOC function', () => {
     dataHook?: string
   };
 
-  const render = (Comp: any) => mount(Comp, { attachTo: document.createElement('div') });
+  const render = (Comp: any) => mount(Comp, {attachTo: document.createElement('div')});
 
   // Regular component with state
   class ChildComponent extends React.Component<ComponentProps, {id: string}> {

--- a/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
+++ b/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
@@ -64,25 +64,6 @@ describe('createHOC function', () => {
       const wrapper = renderIntoDocument(<HOCComponent dataClass="my-data-class"/>);
       expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
     });
-
-    describe('hoisting', () => {
-      it('should hoist static methods', () => {
-        expect(HOCComponent.staticMethod).toBeDefined();
-        expect(HOCComponent.staticMethod()).toEqual('staticMethod');
-      });
-
-      it('should hoist static variables', () => {
-        expect(HOCComponent.staticVariable).toEqual('staticVariable');
-      });
-
-      it('should hoist prototype methods from child to HOC and bind them', () => {
-        const wrapper = renderIntoDocument(<HOCComponent id="some_id"/>);
-        expect(wrapper.unboundMethod).toBeDefined();
-        expect(wrapper.unboundMethod()).toEqual('unboundMethod');
-        expect(wrapper.boundMethod).toBeDefined();
-        expect(wrapper.boundMethod()).toEqual('some_id');
-      });
-    });
   });
 
   describe('Pure components', () => {
@@ -103,24 +84,6 @@ describe('createHOC function', () => {
       expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
     });
 
-    describe('hoisting', () => {
-      it('should hoist static methods', () => {
-        expect(HOCComponent.staticMethod).toBeDefined();
-        expect(HOCComponent.staticMethod()).toEqual('staticMethod');
-      });
-
-      it('should hoist static variables', () => {
-        expect(HOCComponent.staticVariable).toEqual('staticVariable');
-      });
-
-      it('should hoist prototype methods from child to HOC and bind them', () => {
-        const wrapper = renderIntoDocument(<HOCComponent id="some_id" />);
-        expect(wrapper.unboundMethod).toBeDefined();
-        expect(wrapper.unboundMethod()).toEqual('unboundMethod');
-        expect(wrapper.boundMethod).toBeDefined();
-        expect(wrapper.boundMethod()).toEqual('some_id');
-      });
-    });
   });
 
   describe('Stateless components', () => {

--- a/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
+++ b/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
@@ -1,37 +1,146 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import {createHOC} from './';
+import {renderIntoDocument, findRenderedComponentWithType} from 'react-dom/test-utils';
 import {mount} from 'enzyme';
 
 describe('createHOC function', () => {
 
   type ComponentProps = {
-    children?: any,
+    id?: string,
     dataClass?: string,
     dataHook?: string
   };
 
-  const Component: React.SFC<ComponentProps> = ({children}) => React.createElement('div', {children});
+  // Regular component with state
+  class ChildComponent extends React.Component<ComponentProps, {id: string}> {
+    constructor(props) {
+      super(props);
+      this.state = {id : props.id};
+      this.boundMethod = this.boundMethod.bind(this);
+    }
 
-  const HOCComponent = createHOC(Component);
+    static staticVariable = 'staticVariable';
+    static staticMethod() { return 'staticMethod'; }
+    unboundMethod() { return 'unboundMethod'; }
+    boundMethod() { return this.state.id; }
+    render() { return <div>Hello</div>; }
+  }
 
-  const render = (Comp: any) => mount(Comp, {attachTo: document.createElement('div')});
+  // Pure component without state
+  class PureChildComponent extends React.PureComponent<ComponentProps> {
+    id: string;
 
-  let wrapper;
+    constructor(props) {
+      super(props);
+      this.id = props.id;
+      this.boundMethod = this.boundMethod.bind(this);
+    }
 
-  afterEach(() => wrapper.detach());
+    static staticVariable = 'staticVariable';
+    static staticMethod() { return 'staticMethod'; }
+    unboundMethod() { return 'unboundMethod'; }
+    boundMethod() { return this.id; }
+    render() { return <div>Hello</div>; }
+  }
 
-  it('should render the wrapped component', () => {
-    wrapper = render(<HOCComponent>Hello</HOCComponent>);
-    expect(wrapper.html()).toBe('<div>Hello</div>');
+  // Stateless component
+  const StatelessChildComponent = () => (<div>stateless</div>);
+
+  describe('Regular components', () => {
+    const HOCComponent = createHOC(ChildComponent);
+
+    it('should render the wrapped component', () => {
+      const wrapper = renderIntoDocument(<HOCComponent/>);
+      expect(findRenderedComponentWithType(wrapper, ChildComponent)).toBeTruthy();
+    });
+
+    it('should place data-hook on the root of the component', () => {
+      const wrapper = renderIntoDocument(<HOCComponent dataHook="my-data-hook"/>);
+      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-hook')).toBe('my-data-hook');
+    });
+
+    it('should place data-class on the root of the component', () => {
+      const wrapper = renderIntoDocument(<HOCComponent dataClass="my-data-class"/>);
+      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
+    });
+
+    describe('hoisting', () => {
+      it('should hoist static methods', () => {
+        expect(HOCComponent.staticMethod).toBeDefined();
+        expect(HOCComponent.staticMethod()).toEqual('staticMethod');
+      });
+
+      it('should hoist static variables', () => {
+        expect(HOCComponent.staticVariable).toEqual('staticVariable');
+      });
+
+      it('should hoist prototype methods from child to HOC and bind them', () => {
+        const wrapper = renderIntoDocument(<HOCComponent id="some_id"/>);
+        expect(wrapper.unboundMethod).toBeDefined();
+        expect(wrapper.unboundMethod()).toEqual('unboundMethod');
+        expect(wrapper.boundMethod).toBeDefined();
+        expect(wrapper.boundMethod()).toEqual('some_id');
+      });
+    });
   });
 
-  it('should place data-hook on the root of the component', () => {
-    wrapper = render(<HOCComponent dataHook="my-data">Hello</HOCComponent>);
-    expect(wrapper.getDOMNode().getAttribute('data-hook')).toBe('my-data');
+  describe('Pure components', () => {
+    const HOCComponent = createHOC(PureChildComponent);
+
+    it('should render the wrapped component', () => {
+      const wrapper = renderIntoDocument(<HOCComponent />);
+      expect(findRenderedComponentWithType(wrapper, PureChildComponent)).toBeTruthy();
+    });
+
+    it('should place data-hook on the root of the component', () => {
+      const wrapper = renderIntoDocument(<HOCComponent dataHook="my-data-hook" />);
+      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-hook')).toBe('my-data-hook');
+    });
+
+    it('should place data-class on the root of the component', () => {
+      const wrapper = renderIntoDocument(<HOCComponent dataClass="my-data-class" />);
+      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
+    });
+
+    describe('hoisting', () => {
+      it('should hoist static methods', () => {
+        expect(HOCComponent.staticMethod).toBeDefined();
+        expect(HOCComponent.staticMethod()).toEqual('staticMethod');
+      });
+
+      it('should hoist static variables', () => {
+        expect(HOCComponent.staticVariable).toEqual('staticVariable');
+      });
+
+      it('should hoist prototype methods from child to HOC and bind them', () => {
+        const wrapper = renderIntoDocument(<HOCComponent id="some_id" />);
+        expect(wrapper.unboundMethod).toBeDefined();
+        expect(wrapper.unboundMethod()).toEqual('unboundMethod');
+        expect(wrapper.boundMethod).toBeDefined();
+        expect(wrapper.boundMethod()).toEqual('some_id');
+      });
+    });
   });
 
-  it('should place data-class on the root of the component', () => {
-    wrapper = render(<HOCComponent dataClass="my-data">Hello</HOCComponent>);
-    expect(wrapper.getDOMNode().getAttribute('data-class')).toBe('my-data');
+  describe('Stateless components', () => {
+    const HOCComponent = createHOC(StatelessChildComponent);
+
+    it('should render the wrapped component', () => {
+      const wrapper = mount(<HOCComponent />);
+      expect(wrapper.containsMatchingElement(<StatelessChildComponent/>)).toBeTruthy();
+    });
+
+    it('should place data-hook on the root of the component', () => {
+      const wrapper = renderIntoDocument(<HOCComponent dataHook="my-data-hook" />);
+      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-hook')).toBe('my-data-hook');
+    });
+
+    it('should place data-class on the root of the component', () => {
+      const wrapper = renderIntoDocument(<HOCComponent dataClass="my-data-class" />);
+      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
+    });
+
+    // Nothing to hoist on stateless components
   });
 });

--- a/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
+++ b/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {createHOC} from './';
-import {renderIntoDocument, findRenderedComponentWithType} from 'react-dom/test-utils';
 import {mount} from 'enzyme';
 
 describe('createHOC function', () => {
@@ -11,6 +10,8 @@ describe('createHOC function', () => {
     dataClass?: string,
     dataHook?: string
   };
+
+  const render = (Comp: any) => mount(Comp, { attachTo: document.createElement('div') });
 
   // Regular component with state
   class ChildComponent extends React.Component<ComponentProps, {id: string}> {
@@ -51,23 +52,22 @@ describe('createHOC function', () => {
     const HOCComponent = createHOC(ChildComponent);
 
     it('should render the wrapped component', () => {
-      const wrapper = renderIntoDocument(<HOCComponent/>);
-      expect(findRenderedComponentWithType(wrapper, ChildComponent)).toBeTruthy();
+      const wrapper = render(<HOCComponent />);
+      expect(wrapper.children().instance()).toBeInstanceOf(ChildComponent);
     });
 
     it('should place data-hook on the root of the component', () => {
-      const wrapper = renderIntoDocument(<HOCComponent dataHook="my-data-hook"/>);
-      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-hook')).toBe('my-data-hook');
+      const wrapper = render(<HOCComponent dataHook="my-data-hook" />);
+      expect(wrapper.getDOMNode().getAttribute('data-hook')).toBe('my-data-hook');
     });
 
     it('should place data-class on the root of the component', () => {
-      const wrapper = renderIntoDocument(<HOCComponent dataClass="my-data-class"/>);
-      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
+      const wrapper = render(<HOCComponent dataClass="my-data-class" />);
+      expect(wrapper.getDOMNode().getAttribute('data-class')).toBe('my-data-class');
     });
 
     describe('hoisting', () => {
       it('should hoist static methods', () => {
-        expect(HOCComponent.staticMethod).toBeDefined();
         expect(HOCComponent.staticMethod()).toEqual('staticMethod');
       });
 
@@ -76,11 +76,9 @@ describe('createHOC function', () => {
       });
 
       it('should hoist prototype methods from child to HOC and bind them', () => {
-        const wrapper = renderIntoDocument(<HOCComponent id="some_id"/>);
-        expect(wrapper.unboundMethod).toBeDefined();
-        expect(wrapper.unboundMethod()).toEqual('unboundMethod');
-        expect(wrapper.boundMethod).toBeDefined();
-        expect(wrapper.boundMethod()).toEqual('some_id');
+        const wrapper = render(<HOCComponent id="some_id" />);
+        expect(wrapper.instance().unboundMethod()).toEqual('unboundMethod');
+        expect(wrapper.instance().boundMethod()).toEqual('some_id');
       });
     });
   });
@@ -89,23 +87,22 @@ describe('createHOC function', () => {
     const HOCComponent = createHOC(PureChildComponent);
 
     it('should render the wrapped component', () => {
-      const wrapper = renderIntoDocument(<HOCComponent />);
-      expect(findRenderedComponentWithType(wrapper, PureChildComponent)).toBeTruthy();
+      const wrapper = render(<HOCComponent />);
+      expect(wrapper.children().instance()).toBeInstanceOf(PureChildComponent);
     });
 
     it('should place data-hook on the root of the component', () => {
-      const wrapper = renderIntoDocument(<HOCComponent dataHook="my-data-hook" />);
-      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-hook')).toBe('my-data-hook');
+      const wrapper = render(<HOCComponent dataHook="my-data-hook" />);
+      expect(wrapper.getDOMNode().getAttribute('data-hook')).toBe('my-data-hook');
     });
 
     it('should place data-class on the root of the component', () => {
-      const wrapper = renderIntoDocument(<HOCComponent dataClass="my-data-class" />);
-      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
+      const wrapper = render(<HOCComponent dataClass="my-data-class" />);
+      expect(wrapper.getDOMNode().getAttribute('data-class')).toBe('my-data-class');
     });
 
     describe('hoisting', () => {
       it('should hoist static methods', () => {
-        expect(HOCComponent.staticMethod).toBeDefined();
         expect(HOCComponent.staticMethod()).toEqual('staticMethod');
       });
 
@@ -114,11 +111,9 @@ describe('createHOC function', () => {
       });
 
       it('should hoist prototype methods from child to HOC and bind them', () => {
-        const wrapper = renderIntoDocument(<HOCComponent id="some_id" />);
-        expect(wrapper.unboundMethod).toBeDefined();
-        expect(wrapper.unboundMethod()).toEqual('unboundMethod');
-        expect(wrapper.boundMethod).toBeDefined();
-        expect(wrapper.boundMethod()).toEqual('some_id');
+        const wrapper = render(<HOCComponent id="some_id" />);
+        expect(wrapper.instance().unboundMethod()).toEqual('unboundMethod');
+        expect(wrapper.instance().boundMethod()).toEqual('some_id');
       });
     });
   });
@@ -127,18 +122,21 @@ describe('createHOC function', () => {
     const HOCComponent = createHOC(StatelessChildComponent);
 
     it('should render the wrapped component', () => {
-      const wrapper = mount(<HOCComponent />);
-      expect(wrapper.containsMatchingElement(<StatelessChildComponent/>)).toBeTruthy();
+      const wrapper = render(<HOCComponent />);
+      // This doesn't work - it is actually an instance of React.StatelessComponent
+      // expect(wrapper.children().instance()).toBeInstanceOf(StatelessChildComponent);
+      expect(wrapper.children().length).toEqual(1);
+      expect(wrapper.children().contains(<StatelessChildComponent/>)).toBeTruthy();
     });
 
     it('should place data-hook on the root of the component', () => {
-      const wrapper = renderIntoDocument(<HOCComponent dataHook="my-data-hook" />);
-      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-hook')).toBe('my-data-hook');
+      const wrapper = render(<HOCComponent dataHook="my-data-hook" />);
+      expect(wrapper.getDOMNode().getAttribute('data-hook')).toBe('my-data-hook');
     });
 
     it('should place data-class on the root of the component', () => {
-      const wrapper = renderIntoDocument(<HOCComponent dataClass="my-data-class" />);
-      expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
+      const wrapper = render(<HOCComponent dataClass="my-data-class" />);
+      expect(wrapper.getDOMNode().getAttribute('data-class')).toBe('my-data-class');
     });
 
     // Nothing to hoist on stateless components

--- a/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
+++ b/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
@@ -64,6 +64,25 @@ describe('createHOC function', () => {
       const wrapper = renderIntoDocument(<HOCComponent dataClass="my-data-class"/>);
       expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
     });
+
+    describe('hoisting', () => {
+      it('should hoist static methods', () => {
+        expect(HOCComponent.staticMethod).toBeDefined();
+        expect(HOCComponent.staticMethod()).toEqual('staticMethod');
+      });
+
+      it('should hoist static variables', () => {
+        expect(HOCComponent.staticVariable).toEqual('staticVariable');
+      });
+
+      it('should hoist prototype methods from child to HOC and bind them', () => {
+        const wrapper = renderIntoDocument(<HOCComponent id="some_id"/>);
+        expect(wrapper.unboundMethod).toBeDefined();
+        expect(wrapper.unboundMethod()).toEqual('unboundMethod');
+        expect(wrapper.boundMethod).toBeDefined();
+        expect(wrapper.boundMethod()).toEqual('some_id');
+      });
+    });
   });
 
   describe('Pure components', () => {
@@ -84,6 +103,24 @@ describe('createHOC function', () => {
       expect(ReactDOM.findDOMNode(wrapper).getAttribute('data-class')).toBe('my-data-class');
     });
 
+    describe('hoisting', () => {
+      it('should hoist static methods', () => {
+        expect(HOCComponent.staticMethod).toBeDefined();
+        expect(HOCComponent.staticMethod()).toEqual('staticMethod');
+      });
+
+      it('should hoist static variables', () => {
+        expect(HOCComponent.staticVariable).toEqual('staticVariable');
+      });
+
+      it('should hoist prototype methods from child to HOC and bind them', () => {
+        const wrapper = renderIntoDocument(<HOCComponent id="some_id" />);
+        expect(wrapper.unboundMethod).toBeDefined();
+        expect(wrapper.unboundMethod()).toEqual('unboundMethod');
+        expect(wrapper.boundMethod).toBeDefined();
+        expect(wrapper.boundMethod()).toEqual('some_id');
+      });
+    });
   });
 
   describe('Stateless components', () => {

--- a/packages/wix-ui-core/src/createHOC/index.tsx
+++ b/packages/wix-ui-core/src/createHOC/index.tsx
@@ -8,7 +8,7 @@ export interface WixComponentProps {
   dataClass?: string;
 }
 
-const isStatelessComponent = Component => true;
+const isStatelessComponent = Component => !(Component.prototype && Component.prototype.render);
 
 export const createHOC = Component => {
   class WixComponent extends React.PureComponent<WixComponentProps> {

--- a/packages/wix-ui-core/src/createHOC/index.tsx
+++ b/packages/wix-ui-core/src/createHOC/index.tsx
@@ -8,7 +8,7 @@ export interface WixComponentProps {
   dataClass?: string;
 }
 
-const isStatelessComponent = Component => !(Component.prototype && Component.prototype.render);
+const isStatelessComponent = Component => true;
 
 export const createHOC = Component => {
   class WixComponent extends React.PureComponent<WixComponentProps> {

--- a/packages/wix-ui-core/src/createHOC/index.tsx
+++ b/packages/wix-ui-core/src/createHOC/index.tsx
@@ -12,6 +12,8 @@ const isStatelessComponent = Component => !(Component.prototype && Component.pro
 
 export const createHOC = Component => {
   class WixComponent extends React.PureComponent<WixComponentProps> {
+    private wrappedComponentRef: React.Component = null;
+
     static propTypes = {
       ...Component.propTypes,
       dataHook: string,
@@ -35,11 +37,11 @@ export const createHOC = Component => {
       // Can't pass refs to stateless components (and also there's nothing to hoist)
       return isStatelessComponent(Component)
         ? (<Component {...this.props}/>)
-        : (<Component ref="wrappedComponent" {...this.props}/>);
+        : (<Component ref={ref => this.wrappedComponentRef = ref} {...this.props}/>);
     }
   }
 
   return isStatelessComponent(Component)
     ? WixComponent
-    : hoistNonReactMethods(WixComponent, Component, {delegateTo: c => c.refs.wrappedComponent, hoistStatics: true});
+    : hoistNonReactMethods(WixComponent, Component, {delegateTo: c => c.wrappedComponentRef, hoistStatics: true});
 };

--- a/packages/wix-ui-jss/package.json
+++ b/packages/wix-ui-jss/package.json
@@ -47,6 +47,7 @@
     "wix-ui-test-utils": "^1.0.0"
   },
   "dependencies": {
+    "hoist-non-react-methods": "^1.1.0",
     "hoist-non-react-statics": "^2.3.1",
     "jss": "^9.3.3",
     "jss-preset-default": "^4.0.1",

--- a/packages/wix-ui-jss/package.json
+++ b/packages/wix-ui-jss/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "hoist-non-react-methods": "^1.1.0",
-    "hoist-non-react-statics": "^2.3.1",
     "jss": "^9.3.3",
     "jss-preset-default": "^4.0.1",
     "lodash.uniqueid": "^4.0.1",

--- a/packages/wix-ui-jss/src/withClasses.tsx
+++ b/packages/wix-ui-jss/src/withClasses.tsx
@@ -3,7 +3,7 @@ import * as uniqueId from 'lodash.uniqueid';
 import {generateClasses, detachStyleSheetFromDom} from './domStyleRenderer';
 import hoistNonReactMethods from 'hoist-non-react-methods';
 
-const isStatelessComponent = Component => !(Component.prototype && Component.prototype.render);
+const isStatelessComponent = Component => true;
 
 export interface ThemedComponentProps {
   theme?: object;

--- a/packages/wix-ui-jss/src/withClasses.tsx
+++ b/packages/wix-ui-jss/src/withClasses.tsx
@@ -16,6 +16,7 @@ export interface HasClasses {
 export function withClasses<P extends {ref?: string}>(CoreComponent: React.ComponentType<P & HasClasses>, styles: Function): React.ComponentClass<P & ThemedComponentProps> {
   class ThemedComponent extends React.PureComponent<ThemedComponentProps & P, HasClasses> {
     private id;
+    private wrappedComponentRef: React.Component = null;
     static displayName = CoreComponent.displayName || 'ThemedComponent';
 
     constructor(props) {
@@ -39,7 +40,7 @@ export function withClasses<P extends {ref?: string}>(CoreComponent: React.Compo
 
       return isStatelessComponent(CoreComponent)
         ? (<CoreComponent {...coreProps} classes={this.state.classes}/>)
-        : (<CoreComponent ref="wrappedComponent" {...coreProps} classes={this.state.classes} />);
+        : (<CoreComponent ref={ref => this.wrappedComponentRef = ref} {...this.props}/>);
     }
   }
 

--- a/packages/wix-ui-jss/src/withClasses.tsx
+++ b/packages/wix-ui-jss/src/withClasses.tsx
@@ -40,7 +40,7 @@ export function withClasses<P extends {ref?: string}>(CoreComponent: React.Compo
 
       return isStatelessComponent(CoreComponent)
         ? (<CoreComponent {...coreProps} classes={this.state.classes}/>)
-        : (<CoreComponent ref={ref => this.wrappedComponentRef = ref} {...this.props}/>);
+        : (<CoreComponent ref={ref => this.wrappedComponentRef = ref} {...coreProps} classes={this.state.classes} />);
     }
   }
 

--- a/packages/wix-ui-jss/src/withClasses.tsx
+++ b/packages/wix-ui-jss/src/withClasses.tsx
@@ -3,7 +3,7 @@ import * as uniqueId from 'lodash.uniqueid';
 import {generateClasses, detachStyleSheetFromDom} from './domStyleRenderer';
 import hoistNonReactMethods from 'hoist-non-react-methods';
 
-const isStatelessComponent = Component => true;
+const isStatelessComponent = Component => !(Component.prototype && Component.prototype.render);
 
 export interface ThemedComponentProps {
   theme?: object;

--- a/packages/wix-ui-jss/src/withClasses.tsx
+++ b/packages/wix-ui-jss/src/withClasses.tsx
@@ -46,5 +46,5 @@ export function withClasses<P extends {ref?: string}>(CoreComponent: React.Compo
 
   return isStatelessComponent(CoreComponent)
     ? ThemedComponent
-    : hoistNonReactMethods(ThemedComponent, CoreComponent, {delegateTo: c => c.refs.wrappedComponent, hoistStatics: true});
+    : hoistNonReactMethods(ThemedComponent, CoreComponent, {delegateTo: c => c.wrappedComponentRef, hoistStatics: true});
 }

--- a/packages/wix-ui-jss/src/withClasses.tsx
+++ b/packages/wix-ui-jss/src/withClasses.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import * as uniqueId from 'lodash.uniqueid';
 import {generateClasses, detachStyleSheetFromDom} from './domStyleRenderer';
-const hoistNonReactStatics = require('hoist-non-react-statics');
+import hoistNonReactMethods from 'hoist-non-react-methods';
+
+const isStatelessComponent = Component => !(Component.prototype && Component.prototype.render);
 
 export interface ThemedComponentProps {
   theme?: object;
@@ -11,7 +13,7 @@ export interface HasClasses {
   classes?: object;
 }
 
-export function withClasses<P>(CoreComponent: React.ComponentType<P & HasClasses>, styles: Function): React.ComponentClass<P & ThemedComponentProps> {
+export function withClasses<P extends {ref?: string}>(CoreComponent: React.ComponentType<P & HasClasses>, styles: Function): React.ComponentClass<P & ThemedComponentProps> {
   class ThemedComponent extends React.PureComponent<ThemedComponentProps & P, HasClasses> {
     private id;
     static displayName = CoreComponent.displayName || 'ThemedComponent';
@@ -35,11 +37,13 @@ export function withClasses<P>(CoreComponent: React.ComponentType<P & HasClasses
     render() {
       let coreProps = Object.assign({}, this.props, {theme: undefined});
 
-      return (
-        <CoreComponent {...coreProps} classes={this.state.classes}/>
-      );
+      return isStatelessComponent(CoreComponent)
+        ? (<CoreComponent {...coreProps} classes={this.state.classes}/>)
+        : (<CoreComponent ref="wrappedComponent" {...coreProps} classes={this.state.classes} />);
     }
   }
 
-  return hoistNonReactStatics(ThemedComponent, CoreComponent, {inner: true});
+  return isStatelessComponent(CoreComponent)
+    ? ThemedComponent
+    : hoistNonReactMethods(ThemedComponent, CoreComponent, {delegateTo: c => c.refs.wrappedComponent, hoistStatics: true});
 }


### PR DESCRIPTION
In wix-ui-core (createHOC) and wix-ui-jss (withClasses)

To expose non-static methods as well.