### PR TITLE
Wix storybook utils/autoexample preview

### DIFF
--- a/packages/wix-storybook-utils/.storybook/config.js
+++ b/packages/wix-storybook-utils/.storybook/config.js
@@ -2,7 +2,7 @@ import {configure, storiesOf} from '@storybook/react';
 import {setOptions} from '@storybook/addon-options';
 
 function loadStories() {
-  require('../stories');
+  require('../stories/index.story.js');
   require('./stories.scss');
 }
 

--- a/packages/wix-storybook-utils/.storybook/webpack.config.js
+++ b/packages/wix-storybook-utils/.storybook/webpack.config.js
@@ -1,6 +1,25 @@
+const path = require('path');
 const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js');
 const wixStorybookConfig = require('haste-preset-yoshi/config/webpack.config.storybook');
 
 module.exports = (config, env) => {
-  return wixStorybookConfig(genDefaultConfig(config, env));
+  const newConfig = wixStorybookConfig(genDefaultConfig(config, env));
+
+  newConfig.resolve.alias = Object.assign({}, newConfig.resolve.alias, {
+    'wix-storybook-utils': path.resolve(__dirname, '..', 'src')
+  });
+
+  newConfig.module.rules.push({
+    test: /\.story\.[j|t]sx?$/,
+    loader: './src/loader',
+    options: {
+      storyConfig: {
+        moduleName: 'wix-storybook-utils',
+        repoBaseURL: 'https://github.com/wix/wix-ui/tree/master/packages/wix-storybook-utils/src/components/'
+      }
+    }
+  });
+
+  return newConfig;
 };
+

--- a/packages/wix-storybook-utils/src/FormComponents/styles.scss
+++ b/packages/wix-storybook-utils/src/FormComponents/styles.scss
@@ -62,9 +62,6 @@
 
 .preview {
   padding: 60px 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 
   border: 1px solid #dee6ed;
   box-shadow: 0 0 10px 2px #e5ebf1 inset;

--- a/packages/wix-storybook-utils/stories/component.js
+++ b/packages/wix-storybook-utils/stories/component.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const enabledStyle = {
+  fontSize: 20
+};
+
+const disabledStyle = {
+  fontSize: 12,
+  color: 'grey'
+};
+
+const Component = ({enabled, children}) =>
+  <div style={enabled ? enabledStyle : disabledStyle}>
+    {children}
+  </div>;
+
+Component.propTypes = {
+  children: PropTypes.node,
+  enabled: PropTypes.bool
+};
+
+Component.defaultProps = {
+  children: 'Hello dummy component!',
+  enabled: true
+};
+
+Component.displayName = 'DummyComponent';
+
+export default Component;

--- a/packages/wix-storybook-utils/stories/index.js
+++ b/packages/wix-storybook-utils/stories/index.js
@@ -1,5 +1,0 @@
-import React from 'react';
-import {storiesOf} from '@storybook/react';
-
-storiesOf('Home', module)
-  .add('Hello World', () => <div>Hello World</div>);

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -1,0 +1,8 @@
+import Component from './component';
+
+export default {
+  category: 'Components',
+  component: Component,
+  storyName: 'Dummy Component',
+  componentPath: './component.js'
+};


### PR DESCRIPTION
1. remove `flex` from preview section in autodocs, because it makes previewable component a flex item and may show different width than it actually has
2. add dummy component for fun and to have something to play with