### PR TITLE
ToggleSwitch - Removing unnecessary z-index from CSS

### DIFF
--- a/packages/wix-ui-core/src/components/StylableToggleSwitch/ToggleSwitch.st.css
+++ b/packages/wix-ui-core/src/components/StylableToggleSwitch/ToggleSwitch.st.css
@@ -20,7 +20,6 @@
 
   position: absolute;
   left: 1px;
-  z-index: 1;
 
   text-align: center;
   align-items: center;

--- a/packages/wix-ui-core/src/components/ToggleSwitch/styles.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/styles.ts
@@ -174,7 +174,6 @@ export const styles = (theme: ToggleSwitchTheme) => {
 
       position: 'absolute',
       left: '1px',
-      zIndex: 1,
 
       textAlign: 'center',
       alignItems: 'center',


### PR DESCRIPTION
`z-index` is not needed in this case, as the knob is located after the track (outer label) in the DOM, and thus will be rendered above it. The reason I'm removing it, is because it might mess the layering in consumer's systems