### PR TITLE
[WIP] - Upgrade to yoshi_2 (and storybook 4)

### DIFF
--- a/packages/wix-ui-core/.storybook/webpack.config.js
+++ b/packages/wix-ui-core/.storybook/webpack.config.js
@@ -1,8 +1,7 @@
-const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js');
 const wixStorybookConfig = require('yoshi/config/webpack.config.storybook');
 
-module.exports = (config, env) => {
-  const newConfig = wixStorybookConfig(genDefaultConfig(config, env));
+module.exports = (config, env, defaultConfig) => {
+  const newConfig = wixStorybookConfig(defaultConfig);
 
   newConfig.module.rules.push({
     test: /\.story\.[j|t]sx?$/,

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -49,8 +49,8 @@
     "wix-ui-test-utils": "^1.0.0"
   },
   "devDependencies": {
-    "@storybook/addon-options": "^3.3.7",
-    "@storybook/react": "^3.3.7",
+    "@storybook/addon-options": "^4.0.0-alpha.3",
+    "@storybook/react": "^4.0.0-alpha.3",
     "@types/classnames": "^2.2.3",
     "@types/enzyme": "^3.1.9",
     "@types/jest": "^22.1.1",
@@ -79,7 +79,7 @@
     "wix-eventually": "latest",
     "wix-storybook-utils": "^1.0.0",
     "wix-ui-icons-common": "^1.0.0",
-    "yoshi": "^1.2.0"
+    "yoshi": "^2.1.3"
   },
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Still getting an error with `stylable-webpack-plugin`.

Looking into it, we discovered that in this line the `chunk.entryModule` sometimes is undefined.
In my example this line runs 2 times, once with a chunk called ‘preview’ in which entryModule is defined. And a second time with a chunk called `vendor~preview` in which the entryModule is NOT defined.

We tried Not to `addStylableModuleDependenty` when the entryModule is undefined, and our `build_storybook` passed (not sure yet if the results are proper).