### PR TITLE
Wix storybook utils/unfiltered example props

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -51,7 +51,6 @@
     "babel-runtime": "^6.25.0",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",
-    "deep-eql": "^3.0.1",
     "github-markdown-css": "^2.9.0",
     "highlight.js": "^9.12.0",
     "import-path": "latest",

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -178,12 +178,6 @@ export default class extends Component {
       ) :
       props;
 
-
-  mapControllableProps = fn =>
-    Object
-      .keys(this.parsedComponent.props)
-      .map(key => fn(this.parsedComponent.props[key], key));
-
   setProp = (key, value) =>
     this.setState({propsState: {...this.state.propsState, [key]: value}});
 
@@ -200,7 +194,11 @@ export default class extends Component {
         }
 
         if (this.props.exampleProps[propKey]) {
-          return <div className={classNames}>{this.state.funcValues[propKey] || 'Interaction preview'}</div>;
+          return (
+            <div className={classNames}>
+              {this.state.funcValues[propKey] || 'Interaction preview'}
+            </div>
+          );
         }
       }
     },
@@ -261,8 +259,6 @@ export default class extends Component {
   }
 
   render() {
-    const component = this.props.component;
-
     const functionExampleProps = Object.keys(this.props.exampleProps).filter(
       prop =>
         this.parsedComponent.props[prop] &&
@@ -300,22 +296,24 @@ export default class extends Component {
     };
 
     if (!this.props.isInteractive) {
-      return React.createElement(component, componentProps);
+      return React.createElement(this.props.component, componentProps);
     }
 
     return (
       <Wrapper dataHook="auto-example">
         <Options>
-          { this.mapControllableProps((prop, key) =>
-            <Option
-              {...{
-                key,
-                label: key,
-                value: componentProps[key],
-                onChange: value => this.setProp(key, value),
-                children: this.getPropControlComponent(key, prop.type)
-              }}
-              />
+          { Object
+              .entries(this.parsedComponent.props)
+              .map(([key, prop]) =>
+                <Option
+                  key={key}
+                  {...{
+                    label: key,
+                    value: componentProps[key],
+                    onChange: value => this.setProp(key, value),
+                    children: this.getPropControlComponent(key, prop.type)
+                  }}
+                  />
           ) }
         </Options>
 
@@ -324,12 +322,12 @@ export default class extends Component {
           isDarkBackground={this.state.isDarkBackground}
           onToggleRtl={isRtl => this.setState({isRtl})}
           onToggleBackground={isDarkBackground => this.setState({isDarkBackground})}
-          children={React.createElement(component, componentProps)}
+          children={React.createElement(this.props.component, componentProps)}
           />
 
         <Code
           dataHook="metadata-codeblock"
-          component={React.createElement(component, codeProps)}
+          component={React.createElement(this.props.component, codeProps)}
           displayName={this.parsedComponent.displayName}
           />
       </Wrapper>

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -215,14 +215,6 @@ export default class extends Component {
     },
 
     {
-      types: ['string', 'number', /ReactText/, 'arrayOf', 'union', 'node', 'ReactNode'],
-      controller: ({propKey}) =>
-        this.props.exampleProps[propKey] ?
-          <List values={this.props.exampleProps[propKey]}/> :
-          <Input/>
-    },
-
-    {
       types: ['bool', 'Boolean'],
       controller: () => <Toggle/>
     },
@@ -231,6 +223,11 @@ export default class extends Component {
       types: ['enum'],
       controller: ({type}) =>
         <List values={type.value.map(({value}) => stripQuotes(value))}/>
+    },
+
+    {
+      types: ['string', 'number', /ReactText/, 'arrayOf', 'union', 'node', 'ReactNode'],
+      controller: () => <Input/>
     }
   ]
 
@@ -239,12 +236,14 @@ export default class extends Component {
       return <List values={this.props.exampleProps[propKey]}/>;
     }
 
-    const {controller = () => null} =
-      this.propControllers.find(({types}) =>
+    const propControllerCandidate = this.propControllers
+      .find(({types}) =>
         types.some(t => ensureRegexp(t).test(type.name))
       );
 
-    return controller({propKey, type});
+    return propControllerCandidate && propControllerCandidate.controller ?
+      propControllerCandidate.controller({propKey, type}) :
+      <Input/>;
   }
 
   render() {

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -22,7 +22,11 @@ const stripQuotes = string => {
 };
 
 const matchFuncProp = typeName =>
-  typeName === 'func' || typeName.match(/event/) || typeName.match(/\) => void$/);
+  [
+    /^func/,
+    /event/,
+    /\) => void$/
+  ].some(needle => typeName.match(needle));
 
 const ensureRegexp = a =>
   a instanceof RegExp ? a : new RegExp(a);
@@ -204,7 +208,7 @@ export default class extends Component {
     },
 
     {
-      types: ['string', 'number', /ReactText/],
+      types: ['string', 'number', /ReactText/, 'arrayOf', 'union', 'node', 'ReactNode'],
       controller: ({propKey}) =>
         this.props.exampleProps[propKey] ?
           <NodesList values={this.props.exampleProps[propKey]}/> :
@@ -217,39 +221,17 @@ export default class extends Component {
     },
 
     {
-      types: ['union'],
-
-      controller: ({propKey}) =>
-        this.props.exampleProps[propKey] ?
-          <NodesList values={this.props.exampleProps[propKey]}/> :
-          <Input/>
-    },
-
-    {
-      types: ['node', 'ReactNode'],
-      controller: ({propKey}) =>
-        this.props.exampleProps[propKey] ?
-          <NodesList values={this.props.exampleProps[propKey]}/> :
-          <Input/>
-    },
-
-    {
       types: ['enum'],
       controller: ({type}) =>
         <List values={type.value.map(({value}) => stripQuotes(value))}/>
-    },
-
-    {
-      types: ['arrayOf'],
-      controller: ({propKey}) => {
-        if (this.props.exampleProps[propKey]) {
-          return <NodesList values={this.props.exampleProps[propKey]}/>;
-        }
-      }
     }
   ]
 
   getPropControlComponent = (propKey, type) => {
+    if (!matchFuncProp(type.name) && this.props.exampleProps[propKey]) {
+      return <NodesList values={this.props.exampleProps[propKey]}/>;
+    }
+
     const pretender =
       this.propControllers.find(({types}) =>
         types.some(t => ensureRegexp(t).test(type.name))

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -64,7 +64,7 @@ describe('AutoExample', () => {
           }
         },
         exampleProps: {
-          someProp: [1, 2, 3]
+          someProp: [1, 2, 3, 4, 5]
         }
       });
 

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -54,7 +54,7 @@ describe('AutoExample', () => {
       expect(option.children.props.children).toBe('Interaction preview');
     });
 
-    it.skip('should display NodesList regardless of type in parsedSource', () => {
+    it('should display NodesList regardless of type in parsedSource', () => {
       const driver = new Driver();
       driver.when.created({
         parsedSource: {

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -7,18 +7,9 @@ import AutoExample from './';
 class Driver {
   component;
 
-  constructor(parsedSource) {
-    this.parsedSource = parsedSource;
-  }
-
   when = {
     created: props =>
-      this.component = mount(
-        <AutoExample
-          parsedSource={this.parsedSource}
-          {...props}
-          />
-      )
+      this.component = mount(<AutoExample {...props}/>)
   }
 
   get = {
@@ -26,18 +17,59 @@ class Driver {
   }
 }
 
-const parsedSource = {
-  displayName: 'TestComponent',
-  props: {
-    test: {type: 'string'}
-  }
-};
-
-const driver = new Driver(parsedSource);
-
 describe('AutoExample', () => {
-  it('should have one option', () => {
-    driver.when.created();
-    expect(driver.get.options().length).toBe(1);
+  it('should have two options', () => {
+    const driver = new Driver();
+    driver.when.created({
+      parsedSource: {
+        displayName: 'TestComponent',
+        props: {
+          stringProp: {type: {name: 'string'}},
+          functionProp: {type: {name: 'func'}}
+        }
+      }
+    });
+    const [prop1, prop2] = driver.get.options();
+
+    expect(prop1.props.label).toBe('stringProp');
+    expect(prop2.props.label).toBe('functionProp');
+  });
+
+  describe('exampleProps', () => {
+    it('should display "Interaction preview" for function type', () => {
+      const driver = new Driver();
+      driver.when.created({
+        parsedSource: {
+          displayName: 'TestComponent',
+          props: {
+            functionProp: {type: {name: 'func'}}
+          }
+        },
+        exampleProps: {
+          functionProp: () => {}
+        }
+      });
+
+      const option = driver.get.options().props();
+      expect(option.children.props.children).toBe('Interaction preview');
+    });
+
+    it.skip('should display NodesList regardless of type in parsedSource', () => {
+      const driver = new Driver();
+      driver.when.created({
+        parsedSource: {
+          displayName: 'TestComponent',
+          props: {
+            someProp: {type: {name: 'unknown type name, something really obscure'}}
+          }
+        },
+        exampleProps: {
+          someProp: [1, 2, 3]
+        }
+      });
+
+      const option = driver.get.options().props();
+      expect(option.children).not.toBe(null);
+    });
   });
 });

--- a/packages/wix-storybook-utils/src/AutoExample/no-value-type.js
+++ b/packages/wix-storybook-utils/src/AutoExample/no-value-type.js
@@ -1,0 +1,8 @@
+/**
+  * this is used to mark a prop for removal.
+  *
+  * i cannot use null nor undefined, nor false, nor 0 or anything alike since
+  * all of these are valid values
+  */
+
+export default '@@NO-VALUE-TYPE@@';

--- a/packages/wix-storybook-utils/src/FormComponents/index.js
+++ b/packages/wix-storybook-utils/src/FormComponents/index.js
@@ -49,7 +49,7 @@ const Option = ({label, value, children, onChange}) => {
       </Col>
 
       <Col span={6}>
-        {React.cloneElement(children, {value, onChange})}
+        {React.cloneElement(children, {value: value && value.toString(), onChange})}
       </Col>
     </Row>) : null;
 };

--- a/packages/wix-storybook-utils/src/FormComponents/index.js
+++ b/packages/wix-storybook-utils/src/FormComponents/index.js
@@ -1,17 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isEqual from 'deep-eql';
 import classnames from 'classnames';
 
 import {Container, Row, Col} from 'wix-style-react/Grid';
 import {default as WixInput} from 'wix-style-react/Input';
 import ToggleSwitch from 'wix-style-react/ToggleSwitch';
-import {default as WixRadioGroup} from 'wix-style-react/RadioGroup';
-import Dropdown from 'wix-style-react/Dropdown';
 import Text from 'wix-style-react/Text';
 
 import Markdown from '../Markdown';
 import ComponentSource from '../ComponentSource';
+import List from './list';
 
 import styles from './styles.scss';
 
@@ -41,26 +39,33 @@ Options.propTypes = {
 };
 
 
-const Option = ({label, value, children, onChange}) => {
-  return children ?
-    (<Row className={styles.option}>
+const Option = ({label, value, children, onChange, defaultValue}) =>
+  children ?
+    <Row className={styles.option}>
       <Col span={6}>
         <Markdown source={`\`${label}\``}/>
       </Col>
 
       <Col span={6}>
-        {React.cloneElement(children, {value: value && value.toString(), onChange})}
+        { React.cloneElement(
+          children,
+          {
+            value: children.type === 'div' ? value.toString() : value,
+            defaultValue,
+            onChange
+          }
+        ) }
       </Col>
-    </Row>) : null;
-};
+    </Row> :
+    null;
 
 Option.propTypes = {
   label: PropTypes.string,
   value: PropTypes.any,
+  defaultValue: PropTypes.any,
   children: PropTypes.node,
   onChange: PropTypes.func
 };
-
 
 const Preview = ({children, isRtl, onToggleRtl, isDarkBackground, onToggleBackground}) =>
   <Col span={6}>
@@ -128,71 +133,6 @@ Toggle.propTypes = {
   onChange: PropTypes.func
 };
 
-
-const List = ({value, values = [], onChange, ...props}) =>
-  values.length > 3 ?
-    <Dropdown
-      options={values.map(v => ({id: v, value: v}))}
-      selectedId={value}
-      onSelect={({value}) => onChange(value)}
-      /> :
-    <WixRadioGroup
-      value={value}
-      onChange={onChange}
-      {...props}
-      >
-      {values.map((value, i) =>
-        <WixRadioGroup.Radio
-          key={i}
-          value={value}
-          >
-          <Markdown source={`\`${value}\``}/>
-        </WixRadioGroup.Radio>
-      )}
-    </WixRadioGroup>;
-
-List.propTypes = {
-  value: PropTypes.string,
-  values: PropTypes.arrayOf(PropTypes.string),
-  onChange: PropTypes.func
-};
-
-class NodesList extends React.Component {
-  view = e => typeof e === 'function' ? React.createElement(e) : e;
-
-  render() {
-    const {value = {}, values = [], onChange} = this.props;
-
-    return values.length > 3 ?
-      <Dropdown
-        options={values.map((value, id) => ({id, value: this.view(value)}))}
-        selectedId={values.findIndex(({type}) => isEqual(type, value.type)) || 0}
-        onSelect={({value}) => onChange(value)}
-        valueParser={({value}) => typeof value.type === 'string' ? value.type : value.type.name}
-        /> :
-        <WixRadioGroup
-          value={this.state && this.state.selected}
-          onChange={ev => {
-            this.setState({selected: ev});
-            onChange(this.view(values[ev]));
-          }}
-          >
-          {values.map((value, i) =>
-            <WixRadioGroup.Radio key={i} value={i}>
-              {this.view(values[i])}
-            </WixRadioGroup.Radio>
-          )}
-        </WixRadioGroup>;
-  }
-}
-
-NodesList.propTypes = {
-  value: PropTypes.node,
-  values: PropTypes.arrayOf(PropTypes.any),
-  onChange: PropTypes.func
-};
-
-
 const Input = ({value, onChange, ...props}) =>
   <WixInput
     value={value}
@@ -227,6 +167,5 @@ export {
   Toggle,
   Input,
   List,
-  Code,
-  NodesList
+  Code
 };

--- a/packages/wix-storybook-utils/src/FormComponents/list.js
+++ b/packages/wix-storybook-utils/src/FormComponents/list.js
@@ -28,15 +28,14 @@ export default class List extends React.Component {
   }
 
   componentWillMount() {
-    const options = this.createOptions(this.props.values);
-    this.setState({options});
+    this.setState({options: this.createOptions()});
   }
 
   view = e => typeof e === 'function' ? React.createElement(e) : e;
 
-  createOptions = values =>
+  createOptions = () =>
     (this.props.defaultValue ? [this.props.defaultValue] : [])
-      .concat(values)
+      .concat(this.props.values)
       .map((option, id) => ({
         id: option.id || id,
 
@@ -44,7 +43,7 @@ export default class List extends React.Component {
         // however, it's possible `value` is complex react component. instead of
         // displaying that component, we save it in `realValue` and
         // show `value` as some string representation of component instead
-        value: option.label || '' + option,
+        value: option.label || (option.type && option.type.name) || '' + option,
         realValue: isUndefined(option.value) ? option : option.value
       }));
 
@@ -100,6 +99,7 @@ export default class List extends React.Component {
         selectedId={this.getSelectedId()}
         onSelect={this.onOptionChange}
         onChange={this.onFilterChange}
+        placeholder={this.props.defaultValue || ''}
         {...(this.state.currentFilter ? {suffix: this.clearButton} : {})}
         />
     );

--- a/packages/wix-storybook-utils/src/FormComponents/list.js
+++ b/packages/wix-storybook-utils/src/FormComponents/list.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import CloseIcon from 'wix-style-react/dist/src/Icons/dist/components/CloseThin';
+import InputWithOptions from 'wix-style-react/InputWithOptions';
+import {default as WixRadioGroup} from 'wix-style-react/RadioGroup';
+
+import NO_VALUE_TYPE from '../AutoExample/no-value-type';
+
+const isUndefined = a => typeof a === 'undefined';
+
+export default class List extends React.Component {
+  static propTypes = {
+    value: PropTypes.any,
+    defaultValue: PropTypes.any,
+    values: PropTypes.arrayOf(PropTypes.any),
+    onChange: PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentValue: {},
+      currentFilter: props.defaultValue || '',
+      isFiltering: false
+    };
+  }
+
+  componentWillMount() {
+    const options = this.createOptions(this.props.values);
+    this.setState({options});
+  }
+
+  view = e => typeof e === 'function' ? React.createElement(e) : e;
+
+  createOptions = values =>
+    (this.props.defaultValue ? [this.props.defaultValue] : [])
+      .concat(values)
+      .map((option, id) => ({
+        id: option.id || id,
+
+        // `value` is used in InputWithOptions as displayed value in dropdown
+        // however, it's possible `value` is complex react component. instead of
+        // displaying that component, we save it in `realValue` and
+        // show `value` as some string representation of component instead
+        value: option.label || '' + option,
+        realValue: isUndefined(option.value) ? option : option.value
+      }));
+
+
+  getFilteredOptions = () =>
+    this.state.isFiltering ?
+      this.state.options
+        .filter(({value}) =>
+          this.state.currentFilter.length ?
+            value.toLowerCase().includes(this.state.currentFilter) :
+            true
+        ) : this.state.options;
+
+  clearValue = () =>
+    this.setState(
+      {currentValue: {}, currentFilter: ''},
+      () => this.props.onChange(NO_VALUE_TYPE)
+    );
+
+  clearButton =
+    <span
+      onClick={this.clearValue}
+      style={{color: '#3899ec', cursor: 'pointer'}}
+      children={<CloseIcon size="8px"/>}
+      />;
+
+  getSelectedId = () => {
+    const id = this.state.options.find(option => option.id === this.state.currentValue.id);
+    return id || 0;
+  }
+
+  onOptionChange = ({id}) => {
+    const currentValue = this.state.options.find(option => option.id === id) || {};
+
+    this.setState(
+      {
+        currentValue,
+        currentFilter: currentValue.value,
+        isFiltering: false
+      },
+      () => this.props.onChange(currentValue.realValue)
+    );
+  }
+
+  onFilterChange = ({target: {value: currentFilter}}) =>
+    this.setState({currentFilter, isFiltering: true})
+
+  dropdown() {
+    return (
+      <InputWithOptions
+        value={this.state.currentFilter}
+        options={this.getFilteredOptions()}
+        selectedId={this.getSelectedId()}
+        onSelect={this.onOptionChange}
+        onChange={this.onFilterChange}
+        {...(this.state.currentFilter ? {suffix: this.clearButton} : {})}
+        />
+    );
+  }
+
+  radios() {
+    const {values, onChange} = this.props;
+
+    return (
+      <WixRadioGroup
+        value={this.state && this.state.selected}
+        onChange={ev => {
+          this.setState({selected: ev});
+          onChange(this.view(values[ev]));
+        }}
+        >
+        {values.map((value, i) =>
+          <WixRadioGroup.Radio
+            key={i}
+            value={i}
+            children={this.view(values[i])}
+            />
+        )}
+      </WixRadioGroup>
+    );
+  }
+
+  render() {
+    return this.props.values.length > 3 ? this.dropdown() : this.radios();
+  }
+}
+

--- a/packages/wix-storybook-utils/src/FormComponents/list.js
+++ b/packages/wix-storybook-utils/src/FormComponents/list.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import CloseIcon from 'wix-style-react/dist/src/Icons/dist/components/CloseThin';
 import InputWithOptions from 'wix-style-react/InputWithOptions';
 import {default as WixRadioGroup} from 'wix-style-react/RadioGroup';
+import Button from 'wix-style-react/Button';
 
 import NO_VALUE_TYPE from '../AutoExample/no-value-type';
 
@@ -30,8 +31,6 @@ export default class List extends React.Component {
   componentWillMount() {
     this.setState({options: this.createOptions()});
   }
-
-  view = e => typeof e === 'function' ? React.createElement(e) : e;
 
   createOptions = () =>
     (this.props.defaultValue ? [this.props.defaultValue] : [])
@@ -63,16 +62,26 @@ export default class List extends React.Component {
       () => this.props.onChange(NO_VALUE_TYPE)
     );
 
-  clearButton =
+  clearIcon =
     <span
       onClick={this.clearValue}
       style={{color: '#3899ec', cursor: 'pointer'}}
       children={<CloseIcon size="8px"/>}
       />;
 
+  clearButton =
+    <div style={{padding: '1em 0'}}>
+      <Button
+        height="x-small"
+        theme="transparent"
+        children="Clear"
+        onClick={this.clearValue}
+        />
+    </div>;
+
   getSelectedId = () => {
-    const id = this.state.options.find(option => option.id === this.state.currentValue.id);
-    return id || 0;
+    const selectedOption = this.state.options.find(option => option.id === this.state.currentValue.id) || {};
+    return selectedOption.id || 0;
   }
 
   onOptionChange = ({id}) => {
@@ -100,30 +109,29 @@ export default class List extends React.Component {
         onSelect={this.onOptionChange}
         onChange={this.onFilterChange}
         placeholder={this.props.defaultValue || ''}
-        {...(this.state.currentFilter ? {suffix: this.clearButton} : {})}
+        {...(this.state.currentFilter ? {suffix: this.clearIcon} : {})}
         />
     );
   }
 
   radios() {
-    const {values, onChange} = this.props;
-
     return (
-      <WixRadioGroup
-        value={this.state && this.state.selected}
-        onChange={ev => {
-          this.setState({selected: ev});
-          onChange(this.view(values[ev]));
-        }}
-        >
-        {values.map((value, i) =>
-          <WixRadioGroup.Radio
-            key={i}
-            value={i}
-            children={this.view(values[i])}
-            />
-        )}
-      </WixRadioGroup>
+      <div>
+        <WixRadioGroup
+          value={this.state.currentValue.id}
+          onChange={id => this.onOptionChange({id})}
+          >
+          {this.state.options.map(({id, realValue}) =>
+            <WixRadioGroup.Radio
+              key={id}
+              value={id}
+              children={typeof realValue === 'function' ? React.createElement(realValue) : realValue}
+              />
+          )}
+        </WixRadioGroup>
+
+        { this.state.currentValue.value && this.clearButton }
+      </div>
     );
   }
 
@@ -131,4 +139,3 @@ export default class List extends React.Component {
     return this.props.values.length > 3 ? this.dropdown() : this.radios();
   }
 }
-

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -19,6 +19,7 @@ export default {
   },
 
   exampleProps: {
-    onClick: () => 'hai'
+    onClick: () => 'hai',
+    enabled: [true, false]
   }
 };


### PR DESCRIPTION
various improvements for `exampleProps` of AutoExample.

the behavior mostly remains the same with a few added features:
* "clear" button for radiogroup options (no more `['', 1,2]`, just `[1,2]`)
* "autocomplete" dropdown for many options (simple filtering)
* `exampleProps` now supports `{ label: 'some string', value: <div>component?</div> }`