### PR TITLE
ToggleSwitch - changing input style from display: none to opacity: 0

### DIFF
--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -58,21 +58,6 @@ class ToggleSwitch extends React.PureComponent<ToggleSwitchProps> {
 
   static defaultProps = {checked: false, styles: {}, previewState: ''};
 
-  componentDidMount() {
-    this.toggle.addEventListener('keydown', this._listenToSpace);
-  }
-
-  componentWillUnmount() {
-    this.toggle.removeEventListener('keydown', this._listenToSpace);
-  }
-
-  _listenToSpace = e => {
-    if (e.key === ' ') {
-      e.preventDefault();
-      this._handleChange(e);
-    }
-  }
-
   _handleChange = e => {
     if (!this.props.disabled) {
       this.props.onChange(e);

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -58,6 +58,21 @@ class ToggleSwitch extends React.PureComponent<ToggleSwitchProps> {
 
   static defaultProps = {checked: false, styles: {}, previewState: ''};
 
+  componentDidMount() {
+    this.toggle.addEventListener('keydown', this._listenToSpace);
+  }
+
+  componentWillUnmount() {
+    this.toggle.removeEventListener('keydown', this._listenToSpace);
+  }
+
+  _listenToSpace = e => {
+    if (e.key === ' ') {
+      e.preventDefault();
+      this._handleChange(e);
+    }
+  }
+
   _handleChange = e => {
     if (!this.props.disabled) {
       this.props.onChange(e);

--- a/packages/wix-ui-core/src/components/ToggleSwitch/styles.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/styles.ts
@@ -32,7 +32,10 @@ export const styles = (theme: ToggleSwitchTheme) => {
       outline: 'none',
 
       '& > input[type=checkbox]': {
-        display: 'none'
+        width: 0,
+        height: 0,
+        opacity: 0,
+        margin: 0
       },
 
       [selectors.state('checked')]: {


### PR DESCRIPTION
this way, the element is actually in the DOM, thus native focus behavior is supported.