### PR TITLE
Fix Build: workaround for ts error in react-popper

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -43,7 +43,8 @@
     "react-popper": "^0.8.0",
     "react-transition-group": "^2.2.1",
     "wix-ui-jss": "^1.0.0",
-    "wix-ui-test-utils": "^1.0.0"
+    "wix-ui-test-utils": "^1.0.0",
+    "popper.js": "1.12"
   },
   "devDependencies": {
     "@storybook/addon-options": "^3.3.7",


### PR DESCRIPTION
See https://github.com/souporserious/react-popper/issues/101

Workaround (according to issue in `react-popper`) is to set `popper.js` version to "1.12", until issue is resolved.