### PR TITLE
feat(Pop): POC of how popover should look like DONT MERGE THIS IS POC

### DIFF
--- a/packages/wix-ui-core/src/baseComponents/Pop/index.tsx
+++ b/packages/wix-ui-core/src/baseComponents/Pop/index.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import Popper from 'popper.js';
+
+export interface Controls {
+  toggle(): void;
+  show(): void;
+  hide(): void;
+}
+
+export type Placement = Popper.Placement;
+
+export interface Props {
+  trigger(Controls): React.ReactNode;
+  menu(Controls): React.ReactNode;
+  placement?: Placement;
+}
+
+export interface State {
+  open: Boolean;
+}
+
+export class Pop extends React.PureComponent<Props, State> {
+  toggleRef: Element;
+  menuRef: Element;
+  popper: any;
+
+  state = {
+    open: false
+  };
+
+  defaultProps = {
+    placement: 'bottom'
+  };
+
+  componentDidMount() {
+    this.popper = new Popper(
+      this.toggleRef,
+      this.menuRef,
+      {
+        placement: this.props.placement || 'bottom'
+      }
+    );
+  }
+
+  _update(state) {
+    this.setState(state, this.popper.scheduleUpdate);
+  }
+
+  _componentInterface = {
+    toggle: () => this._update({open: !this.state.open}),
+    show: () => this._update({open: true}),
+    hide: () => this._update({open: false})
+  };
+
+  render() {
+    return (
+      <div style={{display: 'inline-block'}}>
+        <div ref={ref => this.toggleRef = ref}>
+          {this.props.trigger(this._componentInterface)}
+        </div>
+
+        <div ref={ref => this.menuRef = ref}>
+          {this.state.open && this.props.menu(this._componentInterface) }
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/wix-ui-core/stories/Pop.tsx
+++ b/packages/wix-ui-core/stories/Pop.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import {storiesOf} from '@storybook/react';
+import onClickOutside, {InjectedOnClickOutProps, OnClickOutProps} from 'react-onclickoutside';
+
+import {Pop, Placement} from '../src/baseComponents/Pop';
+import {Input} from '../src/components/Input';
+
+interface Props {
+  hide: Function;
+}
+
+class Menu extends React.Component<Props & InjectedOnClickOutProps> {
+  handleClickOutside() {
+    this.props.hide();
+  }
+
+  render() {
+    return (
+      <div
+      style = {{
+        display: 'inline-block',
+        background: 'white',
+        padding: '.5em',
+        border: '1px solid black'
+      }}
+      children="Hello menu woo!"
+      />
+    );
+  }
+}
+
+const DropdownMenu = onClickOutside(Menu);
+
+export const PopStory = () =>
+  <div>
+    <h2>popover mechanism to create any kind of popover</h2>
+
+    <Pop
+      placement="bottom-start"
+      trigger={({toggle}) => <span onClick={toggle}>Click me!</span>}
+      menu={({hide}) => <DropdownMenu hide={hide}/>}
+      />
+
+    <br/>
+    <br/>
+    <br/>
+    <br/>
+    <br/>
+
+    <Pop
+      placement="bottom-start"
+      trigger={({show}) => <Input value="hello" onClick={show}/>}
+      menu={({hide}) => <DropdownMenu hide={hide}/>}
+      />
+
+    <br/>
+    <br/>
+    <br/>
+    <br/>
+    <br/>
+
+    <Pop
+      placement="top-start"
+      trigger={({show, hide}) =>
+        <div
+        onMouseOver={show}
+        onMouseOut={hide}
+        children="hover me for tooltip"
+        />
+      }
+      menu={() =>
+        <div
+        style={{
+          background: 'teal'
+        }}
+        children="Hello from tooltip!"
+        />
+      }
+    />
+  </div>;

--- a/packages/wix-ui-core/stories/index.tsx
+++ b/packages/wix-ui-core/stories/index.tsx
@@ -7,6 +7,7 @@ import {GoogleMapsIframeClientStory} from './clients/GoogleMapsIframeClient-stor
 import {CheckboxStory} from './Checkbox/Checkbox-story';
 import {TooltipStory} from './Tooltip/custom';
 import {RadioButtonStory} from './RadioButton';
+import {PopStory} from './Pop';
 
 // baseComponents
 import './InputWithOptions.story';
@@ -41,4 +42,5 @@ storiesOf('Components', module)
   .add('Divider', () => <DividerStory/>)
   .add('Checkbox', () => <CheckboxStory/>)
   .add('Tooltip Custom', () => <TooltipStory/>)
-  .add('RadioButton', () => <RadioButtonStory/>);
+  .add('RadioButton', () => <RadioButtonStory/>)
+  .add('Pop', PopStory);


### PR DESCRIPTION
this is an example of how i imagine composition done in popover.

quick & dirty, actual implementation may differ from this example. The idea is to use functions for trigger and menu elements. some say it's "render prop". it's just a function.

this approach makes [magic children calculations](https://github.com/wix/wix-ui/blob/wix-ui-core/popover-poc/packages/wix-ui-core/src/utils/index.ts) unnecessary and, what's important, it totally disconnects popover mechanism from rendered components

to expand further, `arrow` could also come as prop to `Popover`. `if prop.arrow then render it otherwise render default arrow `

component api in this example has `show`, `hide` and `toggle`. it could also have `move`, `update` and whatever else we wish