### PR TITLE
<Checkbox /> - fix driver

### DIFF
--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
@@ -24,6 +24,8 @@ export const checkboxDriverFactory = ({element, eventTrigger}) => {
     getType: () => element.getAttribute('type'),
     /** checks if the tickmark exists, i.e. the checkbox is checked */
     isChecked: () => hasStyleState(element, 'checked'),
+    /** returns true if the element has indeterminate state */
+    isIndeterminate: () => hasStyleState(element, 'indeterminate'),
     /** returns elements textContent */
     getTextContent: () => element.textContent,
     /** returns the checkbox children */
@@ -36,25 +38,11 @@ export const checkboxDriverFactory = ({element, eventTrigger}) => {
     isDisabled: () => element.getAttribute('disabled') === '',
     /** returns true if the element has error state */
     hasErrorState: () => hasStyleState(element, 'error'),
-    /** returns true if the element has indeterminate state */
-    hasIndeterminateState: () => hasStyleState(element, 'indeterminate'),
     /** returns true if the element has focus state */
     hasFocusState: () => hasStyleState(element, 'focus'),
     /** returns true if the element has disabled state */
     hasDisabledState: () => hasStyleState(element, 'disabled'),
     /** returns true if the element has error state */
     hasReadOnlyState: () => hasStyleState(element, 'readonly'),
-    styles: {
-      /** returns elements min-width css property */
-      getMinWidth: () => getCheckboxStyle().minWidth,
-      /** returns elements width css property */
-      getWidth: () => getCheckboxStyle().width,
-      /** returns elements height css property */
-      getHeight: () => getCheckboxStyle().height,
-      /** returns elements padding css property */
-      getPadding: () => getCheckboxStyle().padding,
-      /** returns elements border-radius css property */
-      getBorderRadius: () => getCheckboxStyle().borderRadius,
-    }
   };
 };

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
@@ -1,12 +1,8 @@
 import {StylableDOMUtil} from 'stylable/test-utils';
 import styles from './Checkbox.st.css';
-import {BaseDriver} from 'wix-ui-test-utils';
 
 const utils = new StylableDOMUtil(styles);
 const hasStyleState = (element, state) => utils.hasStyleState(element, state);
-
-interface CheckboxDriver extends BaseDriver {
-}
 
 export const checkboxDriverFactory = ({element, eventTrigger}) => {
   const getCheckboxStyle = () => window.getComputedStyle(element);

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
@@ -1,8 +1,12 @@
 import {StylableDOMUtil} from 'stylable/test-utils';
 import styles from './Checkbox.st.css';
+import {BaseDriver} from 'wix-ui-test-utils';
 
 const utils = new StylableDOMUtil(styles);
 const hasStyleState = (element, state) => utils.hasStyleState(element, state);
+
+interface CheckboxDriver extends BaseDriver {
+}
 
 export const checkboxDriverFactory = ({element, eventTrigger}) => {
   const getCheckboxStyle = () => window.getComputedStyle(element);
@@ -23,17 +27,13 @@ export const checkboxDriverFactory = ({element, eventTrigger}) => {
     /** returns elements type attribute */
     getType: () => element.getAttribute('type'),
     /** checks if the tickmark exists, i.e. the checkbox is checked */
-    isChecked: () => !!element.querySelector('[data-hook="CHECKBOX_TICKMARK"]'),
+    isChecked: () => hasStyleState(element, 'checked'),
     /** returns elements textContent */
     getTextContent: () => element.textContent,
     /** returns the checkbox children */
     children: () => element.querySelectorAll('[data-hook="CHECKBOX_CHILD_CONTAINER"]'),
     /** returns the checkbox tickmark */
-    tickmark: () => element.querySelector('[data-hook="CHECKBOX_TICKMARK"]'),
-    /** returns the indeterminate icon */
-    indeterminateMark: () => element.querySelector('[data-hook="CHECKBOX_INDETERMINATE"]'),
-    /** returns a boolean indicating whether the checkbox is in indeterminate state */
-    isIndeterminate: () => !!element.querySelector('[data-hook="CHECKBOX_INDETERMINATE"]'),
+    tickmark: () => element.querySelector('[data-hook="CHECKBOX_BOX"]').firstChild,
     /** returns the checkbox native input */
     input: () => element.querySelector('[data-hook="NATIVE_CHECKBOX"]'),
     /** returns if the element is disabled */

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
@@ -26,6 +26,8 @@ export const checkboxDriverFactory = ({element, eventTrigger}) => {
     isChecked: () => hasStyleState(element, 'checked'),
     /** returns true if the element has indeterminate state */
     isIndeterminate: () => hasStyleState(element, 'indeterminate'),
+    /** returns if the element is disabled */
+    isDisabled: () => hasStyleState(element, 'disabled'),
     /** returns elements textContent */
     getTextContent: () => element.textContent,
     /** returns the checkbox children */
@@ -34,14 +36,10 @@ export const checkboxDriverFactory = ({element, eventTrigger}) => {
     tickmark: () => element.querySelector('[data-hook="CHECKBOX_BOX"]').firstChild,
     /** returns the checkbox native input */
     input: () => element.querySelector('[data-hook="NATIVE_CHECKBOX"]'),
-    /** returns if the element is disabled */
-    isDisabled: () => element.getAttribute('disabled') === '',
     /** returns true if the element has error state */
     hasErrorState: () => hasStyleState(element, 'error'),
     /** returns true if the element has focus state */
     hasFocusState: () => hasStyleState(element, 'focus'),
-    /** returns true if the element has disabled state */
-    hasDisabledState: () => hasStyleState(element, 'disabled'),
     /** returns true if the element has error state */
     hasReadOnlyState: () => hasStyleState(element, 'readonly'),
   };

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
@@ -20,16 +20,12 @@ export const checkboxDriverFactory = ({element, eventTrigger}) => {
     mouseLeave: () => eventTrigger.mouseLeave(element),
     /** trigger focus on the element */
     focus: () => eventTrigger.focus(element.querySelector('[data-hook="NATIVE_CHECKBOX"]')),
-    /** returns elements type attribute */
-    getType: () => element.getAttribute('type'),
     /** checks if the tickmark exists, i.e. the checkbox is checked */
     isChecked: () => hasStyleState(element, 'checked'),
     /** returns true if the element has indeterminate state */
     isIndeterminate: () => hasStyleState(element, 'indeterminate'),
     /** returns if the element is disabled */
     isDisabled: () => hasStyleState(element, 'disabled'),
-    /** returns elements textContent */
-    getTextContent: () => element.textContent,
     /** returns the checkbox children */
     children: () => element.querySelectorAll('[data-hook="CHECKBOX_CHILD_CONTAINER"]'),
     /** returns the checkbox tickmark */

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
@@ -27,9 +27,9 @@ export const checkboxDriverFactory = ({element, eventTrigger}) => {
     /** returns the checkbox children */
     children: () => utils.select('.childContainer'),
     /** returns the checkbox tickmark */
-    tickmark: () => utils.select('.box').firstChild,
+    tickmark: () => utils.select('.box').firstElementChild,
     /** returns the checkbox native input */
-    input: () => utils.select('.nativeCheckbox'),
+    input: () => utils.select('.nativeCheckbox') as HTMLInputElement,
     /** returns true if the element has error state */
     hasErrorState: () => hasStyleState('error'),
     /** returns true if the element has focus state */

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.driver.ts
@@ -1,11 +1,9 @@
 import {StylableDOMUtil} from 'stylable/test-utils';
 import styles from './Checkbox.st.css';
 
-const utils = new StylableDOMUtil(styles);
-const hasStyleState = (element, state) => utils.hasStyleState(element, state);
-
 export const checkboxDriverFactory = ({element, eventTrigger}) => {
-  const getCheckboxStyle = () => window.getComputedStyle(element);
+  const utils = new StylableDOMUtil(styles, element);
+  const hasStyleState = (state) => utils.hasStyleState(element, state);
 
   return {
     /** returns the element */
@@ -19,24 +17,24 @@ export const checkboxDriverFactory = ({element, eventTrigger}) => {
     /** trigger mouseleave on the element */
     mouseLeave: () => eventTrigger.mouseLeave(element),
     /** trigger focus on the element */
-    focus: () => eventTrigger.focus(element.querySelector('[data-hook="NATIVE_CHECKBOX"]')),
+    focus: () => eventTrigger.focus(utils.select('.nativeCheckbox')),
     /** checks if the tickmark exists, i.e. the checkbox is checked */
-    isChecked: () => hasStyleState(element, 'checked'),
+    isChecked: () => hasStyleState('checked'),
     /** returns true if the element has indeterminate state */
-    isIndeterminate: () => hasStyleState(element, 'indeterminate'),
+    isIndeterminate: () => hasStyleState('indeterminate'),
     /** returns if the element is disabled */
-    isDisabled: () => hasStyleState(element, 'disabled'),
+    isDisabled: () => hasStyleState('disabled'),
     /** returns the checkbox children */
-    children: () => element.querySelectorAll('[data-hook="CHECKBOX_CHILD_CONTAINER"]'),
+    children: () => utils.select('.childContainer'),
     /** returns the checkbox tickmark */
-    tickmark: () => element.querySelector('[data-hook="CHECKBOX_BOX"]').firstChild,
+    tickmark: () => utils.select('.box').firstChild,
     /** returns the checkbox native input */
-    input: () => element.querySelector('[data-hook="NATIVE_CHECKBOX"]'),
+    input: () => utils.select('.nativeCheckbox'),
     /** returns true if the element has error state */
-    hasErrorState: () => hasStyleState(element, 'error'),
+    hasErrorState: () => hasStyleState('error'),
     /** returns true if the element has focus state */
-    hasFocusState: () => hasStyleState(element, 'focus'),
+    hasFocusState: () => hasStyleState('focus'),
     /** returns true if the element has error state */
-    hasReadOnlyState: () => hasStyleState(element, 'readonly'),
+    hasReadOnlyState: () => hasStyleState('readonly'),
   };
 };

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
@@ -294,7 +294,6 @@ describe('Checkbox', () => {
 
       expect(checkbox.exists()).toBe(true);
       expect(checkbox.isIndeterminate()).toBe(true);
-      expect(checkbox.isChecked()).toBe(false);
     });
 
     it('renders indeterminate icon when value is false', async () => {

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
@@ -27,7 +27,7 @@ describe('Checkbox', () => {
       </Checkbox>
     );
 
-    expect(checkbox.children()[0].textContent).toContain('covfefe');
+    expect(checkbox.children().textContent).toContain('covfefe');
   });
 
   it('Displays custom tick mark when value is true', async () => {

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
@@ -6,25 +6,7 @@ import {Checkbox} from './Checkbox';
 import {StylableDOMUtil} from 'stylable/test-utils';
 
 const tickSVG: React.ReactNode = (
-  <svg
-    data-hook="CHECKBOX_TICKMARK"
-    data-name="custom-tickmark"
-    height="1em"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path stroke="black" strokeLinecap="square" strokeWidth="1.5" d="M5 8.685l2.496 1.664M8 10.685L11.748 6" />
-  </svg>
-);
-
-const IndeterminateSVG: React.ReactNode = (
-  <svg
-    data-hook="CHECKBOX_INDETERMINATE"
-    data-name="custom-indeterminate"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path d="M5 0h8v2H0z" />
-  </svg>
+  <span data-name="custom-tickmark">1</span>
 );
 
 describe('Checkbox', () => {
@@ -245,7 +227,7 @@ describe('Checkbox', () => {
         />
       );
 
-      expect(checkbox.isIndeterminate()).toBe(true);
+      expect(checkbox.hasIndeterminateState()).toBe(true);
     });
 
     it('gets disabled style state', async () => {
@@ -311,7 +293,7 @@ describe('Checkbox', () => {
       );
 
       expect(checkbox.exists()).toBe(true);
-      expect(checkbox.isIndeterminate()).toBe(true);
+      expect(checkbox.hasIndeterminateState()).toBe(true);
       expect(checkbox.isChecked()).toBe(false);
     });
 
@@ -324,7 +306,7 @@ describe('Checkbox', () => {
       );
 
       expect(checkbox.exists()).toBe(true);
-      expect(checkbox.isIndeterminate()).toBe(true);
+      expect(checkbox.hasIndeterminateState()).toBe(true);
     });
 
     it('click calls onChange with value true', async () => {
@@ -350,12 +332,12 @@ describe('Checkbox', () => {
       const checkbox = createDriver(
         <Checkbox
           indeterminate
-          indeterminateIcon={IndeterminateSVG}
+          indeterminateIcon={tickSVG}
         />
       );
 
-      expect(checkbox.isIndeterminate()).toBe(true);
-      expect(checkbox.indeterminateMark().getAttribute('data-name')).toBe('custom-indeterminate');
+      expect(checkbox.hasIndeterminateState()).toBe(true);
+      expect(checkbox.tickmark().getAttribute('data-name')).toBe('custom-tickmark');
     });
 
     it('does not call onChange when disabled', async () => {

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
@@ -233,7 +233,7 @@ describe('Checkbox', () => {
     it('gets disabled style state', async () => {
       const checkbox = createDriver(<Checkbox disabled />);
 
-      expect(checkbox.hasDisabledState()).toBe(true);
+      expect(checkbox.isDisabled()).toBe(true);
     });
   });
 

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.spec.tsx
@@ -227,7 +227,7 @@ describe('Checkbox', () => {
         />
       );
 
-      expect(checkbox.hasIndeterminateState()).toBe(true);
+      expect(checkbox.isIndeterminate()).toBe(true);
     });
 
     it('gets disabled style state', async () => {
@@ -293,7 +293,7 @@ describe('Checkbox', () => {
       );
 
       expect(checkbox.exists()).toBe(true);
-      expect(checkbox.hasIndeterminateState()).toBe(true);
+      expect(checkbox.isIndeterminate()).toBe(true);
       expect(checkbox.isChecked()).toBe(false);
     });
 
@@ -306,7 +306,7 @@ describe('Checkbox', () => {
       );
 
       expect(checkbox.exists()).toBe(true);
-      expect(checkbox.hasIndeterminateState()).toBe(true);
+      expect(checkbox.isIndeterminate()).toBe(true);
     });
 
     it('click calls onChange with value true', async () => {
@@ -336,7 +336,7 @@ describe('Checkbox', () => {
         />
       );
 
-      expect(checkbox.hasIndeterminateState()).toBe(true);
+      expect(checkbox.isIndeterminate()).toBe(true);
       expect(checkbox.tickmark().getAttribute('data-name')).toBe('custom-tickmark');
     });
 
@@ -363,7 +363,7 @@ describe('Checkbox', () => {
     it('gets indeterminate style state', async () => {
       const checkbox = createDriver(<Checkbox indeterminate />);
 
-      expect(checkbox.hasIndeterminateState()).toBe(true);
+      expect(checkbox.isIndeterminate()).toBe(true);
     });
   });
 });

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.tsx
@@ -153,7 +153,6 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
         aria-checked={this.props.indeterminate ? 'mixed' : this.props.checked}
       >
           <input
-            data-hook="NATIVE_CHECKBOX"
             type="checkbox"
             className={style.nativeCheckbox}
             checked={this.props.checked}
@@ -171,19 +170,13 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
             required={required}
           />
 
-          <span
-            className={style.box}
-            data-hook="CHECKBOX_BOX"
-          >
+          <span className={style.box}>
             {this.props.indeterminate ?
               this.props.indeterminateIcon : (this.props.checked && this.props.tickIcon)}
           </span>
 
           {this.props.children ? (
-            <div
-              data-hook="CHECKBOX_CHILD_CONTAINER"
-              className={style.childContainer}
-            >
+            <div className={style.childContainer}>
               {this.props.children}
             </div>
           ) : null

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.tsx
@@ -146,7 +146,7 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
     const focus = this.state.isFocused;
 
     return (
-      <div {...style('root', {checked: indeterminate ? false : checked, disabled, focus, readonly, error, indeterminate}, this.props) }
+      <div {...style('root', {checked, disabled, focus, readonly, error, indeterminate}, this.props) }
         onClick={this.handleClick}
         onKeyDown={this.handleKeydown}
         role="checkbox"

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.tsx
@@ -146,7 +146,7 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
     const focus = this.state.isFocused;
 
     return (
-      <div {...style('root', {checked, disabled, focus, readonly, error, indeterminate}, this.props) }
+      <div {...style('root', {checked: indeterminate ? false : checked, disabled, focus, readonly, error, indeterminate}, this.props) }
         onClick={this.handleClick}
         onKeyDown={this.handleKeydown}
         role="checkbox"


### PR DESCRIPTION
Checked / indeterminate in the driver only work if you use the default tick marks or if you pass a certain data-hook, which causes some problems in wix-ui-backoffice.
I changed them to check for stylable states instead, so they will be less development dependant.

Also, I replaced an overly complex test svg with a span for readability.