### PR TITLE
migrate storybook-utils to new Toggleswitch

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -62,7 +62,8 @@
     "react-motion": "^0.5.2",
     "react-remarkable": "^1.1.3",
     "recast": "^0.13.0",
-    "wix-style-react": "latest"
+    "wix-style-react": "latest",
+    "wix-ui-backoffice": "latest"
   },
   "devDependencies": {
     "@storybook/addon-options": "^3.2.16",

--- a/packages/wix-storybook-utils/src/FormComponents/index.js
+++ b/packages/wix-storybook-utils/src/FormComponents/index.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 
 import {Container, Row, Col} from 'wix-style-react/Grid';
 import {default as WixInput} from 'wix-style-react/Input';
-import ToggleSwitch from 'wix-style-react/ToggleSwitch';
+import {ToggleSwitch} from 'wix-ui-backoffice/ToggleSwitch';
 import {default as WixRadioGroup} from 'wix-style-react/RadioGroup';
 import Dropdown from 'wix-style-react/Dropdown';
 import Text from 'wix-style-react/Text';
@@ -72,7 +72,7 @@ const Preview = ({children, isRtl, onToggleRtl, isDarkBackground, onToggleBackgr
           Imitate RTL:&nbsp;
 
           <ToggleSwitch
-            size="x-small"
+            size="small"
             checked={isRtl}
             onChange={e => onToggleRtl(e.target.checked)}
             />
@@ -82,7 +82,7 @@ const Preview = ({children, isRtl, onToggleRtl, isDarkBackground, onToggleBackgr
           Dark Background:&nbsp;
 
           <ToggleSwitch
-            size="x-small"
+            size="small"
             checked={isDarkBackground}
             onChange={e => onToggleBackground(e.target.checked)}
             />
@@ -117,7 +117,7 @@ Preview.propTypes = {
 
 const Toggle = ({value, onChange, ...props}) =>
   <ToggleSwitch
-    size="small"
+    size="medium"
     checked={value}
     onChange={({target: {checked}}) => onChange(checked)}
     {...props}


### PR DESCRIPTION
When we will release to wix-style-react v4.0.0, we will have a new API for ToggleSwitch.
In order not to forget to migrate ourselves, I have migrated it directly to wix-ui-backoffice.

@argshook If there is any issue wix-ui-backoffice directly, let me know.