### PR TITLE
wix-ui-core: [WIP] <Popover> - Multiple Popover CSS BUG

### DIFF
--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -2,6 +2,57 @@ import * as React from 'react';
 import {Popover} from '../src/components/Popover';
 import {Option} from '../src/baseComponents/DropdownOption';
 
+const exampleMargin = '50px';
+
+class MultiplePopoverExample extends React.Component<{},{open1:boolean}> {
+  state= {open1:true}
+
+  render() {
+    return (
+      <div>
+        <div>
+          <button onClick={()=>this.setState({open1:false})}> click to close 1 </button>
+        </div>
+        <div>
+          <Popover
+              shown={this.state.open1}
+              placement="right"
+              appendTo="window"
+              data-hook="storybook-popover-example-1"
+              showArrow
+              timeout={150}
+              >
+              <Popover.Element>
+                <div>element1</div>
+              </Popover.Element>
+              <Popover.Content>
+                <div>content1</div>
+              </Popover.Content>
+            </Popover>
+          </div>
+          <div>
+            <Popover
+              shown={true}
+              placement="right"
+              appendTo="window"
+              data-hook="storybook-popover-example-2"
+              showArrow
+              timeout={150}
+              >
+              <Popover.Element>
+                <div>element2</div>
+              </Popover.Element>
+              <Popover.Content>
+                <div>content2</div>
+              </Popover.Content>
+            </Popover>
+          </div>
+        </div>
+    );
+  }
+}
+
+
 export default {
   category: 'Components',
   storyName: 'Popover',
@@ -14,5 +65,14 @@ export default {
     // shown: true,
     showArrow: true,
     timeout: 150
-  }
+  },
+  examples: (
+    <div>
+      <h1>Examples2</h1>
+      <div style={{marginTop: exampleMargin, marginBottom: exampleMargin}}>
+        <MultiplePopoverExample/>
+      </div>
+    </div>
+  )
 };
+


### PR DESCRIPTION
Found a bug in Popover.
If you have multiple Popovers in a page,
In this case both attach to the window (I didn't test other attach strategies),
and you close one Popover, the the other Popover's css is gone !

I think it has something to do with our hack to apply/remove css from a portal.

To see the bug in action:
Open Popover's story (in this PR's storybook),
and under the examples part, click the button saying "Click to close 1"