### PR TITLE
chore(package.json): set `src` to also be packaged

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -8,6 +8,7 @@
     "email": "fed-infra@wix.com"
   },
   "files": [
+    "src",
     "dist",
     "*.js",
     "*.d.ts",


### PR DESCRIPTION
currently a requirement if autodocs is wished to be used.
sources are needed for a case when `wix-ui-backoffice` documents
component which HOCs over other component from `wix-ui-core`.

Third party parser (react-docgen-typescript) does not understand such
scenario, whereas our parser does. with a caveat, however, which is
available `src` folder.

i think its a reasonable requirement for documentation tools.

with more effort its possible to go without `src`, i guess we can assume this change is temporary