### PR TITLE
Improving flaky tests for stale requests

### DIFF
--- a/packages/wix-ui-core/src/components/AddressInput/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/AddressInput/AddressInput.spec.tsx
@@ -300,8 +300,8 @@ describe('AddressInput', () => {
             firstRequest.resolve();
 
             await waitForCond.assertHold(() => {
-                expect(helper.getOptionsText(driver)).toEqual([helper.ADDRESS_DESC_2])
-            }, 1000 ,'Address description changed');
+                expect(helper.getOptionsText(driver)).toEqual([helper.ADDRESS_DESC_2]);
+            }, 1000, 'Address description changed');
         });
 
         it('Should ignore stale requests - geocode', async () => {

--- a/packages/wix-ui-core/src/components/AddressInput/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/AddressInput/AddressInput.spec.tsx
@@ -281,64 +281,83 @@ describe('AddressInput', () => {
         });
     });
 
-    describe.skip('Stale requests', () => {
+    describe('Stale requests', () => {
         it('Should ignore stale requests - autocomplete', async () => {
-            GoogleMapsClientStub.setAddresses([helper.ADDRESS_1], 100);
+            init({throttleInterval: 0});
+            const firstRequest = GoogleMapsClientStub.setAddressesPromise([helper.ADDRESS_1]);
             driver.click();
             driver.setValue('n');
 
-            GoogleMapsClientStub.setAddresses([helper.ADDRESS_2], 1);
+            const secondRequest = GoogleMapsClientStub.setAddressesPromise([helper.ADDRESS_2]);
             driver.setValue('ne');
 
-            await sleep(250);
+            secondRequest.resolve();
+
+            await waitForCond(() => driver.isContentElementExists());
+
             expect(helper.getOptionsText(driver)).toEqual([helper.ADDRESS_DESC_2]);
+
+            firstRequest.resolve();
+
+            await waitForCond.assertHold(() => {
+                expect(helper.getOptionsText(driver)).toEqual([helper.ADDRESS_DESC_2])
+            }, 1000 ,'Address description changed');
         });
 
         it('Should ignore stale requests - geocode', async () => {
+            init({throttleInterval: 0});
             GoogleMapsClientStub.setAddresses([helper.ADDRESS_1]);
-            GoogleMapsClientStub.setGeocode(helper.GEOCODE_1, 1000);
+            const firstRequest = GoogleMapsClientStub.setGeocodePromise(helper.GEOCODE_1);
             driver.click();
             driver.setValue('n');
             await helper.waitForSingleOption(helper.ADDRESS_DESC_1, driver);
             driver.optionAt(0).click();
 
             GoogleMapsClientStub.setAddresses([helper.ADDRESS_2]);
-            GoogleMapsClientStub.setGeocode(helper.GEOCODE_2, 1);
+            const secondRequest = GoogleMapsClientStub.setGeocodePromise(helper.GEOCODE_2);
             driver.setValue('ne');
             await helper.waitForSingleOption(helper.ADDRESS_DESC_2, driver);
             driver.optionAt(0).click();
 
-            await sleep(250);
-            expect(onSelectSpy).toHaveBeenCalledWith({
-                originValue: helper.ADDRESS_DESC_2,
-                googleResult: helper.GEOCODE_2,
-                address: helper.INTERNAL_ADDRESS_GEOCODE_2
+            secondRequest.resolve();
+            firstRequest.resolve();
+
+            return eventually(() => {
+                expect(onSelectSpy).toHaveBeenCalledWith({
+                    originValue: helper.ADDRESS_DESC_2,
+                    googleResult: helper.GEOCODE_2,
+                    address: helper.INTERNAL_ADDRESS_GEOCODE_2
+                });
+                expect(onSelectSpy).toHaveBeenCalledTimes(1);
             });
-            expect(onSelectSpy).toHaveBeenCalledTimes(1);
         });
 
         it('Should ignore stale requests - placeDetails', async () => {
             init({handler: Handler.places});
             GoogleMapsClientStub.setAddresses([helper.ADDRESS_1]);
-            GoogleMapsClientStub.setPlaceDetails(helper.PLACE_DETAILS_1, 1000);
+            const firstRequest = GoogleMapsClientStub.setPlaceDetailsPromise(helper.PLACE_DETAILS_1);
             driver.click();
             driver.setValue('n');
             await helper.waitForSingleOption(helper.ADDRESS_DESC_1, driver);
             driver.optionAt(0).click();
 
             GoogleMapsClientStub.setAddresses([helper.ADDRESS_2]);
-            GoogleMapsClientStub.setPlaceDetails(helper.PLACE_DETAILS_2, 1);
+            const secondRequest = GoogleMapsClientStub.setPlaceDetailsPromise(helper.PLACE_DETAILS_2);
             driver.setValue('ne');
             await helper.waitForSingleOption(helper.ADDRESS_DESC_2, driver);
             driver.optionAt(0).click();
 
-            await sleep(250);
-            expect(onSelectSpy).toHaveBeenCalledWith({
-                originValue: helper.ADDRESS_DESC_2,
-                googleResult: helper.PLACE_DETAILS_2,
-                address: helper.INTERNAL_ADDRESS_PLACE_DETAILS_2
+            secondRequest.resolve();
+            firstRequest.resolve();
+
+            return eventually(() => {
+                expect(onSelectSpy).toHaveBeenCalledWith({
+                    originValue: helper.ADDRESS_DESC_2,
+                    googleResult: helper.PLACE_DETAILS_2,
+                    address: helper.INTERNAL_ADDRESS_PLACE_DETAILS_2
+                });
+                expect(onSelectSpy).toHaveBeenCalledTimes(1);
             });
-            expect(onSelectSpy).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/wix-ui-core/src/components/AddressInput/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/AddressInput/AddressInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import style from './AddressInput.st.css';
-import {func, string, array, bool, oneOf, arrayOf, Requireable} from 'prop-types';
+import {func, string, array, number, bool, oneOf, arrayOf, Requireable} from 'prop-types';
 import {InputWithOptions} from '../../baseComponents/InputWithOptions/InputWithOptions';
 
 import {Option, OptionFactory} from '../../baseComponents/DropdownOption';
@@ -60,6 +60,8 @@ export interface AddressInputProps {
     forceContentElementVisibility?: boolean;
     /** Options to override default one, used for preview mode */
     forceOptions?: Array<Option>;
+    /** Options to override default throttle value, 0 used to disable throttle */
+    throttleInterval?: number;
 }
 
 export interface AddressInputState {
@@ -149,11 +151,14 @@ export class AddressInput extends React.PureComponent<AddressInputProps, Address
         /** If set to true, content element will always be visible, used for preview mode */
         forceContentElementVisibility: bool,
         /** Options to override default one, used for preview mode */
-        forceOptions: array
+        forceOptions: array,
+        /** Options to override default throttle value (ms), 0 used to disable throttle. Default value is 150 */
+        throttleInterval: number
     };
 
     static defaultProps = {
-        handler: Handler.geocode
+        handler: Handler.geocode,
+        throttleInterval: 150
     };
 
     client: MapsClient;
@@ -169,7 +174,7 @@ export class AddressInput extends React.PureComponent<AddressInputProps, Address
         this.geocodeRequestId = 0;
         this.placeDetailsRequestId = 0;
 
-        this._getAddressOptions = throttle(this._getAddressOptions, 150);
+        this._getAddressOptions = props.throttleInterval === 0 ? this._getAddressOptions.bind(this) : throttle(this._getAddressOptions, 150);
         this._handleOnChange = this._handleOnChange.bind(this);
         this._handleOnManualInput = this._handleOnManualInput.bind(this);
         this._onSelect = this._onSelect.bind(this);

--- a/packages/wix-ui-core/src/components/AddressInput/GoogleMapsClientStub.ts
+++ b/packages/wix-ui-core/src/components/AddressInput/GoogleMapsClientStub.ts
@@ -51,26 +51,50 @@ export function createPlaceDetails(placeId: string, formattedAddress: string): P
 export class GoogleMapsClientStub implements MapsClient {
     static addresses: Array<Address> = [];
     static addressesDelay: number;
+    static addressesPromise: Promise<any>;
     static geocode: Array<Geocode> = [];
     static geocodeDelay: number;
+    static geocodePromise: Promise<any>;
     static placeDetails: PlaceDetails = null;
     static placeDetailsDelay: number;
+    static placeDetailsPromise: Promise<any>;
 
     autocomplete(apiKey: string, lang: string, request: string) {
         const addresses = GoogleMapsClientStub.addresses;
         const delay = GoogleMapsClientStub.addressesDelay;
+
+        if (GoogleMapsClientStub.addressesPromise) {
+            const promise = GoogleMapsClientStub.addressesPromise;
+            GoogleMapsClientStub.addressesPromise = null;
+            return promise.then(() => addresses);
+        }
+
         return new Promise<Array<Address>>((resolve, reject) => setTimeout(() => resolve(addresses), delay));
     }
 
     geocode(apiKey: string, lang: string, request: string) {
         const geocode = GoogleMapsClientStub.geocode;
         const delay = GoogleMapsClientStub.geocodeDelay;
+
+        if (GoogleMapsClientStub.geocodePromise) {
+            const promise = GoogleMapsClientStub.geocodePromise;
+            GoogleMapsClientStub.geocodePromise = null;
+            return promise.then(() => geocode);
+        }
+
         return new Promise<Array<Geocode>>((resolve, reject) => setTimeout(() => resolve(geocode), delay));
     }
 
     placeDetails(apiKey: string, lang: string, request: string) {
         const placeDetails = GoogleMapsClientStub.placeDetails;
         const delay = GoogleMapsClientStub.placeDetailsDelay;
+
+        if (GoogleMapsClientStub.placeDetailsPromise) {
+            const promise = GoogleMapsClientStub.placeDetailsPromise;
+            GoogleMapsClientStub.placeDetailsPromise = null;
+            return promise.then(() => placeDetails);
+        }
+
         return new Promise<PlaceDetails>((resolve, reject) => setTimeout(() => resolve(placeDetails), delay));
     }
 
@@ -79,14 +103,44 @@ export class GoogleMapsClientStub implements MapsClient {
         GoogleMapsClientStub.addressesDelay = addressesDelay;
     }
 
+    static setAddressesPromise(addresses: Array<Address>) {
+        let resolve = null, reject = null;
+        GoogleMapsClientStub.setAddresses(addresses);
+        GoogleMapsClientStub.addressesPromise = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return {resolve, reject};
+    }
+
     static setGeocode(geocode: Geocode, geocodeDelay: number = 0) {
         GoogleMapsClientStub.geocode = [geocode];
         GoogleMapsClientStub.geocodeDelay = geocodeDelay;
     }
 
+    static setGeocodePromise(geocode: Geocode) {
+        let resolve = null, reject = null;
+        GoogleMapsClientStub.setGeocode(geocode);
+        GoogleMapsClientStub.geocodePromise = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return {resolve, reject};
+    }
+
     static setPlaceDetails(placeDetails: PlaceDetails, placeDetailsDelay: number = 0) {
         GoogleMapsClientStub.placeDetails = placeDetails;
         GoogleMapsClientStub.placeDetailsDelay = placeDetailsDelay;
+    }
+
+    static setPlaceDetailsPromise(placeDetails: PlaceDetails) {
+        let resolve = null, reject = null;
+        GoogleMapsClientStub.setPlaceDetails(placeDetails);
+        GoogleMapsClientStub.placeDetailsPromise = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return {resolve, reject};
     }
 
     static reset() {


### PR DESCRIPTION
Not using timers anymore. Improved stub a bit, and now it supports controlling the sequence of requests.