### PR TITLE
Add [TS] Types to all protractor drivers

### DIFF
--- a/packages/wix-ui-core/src/baseComponents/Dropdown/Dropdown.protractor.driver.ts
+++ b/packages/wix-ui-core/src/baseComponents/Dropdown/Dropdown.protractor.driver.ts
@@ -1,7 +1,9 @@
+import {ElementFinder} from 'protractor';
+
 import {popoverDriverFactory} from '../Popover/Popover.protractor.driver';
 import {dropdownContentDriverFactory} from '../DropdownContent/DropdownContent.protractor.driver';
 
-export const dropdownDriverFactory = component => {
+export const dropdownDriverFactory = (component: ElementFinder) => {
   const popoverDriver = popoverDriverFactory(component);
 
   return Object.assign(

--- a/packages/wix-ui-core/src/baseComponents/DropdownContent/DropdownContent.protractor.driver.ts
+++ b/packages/wix-ui-core/src/baseComponents/DropdownContent/DropdownContent.protractor.driver.ts
@@ -1,10 +1,11 @@
+import {ElementFinder} from 'protractor';
 import {dropdownOptionDriverFactory} from '../DropdownOption/DropdownOption.protractor.driver';
 
-export const dropdownContentDriverFactory = component => {
+export const dropdownContentDriverFactory = (component: ElementFinder) => {
   const getOptions = () => component.$$('[data-hook="option"]');
   return {
     element: () => component,
-    getOptionsCount: async () => await getOptions().count(),
+    getOptionsCount: async () => getOptions().count(),
     optionAt: (index: number) => {
       const option = getOptions().get(index);
       return dropdownOptionDriverFactory(option);

--- a/packages/wix-ui-core/src/baseComponents/DropdownOption/DropdownOption.protractor.driver.ts
+++ b/packages/wix-ui-core/src/baseComponents/DropdownOption/DropdownOption.protractor.driver.ts
@@ -1,7 +1,9 @@
-export const dropdownOptionDriverFactory = component => {
+import {ElementFinder} from 'protractor';
+
+export const dropdownOptionDriverFactory = (component: ElementFinder) => {
   return {
     element: () => component,
-    click: () => component.click(),
-    getText: () => component.getText()
+    click: async () => component.click(),
+    getText: async () => component.getText()
   };
 };

--- a/packages/wix-ui-core/src/baseComponents/InputWithOptions/InputWithOptions.protractor.driver.ts
+++ b/packages/wix-ui-core/src/baseComponents/InputWithOptions/InputWithOptions.protractor.driver.ts
@@ -1,7 +1,8 @@
+import {ElementFinder} from 'protractor';
 import {inputDriverFactory} from '../../components/Input/Input.protractor.driver';
 import {dropdownDriverFactory} from '../Dropdown/Dropdown.protractor.driver';
 
-export const inputWithOptionsDriverFactory = component => {
+export const inputWithOptionsDriverFactory = (component: ElementFinder) => {
   const dropdownDriver = dropdownDriverFactory(component);
   const inputDriver = inputDriverFactory(dropdownDriver.getTargetElement().$('[data-hook=input]'));
 

--- a/packages/wix-ui-core/src/baseComponents/Popover/Popover.protractor.driver.ts
+++ b/packages/wix-ui-core/src/baseComponents/Popover/Popover.protractor.driver.ts
@@ -1,7 +1,7 @@
-import {browser} from 'protractor';
+import {browser, ElementFinder} from 'protractor';
 import {mouseEnter, mouseLeave} from 'wix-ui-test-utils/protractor';
 
-export const popoverDriverFactory = component => {
+export const popoverDriverFactory = (component: ElementFinder) => {
   const getTargetElement = () => component.$('[data-hook="popover-element"]');
   const getContentElement = () => component.$('[data-hook="popover-content"]');
 
@@ -9,10 +9,10 @@ export const popoverDriverFactory = component => {
     element: () => component,
     getTargetElement: () => getTargetElement(),
     getContentElement: () => getContentElement(),
-    isTargetElementExists: () => getTargetElement().isPresent(),
-    isContentElementExists: () => getContentElement().isPresent(),
+    isTargetElementExists: async () => getTargetElement().isPresent(),
+    isContentElementExists: async () => getContentElement().isPresent(),
     mouseEnter: () => mouseEnter(component),
     mouseLeave,
-    click: () => component.click()
+    click: async () => component.click()
   };
 };

--- a/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsIframeClient.protractor.driver.ts
+++ b/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsIframeClient.protractor.driver.ts
@@ -1,4 +1,6 @@
-export const googleMapsIframeClientDriverFactory = component => {
+import {ElementFinder} from 'protractor';
+
+export const googleMapsIframeClientDriverFactory = (component: ElementFinder) => {
   const getButtons = () => component.$$('button');
   const input = component.$('input');
   const resultsElementWrapper = component.$('pre');

--- a/packages/wix-ui-core/src/components/Badge/Badge.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Badge/Badge.protractor.driver.ts
@@ -1,6 +1,8 @@
-export const badgeDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const badgeDriverFactory = (component: ElementFinder) => ({
   /** returns the component element */
   element: () => component,
   /** returns the component text */
-  getTextContent: () => component.getText(),
+  getTextContent: async () => component.getText(),
 });

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.protractor.driver.ts
@@ -1,13 +1,15 @@
-export const checkboxDriverFactory = component => {
+import {ElementFinder} from 'protractor';
+
+export const checkboxDriverFactory = (component: ElementFinder) => {
   const input = component.$('input');
   return {
     /** Returns the component instance */
     element: () => component,
     /** Simulates a click on the component */
-    click: () => component.click(),
+    click: async () => component.click(),
     /** Indicates whether the component is disabled or not */
-    isDisabled: () => component.getAttribute('disabled') === '',
+    isDisabled: async () => component.getAttribute('disabled').then(v => v !==  null),
     /** returns a boolean indicating if the checkbox is checked */
-    isChecked: () => input.isSelected(),
+    isChecked: async () => input.isSelected(),
   };
 };

--- a/packages/wix-ui-core/src/components/Divider/Divider.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Divider/Divider.protractor.driver.ts
@@ -1,7 +1,9 @@
-export const dividerDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const dividerDriverFactory = (component: ElementFinder) => ({
   /** returns the element */
   element: () => component,
 
   /** checks if the element exists */
-  exists: () => !!component
+  exists: () => !!component.isPresent()
 });

--- a/packages/wix-ui-core/src/components/Divider/Divider.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Divider/Divider.protractor.driver.ts
@@ -5,5 +5,5 @@ export const dividerDriverFactory = (component: ElementFinder) => ({
   element: () => component,
 
   /** checks if the element exists */
-  exists: () => !!component.isPresent()
+  exists: () => component.isPresent()
 });

--- a/packages/wix-ui-core/src/components/HBox/HBox.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/HBox/HBox.protractor.driver.ts
@@ -1,4 +1,6 @@
-export const hBoxDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const hBoxDriverFactory = (component: ElementFinder) => ({
   /** Returns the wrapped component instance */
   element: () => component
 });

--- a/packages/wix-ui-core/src/components/Input/Input.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Input/Input.protractor.driver.ts
@@ -1,10 +1,15 @@
-export const inputDriverFactory = component => {
+import {ElementFinder} from 'protractor';
+
+export const inputDriverFactory = (component: ElementFinder) => {
   const input = component.$('input');
 
   return {
     element: () => component,
-    enterText: text => input.clear().sendKeys(text),
-    focus: () => input.click(),
-    getText: () => input.getAttribute('value')
+    enterText: async (text) => {
+      await input.clear();
+      await input.sendKeys(text);
+    },
+    focus: async () => input.click(),
+    getText: async () => input.getAttribute('value')
   };
 };

--- a/packages/wix-ui-core/src/components/Label/Label.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Label/Label.protractor.driver.ts
@@ -1,8 +1,10 @@
-export const labelDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const labelDriverFactory = (component: ElementFinder) => ({
     /** returns the component element */
     element: () => component,
     /** returns the component label */
-    getLabelText: () => component.getText(),
+    getLabelText: async () => component.getText(),
     /** clicks the label */
-    click: () => component.click()
+    click: async () => component.click()
   });

--- a/packages/wix-ui-core/src/components/LabelWithOptions/LabelWithOptions.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/LabelWithOptions/LabelWithOptions.protractor.driver.ts
@@ -1,7 +1,8 @@
+import {ElementFinder} from 'protractor';
 import {labelDriverFactory} from '../../components/Label/Label.protractor.driver';
 import {dropdownDriverFactory} from '../../baseComponents/Dropdown/Dropdown.protractor.driver';
 
-export const labelWithOptionsDriverFactory = component => {
+export const labelWithOptionsDriverFactory = (component: ElementFinder) => {
   const dropdownDriver = dropdownDriverFactory(component);
   const labelDriver = labelDriverFactory(dropdownDriver.getTargetElement().$('[data-hook=label]'));
 
@@ -9,4 +10,5 @@ export const labelWithOptionsDriverFactory = component => {
     {},
     dropdownDriver,
     labelDriver);
+
 };

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.protractor.driver.ts
@@ -1,16 +1,18 @@
-export const paginationDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const paginationDriverFactory = (component: ElementFinder) => ({
   /** Returns the root element*/
   element: () => component,
 
   /** Returns x & y coordinates for the element found with data-hook */
-  getElementLocation: (dataHook): Promise<{x: number, y: number}> => component.$(`[data-hook="${dataHook}"]`).getLocation(),
+  getElementLocation: async (dataHook): Promise<{x: number, y: number}> => component.$(`[data-hook="${dataHook}"]`).getLocation(),
 
   /** Returns width & height for the element found with data-hook */
-  getElementSize: (dataHook): Promise<{width: number, height: number}> => component.$(`[data-hook="${dataHook}"]`).getSize(),
+  getElementSize: async (dataHook): Promise<{width: number, height: number}> => component.$(`[data-hook="${dataHook}"]`).getSize(),
 
   /** Get the text content of pages shown in "pages" mode  */
-  getPageList(): Promise<string[]> {
+  getPageList: async (): Promise<string[]> => {
     const pages = component.$$('[data-hook="page-strip"] > :first-child > *');
-    return pages.map(p => p.getText());
+    return pages.map<string>(p => p.getText());
   }
 });

--- a/packages/wix-ui-core/src/components/RadioButton/RadioButton.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/RadioButton/RadioButton.protractor.driver.ts
@@ -1,6 +1,8 @@
-export const radioButtonDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const radioButtonDriverFactory = (component: ElementFinder) => ({
   element: () => component,
-  select: () => component.click(),
+  select: async () => component.click(),
   isSelected: async () => {
     const checked = await component.getAttribute('aria-checked');
     return checked === 'true';

--- a/packages/wix-ui-core/src/components/Slider/Slider.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Slider/Slider.protractor.driver.ts
@@ -1,9 +1,9 @@
-import {browser} from 'protractor';
+import {browser, ElementFinder} from 'protractor';
 import {waitForVisibilityOf} from 'wix-ui-test-utils/protractor';
 
-export const sliderDriverFactory = component => ({
+export const sliderDriverFactory = (component: ElementFinder) => ({
   element: () => component,
-  getSliderValue: () => {
+  getSliderValue: async () => {
     return component.getAttribute('data-value');
   },
   getTooltipValue: async () => {

--- a/packages/wix-ui-core/src/components/StylableBadge/Badge.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/StylableBadge/Badge.protractor.driver.ts
@@ -1,6 +1,8 @@
-export const badgeDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const badgeDriverFactory = (component: ElementFinder) => ({
     /** returns the component element */
     element: () => component,
     /** returns the component text */
-    text: () => component.getText()
+    text: async () => component.getText()
   });

--- a/packages/wix-ui-core/src/components/StylableText/Text.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/StylableText/Text.protractor.driver.ts
@@ -1,6 +1,8 @@
-export const textDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const textDriverFactory = (component: ElementFinder) => ({
     /** returns the component element */
     element: () => component,
     /** returns the component text */
-    getText: () => component.getText()
+    getText: async () => component.getText()
   });

--- a/packages/wix-ui-core/src/components/TimePicker/TimePicker.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/TimePicker/TimePicker.protractor.driver.ts
@@ -1,4 +1,6 @@
-export const timePickerDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const timePickerDriverFactory = (component: ElementFinder) => ({
   /** returns the component element */
   element: () => component,
 });

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.protractor.driver.ts
@@ -1,12 +1,14 @@
-export const toggleSwitchDriverFactory = component => {
+import {ElementFinder} from 'protractor';
+
+export const toggleSwitchDriverFactory = (component: ElementFinder) => {
   const input = component.$('input');
   return {
     /** returns the component element */
     element: () => component,
     /** triggers toggleSwitch change */
-    click: () => component.click(),
+    click: async () => component.click(),
     /** returns a boolean indicating if the toggleSwitch is checked */
-    checked: () => input.isSelected(),
+    checked: async () => input.isSelected(),
     /** returns a boolean indicating if the toggleSwitch is disabled */
     isDisabled: () => !input.isEnabled()
   };

--- a/packages/wix-ui-core/src/components/Tooltip/Tooltip.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Tooltip/Tooltip.protractor.driver.ts
@@ -1,11 +1,13 @@
 import {browser, ElementFinder} from 'protractor';
 import {popoverDriverFactory} from '../../baseComponents/Popover/Popover.protractor.driver';
+import {ILocation} from 'protractor/node_modules/@types/selenium-webdriver';
+export {ILocation};
 
 export const tooltipDriverFactory = (component: ElementFinder) => {
   const popoverDriver = popoverDriverFactory(component);
   return Object.assign(
     {},
     popoverDriver, {
-    getTooltipLocation: () =>  popoverDriver.getContentElement().getWebElement().getLocation()
+    getTooltipLocation: async () =>  popoverDriver.getContentElement().getWebElement().getLocation()
   });
 };

--- a/packages/wix-ui-core/src/components/Tooltip/Tooltip.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/Tooltip/Tooltip.protractor.driver.ts
@@ -1,11 +1,11 @@
-import {browser} from 'protractor';
+import {browser, ElementFinder} from 'protractor';
 import {popoverDriverFactory} from '../../baseComponents/Popover/Popover.protractor.driver';
 
-export const tooltipDriverFactory = component => {
+export const tooltipDriverFactory = (component: ElementFinder) => {
   const popoverDriver = popoverDriverFactory(component);
   return Object.assign(
     {},
     popoverDriver, {
-    getTooltipLocation: async () => (await popoverDriver.getContentElement().getWebElement()).getLocation()
+    getTooltipLocation: () =>  popoverDriver.getContentElement().getWebElement().getLocation()
   });
 };

--- a/packages/wix-ui-core/src/components/VBox/VBox.protractor.driver.ts
+++ b/packages/wix-ui-core/src/components/VBox/VBox.protractor.driver.ts
@@ -1,4 +1,6 @@
-export const vBoxDriverFactory = component => ({
+import {ElementFinder} from 'protractor';
+
+export const vBoxDriverFactory = (component: ElementFinder) => ({
   /** returns the component element */
   element: () => component
 });

--- a/packages/wix-ui-core/src/testkit/protractor.ts
+++ b/packages/wix-ui-core/src/testkit/protractor.ts
@@ -1,4 +1,5 @@
 import {protractorTestkitFactoryCreator} from 'wix-ui-test-utils/protractor';
+import {ElementFinder} from 'protractor';
 
 //JSS
 import {popoverDriverFactory} from '../baseComponents/Popover/Popover.protractor.driver';
@@ -13,7 +14,7 @@ export const paginationTestkitFactory = protractorTestkitFactoryCreator(paginati
 import {badgeDriverFactory} from '../components/Badge/Badge.protractor.driver';
 export const badgeTestkitFactory = protractorTestkitFactoryCreator(badgeDriverFactory);
 
-import {tooltipDriverFactory} from '../components/Tooltip/Tooltip.protractor.driver';
+import {tooltipDriverFactory, ILocation} from '../components/Tooltip/Tooltip.protractor.driver';
 export const tooltipTestkitFactory = protractorTestkitFactoryCreator(tooltipDriverFactory);
 
 import {dividerDriverFactory} from '../components/Divider/Divider.protractor.driver';


### PR DESCRIPTION
While at it, had to workaround a [protractor bug](https://github.com/angular/protractor/issues/4760) by adding `async` before the problematic functions.

EDIT:
after reading this:
https://github.com/Microsoft/TypeScript/issues/5711

There is another solution (not ideal):
To add:
`import {promise} from 'protractor/node_modules/@types/selenium-webdriver';`

that is, instead of adding `async`.