### PR TITLE
wix-storybook-utils: AutoExampleDriver.reset() - Remove click on body

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
+++ b/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
@@ -51,7 +51,6 @@ module.exports = {
     return browser.executeScript(script, props);
   },
   reset: () => {
-    browser.$('body').click();
     return browser.executeScript('window.autoexample.resetState()');
   }
 };


### PR DESCRIPTION
For some reason, in more than 1 case, I encountered, that clicking on the body, actually make the tested component focused.

Remove this, until further investigation. 