### PR TITLE
Fix a warning about unknown pseudo-selector in TimePicker

### DIFF
--- a/packages/wix-ui-core/src/components/TimePicker/TimePicker.st.css
+++ b/packages/wix-ui-core/src/components/TimePicker/TimePicker.st.css
@@ -1,10 +1,17 @@
 :import {
-    -st-from: "../Input/Input.st.css";
-    -st-default: Input;
+  -st-from: "../Input/Input.st.css";
+  -st-default: Input;
+}
+
+:import {
+  -st-from: "./Tickers.st.css";
+  -st-default: Tickers;
 }
 
 .root {
-    -st-extends: Input;
+  -st-extends: Input;
 }
 
-.tickers {}
+.tickers {
+  -st-extends: Tickers;
+}


### PR DESCRIPTION
This:

![image](https://user-images.githubusercontent.com/415252/40587555-37904f82-61d9-11e8-8a0b-f7f483f9524a.png)
