### PR TITLE
[WIP !] -Add withExamples story url param

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/wix/wix-ui#readme",
   "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.js",
   "scripts": {
     "pretest": "npm run build && build-storybook",
     "test": "haste test --jest",

--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -55,6 +55,7 @@
     "import-path": "latest",
     "jsx-to-string": "git+https://github.com/amiryonatan/jsx-to-string.git#release_branch",
     "loader-utils": "^1.1.0",
+    "query-string": "^5.1.0",
     "react-autodocs-utils": "^2.0.1",
     "react-collapse": "^4.0.3",
     "react-docgen": "^2.20.0",
@@ -66,6 +67,7 @@
   "devDependencies": {
     "@storybook/addon-options": "^3.2.16",
     "@storybook/react": "^3.2.16",
+    "@types/query-string": "^5.1.0",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-15": "^1.0.5",
     "eslint-config-wix": "latest",

--- a/packages/wix-storybook-utils/src/StoryNew/index.js
+++ b/packages/wix-storybook-utils/src/StoryNew/index.js
@@ -6,12 +6,9 @@ import Markdown from '../Markdown';
 import CodeBlock from '../CodeBlock';
 import AutoExample from '../AutoExample';
 import AutoDocs from '../AutoDocs';
-import * as queryString from 'query-string';
 import styles from '../Story/styles.scss';
-
+import {isStoryUrlWithExamples} from '../storyUtils';
 const isE2E = global.self === global.top;
-
-export const IS_EXAMPLES_VISIBLE_PARAM_NAME = 'withExamples';
 
 export default ({
   category,
@@ -35,7 +32,7 @@ export default ({
             parsedSource={_metadata}
             />
 
-          {queryString.parse(window.location.search)[IS_EXAMPLES_VISIBLE_PARAM_NAME] !== undefined && examples}
+          {isStoryUrlWithExamples(window.location.search) && examples}
         </div>
       );
     }

--- a/packages/wix-storybook-utils/src/StoryNew/index.js
+++ b/packages/wix-storybook-utils/src/StoryNew/index.js
@@ -6,10 +6,12 @@ import Markdown from '../Markdown';
 import CodeBlock from '../CodeBlock';
 import AutoExample from '../AutoExample';
 import AutoDocs from '../AutoDocs';
-
+import * as queryString from 'query-string';
 import styles from '../Story/styles.scss';
 
 const isE2E = global.self === global.top;
+
+export const IS_EXAMPLES_VISIBLE_PARAM_NAME = 'withExamples';
 
 export default ({
   category,
@@ -33,7 +35,7 @@ export default ({
             parsedSource={_metadata}
             />
 
-          {examples}
+          {queryString.parse(window.location.search)[IS_EXAMPLES_VISIBLE_PARAM_NAME] !== undefined && examples}
         </div>
       );
     }

--- a/packages/wix-storybook-utils/src/index.d.ts
+++ b/packages/wix-storybook-utils/src/index.d.ts
@@ -1,0 +1,7 @@
+export interface StoryUrlParams {
+    kind: string;
+    story: string;
+    withExamples?: boolean;
+}
+
+export function createStoryUrl(params: StoryUrlParams): string;

--- a/packages/wix-storybook-utils/src/index.js
+++ b/packages/wix-storybook-utils/src/index.js
@@ -1,0 +1,1 @@
+export {createStoryUrl} from './storyUtils';

--- a/packages/wix-storybook-utils/src/storyUtils.js
+++ b/packages/wix-storybook-utils/src/storyUtils.js
@@ -1,0 +1,19 @@
+import * as queryString from 'query-string';
+
+const WITH_EXAMPLES_PARAM_NAME = 'withExamples';
+
+/**
+ *
+ * @param {StoryUrlParams} params withExamples defaults to true
+ */
+export function createStoryUrl({kind, story, withExamples = true}) {
+  return `iframe.html?selectedKind=${encodeURIComponent(kind)}&selectedStory=${encodeURIComponent(story)}${withExamples ? `&${WITH_EXAMPLES_PARAM_NAME}=` : ''}`;
+}
+
+/**
+ * @param {string} urlSearchPart usually the return of `window.location.search`
+ */
+export function isStoryUrlWithExamples(urlSearchPart) {
+  return queryString.parse(urlSearchPart)[WITH_EXAMPLES_PARAM_NAME] !== undefined;
+}
+

--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -76,5 +76,8 @@
   },
   "haste": {
     "preset": "yoshi"
+  },
+  "dependencies": {
+    "wix-storybook-utils": "^1.0.46"
   }
 }

--- a/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
@@ -8,11 +8,31 @@ import {
 
 const encode = global.encodeURIComponent;
 
-export const getStoryUrl = (
-  kind: string,
-  story: string
-): string =>
-  `iframe.html?selectedKind=${encode(kind)}&selectedStory=${encode(story)}`;
+// TODO: import from `wix-storybook-utils` or move getStoryUrl() to
+// `wix-storybook-utils` and import/export it here.
+const  WITH_EXAMPLES_PARAM_NAME = 'withExamples';
+
+export interface StoryUrlParams {
+  kind: string;
+  story: string;
+  withExamples?: boolean;
+}
+
+/**
+ * @deprecated
+ * @see createStoryUrl
+ */
+export const getStoryUrl = (kind: string, story: string): string =>
+  createStoryUrl({kind, story});
+
+/**
+ *
+ * @param {StoryUrlParams} params withExamples defaults to true
+ */
+export const createStoryUrl = (params: StoryUrlParams): string => {
+  const {kind, story, withExamples = true} = params;
+  return `iframe.html?selectedKind=${encode(kind)}&selectedStory=${encode(story)}${withExamples ? `&${WITH_EXAMPLES_PARAM_NAME}=` : ''}`;
+};
 
 export const scrollToElement = (element: ElementArrayFinder) =>
   browser.executeScript(

--- a/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
@@ -29,8 +29,7 @@ export const getStoryUrl = (kind: string, story: string): string =>
  *
  * @param {StoryUrlParams} params withExamples defaults to true
  */
-export const createStoryUrl = (params: StoryUrlParams): string => {
-  const {kind, story, withExamples = true} = params;
+export const createStoryUrl = ({kind, story, withExamples = true}: StoryUrlParams): string => {
   return `iframe.html?selectedKind=${encode(kind)}&selectedStory=${encode(story)}${withExamples ? `&${WITH_EXAMPLES_PARAM_NAME}=` : ''}`;
 };
 

--- a/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
@@ -5,18 +5,8 @@ import {
   ElementFinder,
   ElementArrayFinder
 } from 'protractor';
-
+import {createStoryUrl} from 'wix-storybook-utils';
 const encode = global.encodeURIComponent;
-
-// TODO: import from `wix-storybook-utils` or move getStoryUrl() to
-// `wix-storybook-utils` and import/export it here.
-const  WITH_EXAMPLES_PARAM_NAME = 'withExamples';
-
-export interface StoryUrlParams {
-  kind: string;
-  story: string;
-  withExamples?: boolean;
-}
 
 /**
  * @deprecated
@@ -24,14 +14,6 @@ export interface StoryUrlParams {
  */
 export const getStoryUrl = (kind: string, story: string): string =>
   createStoryUrl({kind, story});
-
-/**
- *
- * @param {StoryUrlParams} params withExamples defaults to true
- */
-export const createStoryUrl = ({kind, story, withExamples = true}: StoryUrlParams): string => {
-  return `iframe.html?selectedKind=${encode(kind)}&selectedStory=${encode(story)}${withExamples ? `&${WITH_EXAMPLES_PARAM_NAME}=` : ''}`;
-};
 
 export const scrollToElement = (element: ElementArrayFinder) =>
   browser.executeScript(

--- a/packages/wix-ui-test-utils/test/protractor-helpers.spec.ts
+++ b/packages/wix-ui-test-utils/test/protractor-helpers.spec.ts
@@ -1,0 +1,31 @@
+import {getStoryUrl, createStoryUrl} from '../src/protractor/protractor-helpers';
+
+describe('protractor-helpers', () => {
+
+  describe('getStoryUrl', () => {
+    const kind = '3. Inputs';
+    const story = '3.2 + InputArea';
+
+    const EXPECTED_URL_BASE = 'iframe.html?selectedKind=3.%20Inputs&selectedStory=3.2%20%2B%20InputArea';
+
+    it('Should create story url using deprecated version', () => {
+      expect(getStoryUrl(kind, story))
+      .toEqual(`${EXPECTED_URL_BASE}&withExamples=`);
+    });
+
+    it('Should create story url with options', () => {
+      expect(createStoryUrl({kind, story}))
+      .toEqual(`${EXPECTED_URL_BASE}&withExamples=`);
+    });
+
+    it('Should create story url without examples', () => {
+      expect(createStoryUrl({kind, story, withExamples: false}))
+      .toEqual(`${EXPECTED_URL_BASE}`);
+    });
+
+    it('Should create story url with examples', () => {
+      expect(createStoryUrl({kind, story, withExamples: true}))
+      .toEqual(`${EXPECTED_URL_BASE}&withExamples=`);
+    });
+  });
+});

--- a/packages/wix-ui-test-utils/test/protractor-helpers.spec.ts
+++ b/packages/wix-ui-test-utils/test/protractor-helpers.spec.ts
@@ -20,7 +20,7 @@ describe('protractor-helpers', () => {
 
     it('Should create story url without examples', () => {
       expect(createStoryUrl({kind, story, withExamples: false}))
-      .toEqual(`${EXPECTED_URL_BASE}`);
+      .toEqual(EXPECTED_URL_BASE);
     });
 
     it('Should create story url with examples', () => {


### PR DESCRIPTION
It is helpful for e2e tests, that the e2e story will not include examples, so that we can test an isolated <AutoExample> component.
For example when testing focus behavior, the examples may interfeer if they have autoFocus, and make the test implementation more complicated.

- Added url param `withExamples` to control the rendering of the exmaples.
- in `wix-ui-test-utils`
  -  make `withExamples` default to `true.
  - add `createStoryUrl()` which accepts a params object (deprecate the usage of the multiple arguments `getStoryUrl()`)