### PR TITLE
Add optional dataHook prop name

### DIFF
--- a/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
+++ b/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
@@ -21,14 +21,26 @@ export function enzymeTestkitFactoryCreator<T extends BaseDriver> (driverFactory
   };
 }
 
+export interface Options {
+  withoutDataHook?: boolean;
+  /** The dataHookPropName exists in order to support legacy CamelCase `dataHook`
+   *  which is used in Wix-Style-React, while the current prop name used in
+   * `wix-ui-core` is snake-case `data-hook`.
+   * */
+  dataHookPropName?: 'data-hook' | 'dataHook';
+}
+
+/**
+ * Checks if the given Element accepts a data hook, and that the testkit factory finds the component's root element using that data hook.
+ *
+ * This method supports both new snake-case and legacy camelCase data hook prop name (e.g `data-hook` and `dataHook`).
+ * The default is to check by both prop name options.
+ */
 export function isEnzymeTestkitExists<T extends BaseDriver> (
   Element: React.ReactElement<any>,
   testkitFactory: (obj: WrapperData) => T,
   mount: MountFunctionType,
-  options?: {
-    withoutDataHook?: boolean,
-    dataHookPropName?: string
-  } ) {
+  options?: Options ) {
 
   const withoutDataHook = (options && options.withoutDataHook) || false;
   const dataHookPropName = (options && options.dataHookPropName);

--- a/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
+++ b/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
@@ -21,9 +21,20 @@ export function enzymeTestkitFactoryCreator<T extends BaseDriver> (driverFactory
   };
 }
 
-export function isEnzymeTestkitExists<T extends BaseDriver> (Element: React.ReactElement<any>, testkitFactory: (obj: WrapperData) => T, mount: MountFunctionType, options = {withoutDataHook: false}) {
-  const dataHook = options.withoutDataHook ? '' : 'myDataHook';
-  const elementToRender = React.cloneElement(Element, {dataHook, 'data-hook': dataHook});
+export function isEnzymeTestkitExists<T extends BaseDriver> (
+  Element: React.ReactElement<any>,
+  testkitFactory: (obj: WrapperData) => T,
+  mount: MountFunctionType,
+  options?: {
+    withoutDataHook?: boolean,
+    dataHookPropName?: string
+  } ) {
+
+  const withoutDataHook = (options && options.withoutDataHook) || false;
+  const dataHookPropName = (options && options.dataHookPropName);
+  const dataHook = withoutDataHook ? '' : 'myDataHook';
+  const extraProps = dataHookPropName ? {[dataHookPropName]: dataHook} : {dataHook, 'data-hook': dataHook};
+  const elementToRender = React.cloneElement(Element , extraProps);
   const wrapper = mount(elementToRender);
   const testkit = testkitFactory({wrapper, dataHook});
   return testkit.exists();

--- a/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
+++ b/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
@@ -40,14 +40,38 @@ export function isEnzymeTestkitExists<T extends BaseDriver> (
   Element: React.ReactElement<any>,
   testkitFactory: (obj: WrapperData) => T,
   mount: MountFunctionType,
-  options?: Options ) {
+  options: Options = {}) {
+    return isEnzymeTestkitExistsInternal({Element, testkitFactory, mount, ...options});
+}
 
-  const withoutDataHook = (options && options.withoutDataHook) || false;
-  const dataHookPropName = (options && options.dataHookPropName);
+/**
+ * This internal function is only in order to allow separate defaults to each options.
+ */
+function isEnzymeTestkitExistsInternal<T extends BaseDriver> (
+  {
+    Element,
+    testkitFactory,
+    mount,
+    withoutDataHook = false,
+    dataHookPropName
+  }: FlatOptions<T>) {
+
   const dataHook = withoutDataHook ? '' : 'myDataHook';
   const extraProps = dataHookPropName ? {[dataHookPropName]: dataHook} : {dataHook, 'data-hook': dataHook};
   const elementToRender = React.cloneElement(Element , extraProps);
   const wrapper = mount(elementToRender);
   const testkit = testkitFactory({wrapper, dataHook});
   return testkit.exists();
+}
+
+interface FlatOptions<T extends BaseDriver> {
+  Element: React.ReactElement<any>;
+  testkitFactory: (obj: WrapperData) => T;
+  mount: MountFunctionType;
+  withoutDataHook?: boolean;
+  /** The dataHookPropName exists in order to support legacy CamelCase `dataHook`
+   *  which is used in Wix-Style-React, while the current prop name used in
+   * `wix-ui-core` is snake-case `data-hook`.
+   * */
+  dataHookPropName?: 'data-hook' | 'dataHook';
 }

--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -11,11 +11,14 @@ export function testkitFactoryCreator<T extends BaseDriver> (driverFactory: Driv
   };
 }
 
-export function isTestkitExists<T extends BaseDriver> (Element: React.ReactElement<any>, testkitFactory: (obj: {wrapper: any, dataHook: string}) => T) {
+export function isTestkitExists<T extends BaseDriver> (Element: React.ReactElement<any>, testkitFactory: (obj: {wrapper: any, dataHook: string}) => T, options?: {dataHookPropName?: string}) {
   const div = document.createElement('div');
   const dataHook = 'myDataHook';
-
-  const elementToRender = React.cloneElement(Element, {'data-hook': dataHook, dataHook});
+  const dataHookPropName = options && options.dataHookPropName;
+  const extraProps = dataHookPropName ?
+    {[dataHookPropName]: dataHook} :
+    {'data-hook': dataHook, dataHook}; // For backward compatibility add dataHook which is used in Wix-Style-React
+  const elementToRender = React.cloneElement(Element, extraProps);
   const renderedElement = ReactTestUtils.renderIntoDocument(<div>{elementToRender}</div>);
   const wrapper = div.appendChild((renderedElement as any));
   const testkit = testkitFactory({wrapper, dataHook});

--- a/packages/wix-ui-test-utils/test/testkit-helpers.spec.tsx
+++ b/packages/wix-ui-test-utils/test/testkit-helpers.spec.tsx
@@ -16,7 +16,19 @@ describe('isTestkitExists', () => {
     expect(isTestkitExists(<MyComp/>, testkitFactoryCreator(driver))).toEqual(true);
   });
 
+  it('vanilla should exist using data-hook only', () => {
+    expect(isTestkitExists(<MyComp/>, testkitFactoryCreator(driver), {dataHookPropName: 'data-hook'})).toEqual(true);
+  });
+
   it('enzyme should exist', () => {
     expect(isEnzymeTestkitExists(<MyComp/>, enzymeTestkitFactoryCreator(driver), mount)).toEqual(true);
+  });
+
+  it('enzyme should exist without data-hook value', () => {
+    expect(isEnzymeTestkitExists(<MyComp/>, enzymeTestkitFactoryCreator(driver), mount, {withoutDataHook: true})).toEqual(true);
+  });
+
+  it('enzyme should exist using data-hook prop name only', () => {
+    expect(isEnzymeTestkitExists(<MyComp/>, enzymeTestkitFactoryCreator(driver), mount, {dataHookPropName: 'data-hook'})).toEqual(true);
   });
 });


### PR DESCRIPTION
Motivation is to allow using the teskit method `isTestkitExists()` without rendering the Element with a `dataHook` prop, which causes a Warning like:
```
React does not recognize the `dataHook` prop on a DOM element. If you intentionally want it
 to appear in the DOM as a custom attribute, spell it as lowercase `datahook` instead. If you accidentally
 passed it from a parent component, remove it from the DOM element.
          in button (created by Button)
          in Button
          in div
```

This camelCase dataHook is needed only in WSR.
