### PR TITLE
change badge style

### DIFF
--- a/packages/wix-ui-core/src/components/StylableBadge/BadgeStyle.st.css
+++ b/packages/wix-ui-core/src/components/StylableBadge/BadgeStyle.st.css
@@ -10,6 +10,7 @@
     borderRadius: 2px;
     backgroundColor: grey;
     borderColor: grey;
+    color: white;
 }
 
 .root {
@@ -20,6 +21,7 @@
     border: value(border);
     border-radius: value(borderRadius);
     border-color: value(borderColor);
+    color: value(color);
     
     background: value(backgroundColor);
     

--- a/packages/wix-ui-core/src/components/StylableBadge/BadgeStyle.st.css
+++ b/packages/wix-ui-core/src/components/StylableBadge/BadgeStyle.st.css
@@ -23,10 +23,9 @@
     
     background: value(backgroundColor);
     
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     box-sizing: border-box;
 
     line-height: 1;
-    text-align: center;
-    vertical-align: middle;
 }


### PR DESCRIPTION
Placing text beside icons showed me that this needs to be changed.

Before:
![image](https://user-images.githubusercontent.com/18248989/36759418-f5fc8530-1c1f-11e8-854b-c1577a890a79.png)

After:
![image](https://user-images.githubusercontent.com/18248989/36759437-0f3b1386-1c20-11e8-8982-c443e9ba06bc.png)
