### PR TITLE
chore(AutoExampleDriver): clear focus by clickin `body` when calling `reset`

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
+++ b/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
@@ -46,6 +46,8 @@ module.exports = {
 
     return browser.executeScript(script, props);
   },
-  reset: () =>
-    browser.executeScript('window.autoexample.resetState()')
+  reset: () => {
+    browser.$('body').click();
+    return browser.executeScript('window.autoexample.resetState()');
+  }
 };


### PR DESCRIPTION
closes #297