### PR TITLE
Toggle rtl

### DIFF
--- a/packages/wix-ui-core/src/components/StylableToggleSwitch/ToggleSwitchLayout.st.css
+++ b/packages/wix-ui-core/src/components/StylableToggleSwitch/ToggleSwitchLayout.st.css
@@ -49,10 +49,6 @@
   margin: auto;
 }
 
-:global([dir="rtl"]) .root::knob {
-  transform: translateX(calc(value(knobMovementRange) / 2));
-}
-
 .root::knobIcon {
   width: calc(value(knobHeight) / 2);
   height: calc(value(knobHeight) / 2);
@@ -64,7 +60,8 @@
   height: 100%;
 }
 
-.root:checked::knob {
+.root:checked::knob, 
+:global([dir="rtl"]) .root::knob {
   transform: translateX(calc(value(knobMovementRange) / 2));
 }
 

--- a/packages/wix-ui-core/src/components/StylableToggleSwitch/ToggleSwitchLayout.st.css
+++ b/packages/wix-ui-core/src/components/StylableToggleSwitch/ToggleSwitchLayout.st.css
@@ -49,6 +49,10 @@
   margin: auto;
 }
 
+:global([dir="rtl"]) .root::knob {
+  transform: translateX(calc(value(knobMovementRange) / 2));
+}
+
 .root::knobIcon {
   width: calc(value(knobHeight) / 2);
   height: calc(value(knobHeight) / 2);
@@ -62,4 +66,8 @@
 
 .root:checked::knob {
   transform: translateX(calc(value(knobMovementRange) / 2));
+}
+
+:global([dir="rtl"]) .root:checked::knob {
+  transform: translateX(calc(value(knobMovementRange) / -2));
 }


### PR DESCRIPTION
@barak007 
This pr should work after we will fix the `rootScope` configuration which to allow global css rules
From the addd rule we get:

```css
.style699900968--root.ToggleSwitch73708603--root [dir="rtl"] .style699900968--root.ToggleSwitch73708603--root .ToggleSwitch73708603--knob {
  transform: translateX(calc(calc(48px - calc(24px / 1.2) - 24px + calc(24px / 1.2)) / 2));
}
```

Instead of 

```css
[dir="rtl"] .style699900968--root.ToggleSwitch73708603--root .ToggleSwitch73708603--knob {
  transform: translateX(calc(calc(48px - calc(24px / 1.2) - 24px + calc(24px / 1.2)) / 2));
}
```