### PR TITLE
wix-ui-test-utils: adding mouseEnter and mouseLeave to protractor-helpers

### DIFF
--- a/packages/wix-ui-core/src/baseComponents/Popover/Popover.protractor.driver.ts
+++ b/packages/wix-ui-core/src/baseComponents/Popover/Popover.protractor.driver.ts
@@ -1,9 +1,9 @@
 import {browser} from 'protractor';
+import {mouseEnter, mouseLeave} from 'wix-ui-test-utils/protractor';
 
 export const popoverDriverFactory = component => {
   const getTargetElement = () => component.$('[data-hook="popover-element"]');
   const getContentElement = () => component.$('[data-hook="popover-content"]');
-  const hover = async element => await browser.actions().mouseMove(element).perform();
 
   return {
     element: () => component,
@@ -11,8 +11,8 @@ export const popoverDriverFactory = component => {
     getContentElement: () => getContentElement(),
     isTargetElementExists: () => getTargetElement().isPresent(),
     isContentElementExists: () => getContentElement().isPresent(),
-    mouseEnter: () => hover(component),
-    mouseLeave: () => hover({x: 1000, y: 1000}),
+    mouseEnter: () => mouseEnter(component),
+    mouseLeave,
     click: () => component.click()
   };
 };

--- a/packages/wix-ui-core/src/components/Tooltip/Tooltip.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Tooltip/Tooltip.protractor.driver.ts
@@ -2,7 +2,6 @@ import {browser} from 'protractor';
 import {popoverDriverFactory} from '../../baseComponents/Popover/Popover.protractor.driver';
 
 export const tooltipDriverFactory = component => {
-  const hover = async element => await browser.actions().mouseMove(element).perform();
   const popoverDriver = popoverDriverFactory(component);
   return Object.assign(
     {},

--- a/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
@@ -42,3 +42,6 @@ export const waitForVisibilityOf = (
     )
   );
 };
+
+export const mouseEnter = async (element: any) => await browser.actions().mouseMove(element).perform();
+export const mouseLeave = () => mouseEnter({x: 1000, y: 1000});

--- a/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
@@ -3,7 +3,8 @@ import {
   promise,
   ExpectedConditions,
   ElementFinder,
-  ElementArrayFinder
+  ElementArrayFinder,
+  WebElement
 } from 'protractor';
 
 const encode = global.encodeURIComponent;
@@ -43,5 +44,11 @@ export const waitForVisibilityOf = (
   );
 };
 
-export const mouseEnter = async (element: any) => await browser.actions().mouseMove(element).perform();
+// This interface is copied over from protractor because it isn't exported
+export interface ILocation {
+  x: number;
+  y: number;
+}
+
+export const mouseEnter = async (element: WebElement | ILocation) => await browser.actions().mouseMove(element).perform();
 export const mouseLeave = () => mouseEnter({x: 1000, y: 1000});


### PR DESCRIPTION
For use with hover testing