### PR TITLE
wix-ui-test-utils/wix-storybook-utils: Add storyUrl param withExamples

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -55,6 +55,7 @@
     "import-path": "latest",
     "jsx-to-string": "git+https://github.com/amiryonatan/jsx-to-string.git#release_branch",
     "loader-utils": "^1.1.0",
+    "query-string": "^5.1.0",
     "react-autodocs-utils": "^2.0.1",
     "react-collapse": "^4.0.3",
     "react-docgen": "^2.20.0",

--- a/packages/wix-storybook-utils/src/StoryNew/index.js
+++ b/packages/wix-storybook-utils/src/StoryNew/index.js
@@ -6,7 +6,7 @@ import Markdown from '../Markdown';
 import CodeBlock from '../CodeBlock';
 import AutoExample from '../AutoExample';
 import AutoDocs from '../AutoDocs';
-
+import * as queryString from 'query-string';
 import styles from '../Story/styles.scss';
 
 const isE2E = global.self === global.top;
@@ -33,7 +33,7 @@ export default ({
             parsedSource={_metadata}
             />
 
-          {examples}
+          {queryString.parse(window.location.search).withExamples !== undefined && examples}
         </div>
       );
     }

--- a/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor-helpers.ts
@@ -9,11 +9,26 @@ import {
 
 const encode = global.encodeURIComponent;
 
-export const getStoryUrl = (
-  kind: string,
-  story: string
-): string =>
-  `iframe.html?selectedKind=${encode(kind)}&selectedStory=${encode(story)}`;
+export interface StoryUrlParams {
+  kind: string;
+  story: string;
+  withExamples?: boolean;
+}
+
+/**
+ * @deprecated
+ * @see createStoryUrl
+ */
+export const getStoryUrl = (kind: string, story: string): string =>
+  createStoryUrl({kind, story});
+
+/**
+ *
+ * @param {StoryUrlParams} params withExamples defaults to true
+ */
+export const createStoryUrl = ({kind, story, withExamples = true}: StoryUrlParams): string => {
+  return `iframe.html?selectedKind=${encode(kind)}&selectedStory=${encode(story)}${withExamples ? `&withExamples` : ''}`;
+};
 
 export const scrollToElement = (element: ElementArrayFinder) =>
   browser.executeScript(

--- a/packages/wix-ui-test-utils/test/protractor-helpers.spec.ts
+++ b/packages/wix-ui-test-utils/test/protractor-helpers.spec.ts
@@ -1,0 +1,31 @@
+import {getStoryUrl, createStoryUrl} from '../src/protractor/protractor-helpers';
+
+describe('protractor-helpers', () => {
+
+  describe('getStoryUrl', () => {
+    const kind = '3. Inputs';
+    const story = '3.2 + InputArea';
+
+    const EXPECTED_URL_BASE = 'iframe.html?selectedKind=3.%20Inputs&selectedStory=3.2%20%2B%20InputArea';
+
+    it('Should create story url using deprecated version', () => {
+      expect(getStoryUrl(kind, story))
+      .toEqual(`${EXPECTED_URL_BASE}&withExamples`);
+    });
+
+    it('Should create story url with options', () => {
+      expect(createStoryUrl({kind, story}))
+      .toEqual(`${EXPECTED_URL_BASE}&withExamples`);
+    });
+
+    it('Should create story url without examples', () => {
+      expect(createStoryUrl({kind, story, withExamples: false}))
+      .toEqual(EXPECTED_URL_BASE);
+    });
+
+    it('Should create story url with examples', () => {
+      expect(createStoryUrl({kind, story, withExamples: true}))
+      .toEqual(`${EXPECTED_URL_BASE}&withExamples`);
+    });
+  });
+});


### PR DESCRIPTION
It is helpful for e2e tests, that the e2e story will not include examples, so that we can test an isolated <AutoExample> component.
For example when testing focus behavior, the examples may interfeer if they have autoFocus, and make the test implementation more complicated.

- Added url param `withExamples` to control the rendering of the exmaples.
- in `wix-ui-test-utils`
  -  make `withExamples` default to `true.
  - add `createStoryUrl()` which accepts a params object (deprecate the usage of the multiple arguments `getStoryUrl()`)