### PR TITLE
ToggleSwitch - Adding focus and blur methods

### DIFF
--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.driver.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.driver.ts
@@ -25,6 +25,8 @@ export const toggleSwitchDriverFactory = ({element, eventTrigger}) => {
     getInnerLabelStyles: () => window.getComputedStyle(element.querySelector('.innerLabel')),
     /** Returns the computed styles object of the toggle icon component */
     getToggleIconStyles: () => window.getComputedStyle(element.querySelector('.toggleIcon')),
+    /** Returns true if the ToggleSwitch is currently focused */
+    isFocused: () => toggleSwitch === document.activeElement,
 
     /** returns elements innerHtml */
     styles: {

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.driver.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.driver.ts
@@ -1,4 +1,4 @@
-export const toggleSwitchDriverFactory = ({componentInstance, element, eventTrigger}) => {
+export const toggleSwitchDriverFactory = ({element, eventTrigger}) => {
   const toggleSwitch = element.querySelector('input');
 
   return {
@@ -25,12 +25,6 @@ export const toggleSwitchDriverFactory = ({componentInstance, element, eventTrig
     getInnerLabelStyles: () => window.getComputedStyle(element.querySelector('.innerLabel')),
     /** Returns the computed styles object of the toggle icon component */
     getToggleIconStyles: () => window.getComputedStyle(element.querySelector('.toggleIcon')),
-    /** Returns a boolean indicating whether the toggle switch is focused or not */
-    isFocused: () => toggleSwitch === document.activeElement,
-    /** Invokes the focus method on the toggle switch */
-    focus: () => componentInstance.focus(),
-    /** Invokes the blur method on the toggle switch */
-    blur: () => componentInstance.blur(),
 
     /** returns elements innerHtml */
     styles: {

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.driver.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.driver.ts
@@ -1,4 +1,4 @@
-export const toggleSwitchDriverFactory = ({element, eventTrigger}) => {
+export const toggleSwitchDriverFactory = ({componentInstance, element, eventTrigger}) => {
   const toggleSwitch = element.querySelector('input');
 
   return {
@@ -25,6 +25,12 @@ export const toggleSwitchDriverFactory = ({element, eventTrigger}) => {
     getInnerLabelStyles: () => window.getComputedStyle(element.querySelector('.innerLabel')),
     /** Returns the computed styles object of the toggle icon component */
     getToggleIconStyles: () => window.getComputedStyle(element.querySelector('.toggleIcon')),
+    /** Returns a boolean indicating whether the toggle switch is focused or not */
+    isFocused: () => element.querySelector('input') === document.activeElement,
+    /** Invokes the focus method on the toggle switch */
+    focus: () => componentInstance.focus(),
+    /** Invokes the blur method on the toggle switch */
+    blur: () => componentInstance.blur(),
 
     /** returns elements innerHtml */
     styles: {

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.driver.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.driver.ts
@@ -26,7 +26,7 @@ export const toggleSwitchDriverFactory = ({componentInstance, element, eventTrig
     /** Returns the computed styles object of the toggle icon component */
     getToggleIconStyles: () => window.getComputedStyle(element.querySelector('.toggleIcon')),
     /** Returns a boolean indicating whether the toggle switch is focused or not */
-    isFocused: () => element.querySelector('input') === document.activeElement,
+    isFocused: () => toggleSwitch === document.activeElement,
     /** Invokes the focus method on the toggle switch */
     focus: () => componentInstance.focus(),
     /** Invokes the blur method on the toggle switch */

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -7,6 +7,20 @@ import {toggleSwitchTestkitFactory as enzymeToggleSwitchTestkitFactory} from '..
 import {activeViewBox, activePathD, inactiveViewBox, inactivePathD} from './utils';
 import {mount} from 'enzyme';
 
+const getRefExpose = (Child, props, refs) => {
+  return class RefExpose extends React.Component {
+    childRef: HTMLElement;
+
+    componentDidMount() {
+      refs.childRef = this.childRef;
+    }
+
+    render() {
+      return <Child {...props} ref={e => this.childRef = e}/>;
+    }
+  };
+};
+
 describe('ToggleSwitch', () => {
 
   const createDriver = createDriverFactory(toggleSwitchDriverFactory);
@@ -135,19 +149,28 @@ describe('ToggleSwitch', () => {
   });
 
   describe('focus and blur', () => {
+    let refs;
+
+    beforeEach(() => refs = {});
+    afterEach(() => refs = null);
+
     it('should expose a focus() method', () => {
-      const driver = createDriver(<ToggleSwitch onChange={noop}/>);
-      expect(driver.isFocused()).toBe(false);
-      driver.focus();
-      expect(driver.isFocused()).toBe(true);
+      const RefExpose = getRefExpose(ToggleSwitch, {onChange: () => {}}, refs);
+      const wrapper = mount(<RefExpose />);
+      const input = wrapper.find('input').getDOMNode();
+      expect(input).not.toBe(document.activeElement);
+      refs.childRef.focus();
+      expect(input).toBe(document.activeElement);
     });
 
     it('should expose a blur() method', () => {
-      const driver = createDriver(<ToggleSwitch onChange={noop}/>);
-      driver.focus();
-      expect(driver.isFocused()).toBe(true);
-      driver.blur();
-      expect(driver.isFocused()).toBe(false);
+      const RefExpose = getRefExpose(ToggleSwitch, {onChange: () => {}}, refs);
+      const wrapper = mount(<RefExpose />);
+      const input = wrapper.find('input').getDOMNode();
+      refs.childRef.focus();
+      expect(input).toBe(document.activeElement);
+      refs.childRef.blur();
+      expect(input).not.toBe(document.activeElement);
     });
   });
 });

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -7,12 +7,16 @@ import {toggleSwitchTestkitFactory as enzymeToggleSwitchTestkitFactory} from '..
 import {activeViewBox, activePathD, inactiveViewBox, inactivePathD} from './utils';
 import {mount} from 'enzyme';
 
-const getRefExpose = (Child, props, refs) => {
+const getRefExpose = (Child, props) => {
   return class RefExpose extends React.Component {
     childRef: HTMLElement;
 
-    componentDidMount() {
-      refs.childRef = this.childRef;
+    focus() {
+      this.childRef.focus();
+    }
+
+    blur() {
+      this.childRef.blur();
     }
 
     render() {
@@ -149,28 +153,29 @@ describe('ToggleSwitch', () => {
   });
 
   describe('focus and blur', () => {
-    let refs;
+    let driver, wrapper;
 
-    beforeEach(() => refs = {});
-    afterEach(() => refs = null);
+    const focus = () => wrapper.instance().focus();
+    const blur = () => wrapper.instance().blur();
+
+    beforeEach(() => {
+      const RefExpose = getRefExpose(ToggleSwitch, {onChange: () => {}});
+      wrapper = mount(<RefExpose />);
+      const element = wrapper.getDOMNode();
+      driver = toggleSwitchDriverFactory({element, eventTrigger: {}});
+    });
 
     it('should expose a focus() method', () => {
-      const RefExpose = getRefExpose(ToggleSwitch, {onChange: () => {}}, refs);
-      const wrapper = mount(<RefExpose />);
-      const input = wrapper.find('input').getDOMNode();
-      expect(input).not.toBe(document.activeElement);
-      refs.childRef.focus();
-      expect(input).toBe(document.activeElement);
+      expect(driver.isFocused()).toBeFalsy();
+      focus();
+      expect(driver.isFocused()).toBeTruthy();
     });
 
     it('should expose a blur() method', () => {
-      const RefExpose = getRefExpose(ToggleSwitch, {onChange: () => {}}, refs);
-      const wrapper = mount(<RefExpose />);
-      const input = wrapper.find('input').getDOMNode();
-      refs.childRef.focus();
-      expect(input).toBe(document.activeElement);
-      refs.childRef.blur();
-      expect(input).not.toBe(document.activeElement);
+      focus();
+      expect(driver.isFocused()).toBeTruthy();
+      blur();
+      expect(driver.isFocused()).toBeFalsy();
     });
   });
 });

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -133,4 +133,21 @@ describe('ToggleSwitch', () => {
       expect(driver.getToggleIconStyles().color).toBe('black');
     });
   });
+
+  describe('focus and blur', () => {
+    it('should expose a focus() method', () => {
+      const driver = createDriver(<ToggleSwitch onChange={noop}/>);
+      expect(driver.isFocused()).toBe(false);
+      driver.focus();
+      expect(driver.isFocused()).toBe(true);
+    });
+
+    it('should expose a blur() method', () => {
+      const driver = createDriver(<ToggleSwitch onChange={noop}/>);
+      driver.focus();
+      expect(driver.isFocused()).toBe(true);
+      driver.blur();
+      expect(driver.isFocused()).toBe(false);
+    });
+  });
 });

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.spec.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.spec.tsx
@@ -159,7 +159,7 @@ describe('ToggleSwitch', () => {
     const blur = () => wrapper.instance().blur();
 
     beforeEach(() => {
-      const RefExpose = getRefExpose(ToggleSwitch, {onChange: () => {}});
+      const RefExpose = getRefExpose(ToggleSwitch, {onChange: () => null});
       wrapper = mount(<RefExpose />);
       const element = wrapper.getDOMNode();
       driver = toggleSwitchDriverFactory({element, eventTrigger: {}});

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -34,6 +34,7 @@ export interface ToggleSwitchProps {
 class ToggleSwitch extends React.PureComponent<ToggleSwitchProps> {
   static displayName = 'ToggleSwitch';
   id: string = this.props.id || uniqueId('ToggleSwitch');
+  inputRef: HTMLInputElement;
 
   private toggle: HTMLLabelElement;
 
@@ -78,6 +79,14 @@ class ToggleSwitch extends React.PureComponent<ToggleSwitchProps> {
     }
   }
 
+  focus() {
+    this.inputRef.focus();
+  }
+
+  blur() {
+    this.inputRef.blur();
+  }
+
   render() {
     const {checked, disabled, classes, styles, previewState} = this.props;
     const {id} = this;
@@ -90,6 +99,7 @@ class ToggleSwitch extends React.PureComponent<ToggleSwitchProps> {
           checked={checked}
           disabled={disabled}
           onChange={e => this._handleChange(e)}
+          ref={el => this.inputRef = el}
         />
 
         <div className={classes.outerLabel} style={styles.outerLabel} aria-label="Toggle"/>


### PR DESCRIPTION
Adding due to product request. This raises the question whether we need to support onFocus and onBlur events as well.