### PR TITLE
chore(StoryPage): support explicit displayName

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -328,6 +328,7 @@ export default class extends Component {
           />
 
         <Code
+          dataHook="metadata-codeblock"
           component={React.createElement(component, codeProps)}
           displayName={this.parsedComponent.displayName}
           />

--- a/packages/wix-storybook-utils/src/StoryNew/index.js
+++ b/packages/wix-storybook-utils/src/StoryNew/index.js
@@ -10,6 +10,7 @@ export default ({
   category,
   component,
   storyName,
+  displayName,
   componentProps,
   examples,
   exampleProps,
@@ -41,6 +42,7 @@ export default ({
               componentProps,
               exampleProps,
               exampleImport,
+              displayName,
               examples,
               metadata: _metadata,
               config: _config

--- a/packages/wix-storybook-utils/src/StoryPage/index.js
+++ b/packages/wix-storybook-utils/src/StoryPage/index.js
@@ -52,7 +52,7 @@ const StoryPage = ({
   examples
 }) => {
   const visibleDisplayName = displayName || metadata.displayName;
-  const visibleMetadata = { ...metadata, displayName: visibleDisplayName };
+  const visibleMetadata = {...metadata, displayName: visibleDisplayName};
 
   return (
     <TabbedView tabs={tabs(metadata)}>

--- a/packages/wix-storybook-utils/src/StoryPage/index.js
+++ b/packages/wix-storybook-utils/src/StoryPage/index.js
@@ -46,53 +46,60 @@ const StoryPage = ({
   config,
   component,
   componentProps,
+  displayName,
   exampleProps,
   exampleImport,
   examples
-}) =>
-  <TabbedView tabs={tabs(metadata)}>
-    <div className={styles.usage}>
-      <Markdown
-        dataHook="metadata-readme"
-        source={metadata.readme || `# \`<${metadata.displayName}/>\``}
-        />
+}) => {
+  const visibleDisplayName = displayName || metadata.displayName;
+  const visibleMetadata = { ...metadata, displayName: visibleDisplayName };
 
-      {metadata.displayName &&
-        <div className={styles.githubLink}>
-          <TextLink
-            link={`${config.repoBaseURL}${metadata.displayName}`}
-            target="blank"
-            >
-            View source
-          </TextLink>
-        </div>
-      }
+  return (
+    <TabbedView tabs={tabs(metadata)}>
+      <div className={styles.usage}>
+        <Markdown
+          dataHook="metadata-readme"
+          source={metadata.readme || `# \`<${visibleDisplayName}/>\``}
+          />
 
-      <CodeBlock
-        dataHook="metadata-import"
-        source={importString({
-          config,
-          metadata,
-          exampleImport
-        })}
-        />
+        { (displayName || metadata.displayName) &&
+          <div className={styles.githubLink}>
+            <TextLink
+              link={`${config.repoBaseURL}${visibleDisplayName}`}
+              target="blank"
+              >
+              View source
+            </TextLink>
+          </div>
+        }
 
-      <AutoExample
-        component={component}
-        parsedSource={metadata}
-        componentProps={componentProps}
-        exampleProps={exampleProps}
-        />
+        <CodeBlock
+          dataHook="metadata-import"
+          source={importString({
+            config,
+            metadata: visibleMetadata,
+            exampleImport
+          })}
+          />
 
-      {examples}
-    </div>
+        <AutoExample
+          component={component}
+          parsedSource={visibleMetadata}
+          componentProps={componentProps}
+          exampleProps={exampleProps}
+          />
 
-    <AutoDocs parsedSource={metadata}/>
+        {examples}
+      </div>
 
-    { metadata.readmeTestkit && <Markdown source={metadata.readmeTestkit}/> }
+      <AutoDocs parsedSource={metadata}/>
 
-    { metadata.readmeAccessibility && <Markdown source={metadata.readmeAccessibility}/> }
-  </TabbedView>;
+      { metadata.readmeTestkit && <Markdown source={metadata.readmeTestkit}/> }
+
+      { metadata.readmeAccessibility && <Markdown source={metadata.readmeAccessibility}/> }
+    </TabbedView>
+  );
+};
 
 StoryPage.propTypes = {
   metadata: PropTypes.object,
@@ -103,6 +110,7 @@ StoryPage.propTypes = {
   }),
   component: PropTypes.any,
   componentProps: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  displayName: PropTypes.string,
   exampleProps: PropTypes.object,
 
   /** custom string to be displayed in place of import example

--- a/packages/wix-storybook-utils/src/StoryPage/index.test.js
+++ b/packages/wix-storybook-utils/src/StoryPage/index.test.js
@@ -5,7 +5,7 @@ const testkit = new Testkit();
 describe('StoryPage', () => {
   it('should render readme', () => {
     testkit.when.created();
-    expect(testkit.get.readme().prop('source')).toMatch(/componentName/);
+    expect(testkit.get.readme()).toMatch(/componentName/);
   });
 
   describe('given `exampleImport`', () => {
@@ -41,7 +41,7 @@ describe('StoryPage', () => {
     it('should replace %componentName with metadata.displayName', () => {
       const props = {
         config: {
-          importFormat: `import {%componentName} from '%moduleName/%componentName';`,
+          importFormat: 'import {%componentName} from \'%moduleName/%componentName\';',
           moduleName: 'wix-ui-core'
         },
         metadata: {
@@ -50,7 +50,26 @@ describe('StoryPage', () => {
         }
       };
       testkit.when.created(props);
-      expect(testkit.get.import()).toMatch(`import {BesterestestComponent} from 'wix-ui-core/BesterestestComponent';`);
+      expect(testkit.get.import()).toMatch('import {BesterestestComponent} from \'wix-ui-core/BesterestestComponent\';');
+    });
+  });
+
+  describe('given explicit displayName', () => {
+    it('should show it instead of using one from `metadata`', () => {
+      const props = {
+        metadata: {
+          props: {}
+        },
+        config: {},
+        displayName: 'well hello there'
+      };
+
+      testkit.when.created(props);
+
+      expect(testkit.get.readme()).toMatch(/<well hello there\/>/);
+      expect(testkit.get.import()).toMatch(/well hello there/);
+
+      expect(testkit.get.codeBlock()).toMatch(/<well hello there \/>/);
     });
   });
 });

--- a/packages/wix-storybook-utils/src/StoryPage/index.testkit.js
+++ b/packages/wix-storybook-utils/src/StoryPage/index.testkit.js
@@ -25,9 +25,12 @@ export default class {
 
   get = {
     readme: () =>
-      this.component.find('[dataHook="metadata-readme"]'),
+      this.component.find('[dataHook="metadata-readme"]').prop('source'),
 
     import: () =>
-      this.component.find('[dataHook="metadata-import"]').find(Markdown).prop('source')
+      this.component.find('[dataHook="metadata-import"]').find(Markdown).prop('source'),
+
+    codeBlock: () =>
+      this.component.find('[dataHook="metadata-codeblock"]').find(Markdown).prop('source')
   }
 }


### PR DESCRIPTION
story config now supports explicit `displayName`. if it is set, the one from parsed data will not be used.

this is to circumvent bug in react-docgen-typescript which ignores `displayName` and falls back on file name instead https://github.com/styleguidist/react-docgen-typescript/issues/82

not the best solution in the world, but will hold for a while