### PR TITLE
add className to base class

### DIFF
--- a/packages/wix-ui-core/src/utils/withStylable/withStylable.tsx
+++ b/packages/wix-ui-core/src/utils/withStylable/withStylable.tsx
@@ -59,9 +59,11 @@ export function withStylable<CoreProps, ExtendedProps = {}>(
   stylesheet: RuntimeStylesheet,
   getState: (p?: any, s?: any, c?: any) => StateMap,
   extendedDefaultProps: object = {}): React.ComponentClass<CoreProps & ExtendedProps> | React.SFC<CoreProps & ExtendedProps> {
+    type BaseProps = CoreProps & {className?: string};
+
     if (isReactClassComponent(Component)) {
-      return withStylableStateful<CoreProps & {className?: string}, ExtendedProps>(Component as React.ComponentClass<CoreProps>, stylesheet, getState, extendedDefaultProps);
+      return withStylableStateful<BaseProps, ExtendedProps>(Component as React.ComponentClass<BaseProps>, stylesheet, getState, extendedDefaultProps);
     } else {
-      return withStylableStateless<CoreProps & {className?: string}, ExtendedProps>(Component as React.SFC<CoreProps>, stylesheet, getState, extendedDefaultProps);
+      return withStylableStateless<BaseProps, ExtendedProps>(Component as React.SFC<BaseProps>, stylesheet, getState, extendedDefaultProps);
     }
 }

--- a/packages/wix-ui-core/src/utils/withStylable/withStylable.tsx
+++ b/packages/wix-ui-core/src/utils/withStylable/withStylable.tsx
@@ -60,8 +60,8 @@ export function withStylable<CoreProps, ExtendedProps = {}>(
   getState: (p?: any, s?: any, c?: any) => StateMap,
   extendedDefaultProps: object = {}): React.ComponentClass<CoreProps & ExtendedProps> | React.SFC<CoreProps & ExtendedProps> {
     if (isReactClassComponent(Component)) {
-      return withStylableStateful<CoreProps, ExtendedProps>(Component as React.ComponentClass<CoreProps>, stylesheet, getState, extendedDefaultProps);
+      return withStylableStateful<CoreProps & {className?: string}, ExtendedProps>(Component as React.ComponentClass<CoreProps>, stylesheet, getState, extendedDefaultProps);
     } else {
-      return withStylableStateless<CoreProps, ExtendedProps>(Component as React.SFC<CoreProps>, stylesheet, getState, extendedDefaultProps);
+      return withStylableStateless<CoreProps & {className?: string}, ExtendedProps>(Component as React.SFC<CoreProps>, stylesheet, getState, extendedDefaultProps);
     }
 }


### PR DESCRIPTION
@amiryonatan @shlomitc this is something worth discussing.

In the core we would like to allow the users (like the backoffice) to pass className to the component.

The thing is that we don't want the backoffice components to support className, to prevent future hacks.

I bumped into a scenario where I render bo component inside bo component, and wanted to place className on the inner one.

I am not sure what should our approach be