### PR TITLE
Accept array for src in Video component

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -37,7 +37,7 @@
     "lodash.isundefined": "^3.0.0",
     "lodash.times": "^4.0.0",
     "lodash.uniqueid": "^4.0.0",
-    "playable": "^1.2.0",
+    "playable": "^1.5.0",
     "react-onclickoutside": "^6.7.0",
     "react-popper": "^0.8.0",
     "react-transition-group": "^2.2.1",

--- a/packages/wix-ui-core/src/components/Video/Video.spec.tsx
+++ b/packages/wix-ui-core/src/components/Video/Video.spec.tsx
@@ -14,6 +14,11 @@ describe('Video', () => {
         expect(driver.getSrc()).toBe('https://example.com/video.mp4');
       });
 
+      it('should set array for src', () => {
+        const driver = createDriver(<Video src={['https://example.com/video.mp4']}/>);
+        expect(driver.getSrc()).toEqual(['https://example.com/video.mp4']);
+      });
+
       it('should update value', () => {
         const driver = createDriver(<Video src="https://example.com/video.mp4"/>);
         expect(driver.getSrc()).toBe('https://example.com/video.mp4');

--- a/packages/wix-ui-core/src/components/Video/Video.tsx
+++ b/packages/wix-ui-core/src/components/Video/Video.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import {string, number, func, bool, Requireable} from 'prop-types';
+import {string, number, func, bool, array, oneOfType, Requireable} from 'prop-types';
 import {create, VIDEO_EVENTS, ENGINE_STATES} from 'playable';
 
 export interface VideoProps {
-  src?: string;
+  src?: string | Array<string>;
   width?: number;
   height?: number;
   title?: string;
@@ -51,7 +51,10 @@ export class Video extends React.PureComponent<VideoProps, VideoState> {
 
   static propTypes = {
     /** A string or array with source of the video. For more information see this [page](https://wix.github.io/playable/video-source) */
-    src: string,
+    src: oneOfType([
+      string,
+      array,
+    ]),
     /** Width of video player */
     width: number,
     /** Height of video player */


### PR DESCRIPTION
`src` attribute can accept `string` or array.