### PR TITLE
wix-ui-core: <Popover> - Fix attachTo window

### DIFF
--- a/packages/wix-ui-core/src/components/Popover/Popover.e2e.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.e2e.ts
@@ -5,7 +5,7 @@ import * as autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 import {popoverTestkitFactory} from '../../testkit/protractor';
 
 describe('Popover', () => {
-  const storyUrl = createStoryUrl({kind: 'Components', story: 'Popover'});
+  const storyUrl = createStoryUrl({kind: 'Components', story: 'Popover', withExamples:false});
 
   beforeEach(() => browser.get(storyUrl));
   eyes.it('should exist', async () => {
@@ -14,6 +14,8 @@ describe('Popover', () => {
 
     await waitForVisibilityOf(driver.element(), 'Cannot find Popover');
     expect(await driver.element().isPresent()).toBe(true);
+    // NOTE: make sure the storyURL is has withExample=falase, otherwise,
+    // it might find false positive for an open contentElement.
     expect(await driver.isContentElementExists()).toBe(false);
     await autoExampleDriver.setProps({shown: true});
     expect(await driver.isContentElementExists()).toBe(true);

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -106,7 +106,6 @@ describe('Popover', () => {
         expect(document.body.classList).not.toContain(styles.root);
         wrapper.unmount();
       });
-
     });
 
     describe('viewport', () => {
@@ -173,8 +172,11 @@ describe('Popover', () => {
 
         wrapper.unmount();
       });
+
     });
   });
+
+
 
   describe('testkit', () => {
     it('should exist', () => {
@@ -187,4 +189,5 @@ describe('Popover', () => {
       expect(isEnzymeTestkitExists(createPopover(), enzymePopoverTestkitFactory, mount)).toBe(true);
     });
   });
+
 });

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -203,8 +203,6 @@ describe('Popover', () => {
     });
   });
 
-
-
   describe('testkit', () => {
     it('should exist', () => {
       expect(isTestkitExists(createPopover(), popoverTestkitFactory)).toBe(true);

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import {popoverDriverFactory} from './Popover.driver';
 import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {Popover, PopoverProps} from './';
-import {mount} from 'enzyme';
+import {Popover, PopoverProps, AppendTo} from './';
+import {Boundary} from 'popper.js';
+import {mount, ReactWrapper} from 'enzyme';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
 import * as eventually from 'wix-eventually';
 import {popoverTestkitFactory as enzymePopoverTestkitFactory} from '../../testkit/enzyme';
@@ -10,14 +11,23 @@ import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
 import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
 import {popoverTestkitFactory} from '../../testkit';
 import styles from './Popover.st.css';
+import {PopoverDriver} from '../../testkit/protractor';
 
-describe('Popover', () => {
+fdescribe('Popover', () => {
+  let wrapper;
+  
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
   const container = new ReactDOMTestContainer().unmountAfterEachTest();
 
   const render = container.createLegacyRenderer(popoverDriverFactory);
 
-  const renderWithEnzyme = jsx => {
-    const wrapper = mount(jsx, {attachTo: container.node});
+  const renderWithEnzyme = (jsx, {attachTo}) => {
+    wrapper = mount<PopoverProps,{}>(jsx, {attachTo});
     const driver = popoverDriverFactory({
       element: wrapper.find(Popover).getDOMNode(),
       eventTrigger: null
@@ -74,15 +84,16 @@ describe('Popover', () => {
   });
 
   it('should animate given timeout', async () => {
-    const {wrapper, driver} = renderWithEnzyme(createPopover({shown: true, timeout: 100}));
+    wrapper = mount(createPopover({shown: true, timeout: 100}));
+    const driver = popoverDriverFactory({element: wrapper.children().at(0).getDOMNode(), eventTrigger: null});
     wrapper.setProps({shown: false});
     expect(driver.isContentElementExists()).toBeTruthy();
     await eventually(() => expect(driver.isContentElementExists()).toBeFalsy());
-    wrapper.unmount();
   });
 
   it('should not animate in case timeout is set to 0', async () => {
-    const {wrapper, driver} = renderWithEnzyme(createPopover({shown: true, timeout: 0}));
+    wrapper = mount(createPopover({shown: true, timeout: 0}));
+    const driver = popoverDriverFactory({element: wrapper.children().at(0).getDOMNode(), eventTrigger: null});
     wrapper.setProps({shown: false});
     expect(driver.isContentElementExists()).toBeFalsy();
     expect(wrapper.text()).toBe('Element');
@@ -91,88 +102,107 @@ describe('Popover', () => {
 
   describe('appendTo', () => {
 
-    describe('window', () => {
-      it('should append popover to body when appendTo is window', () => {
-        const {wrapper, driver} = renderWithEnzyme(createPopover({shown: true, appendTo: 'window'}));
-        const contentElement = driver.getContentElement();
-        expect(contentElement.parentElement).toBe(document.body);
-        wrapper.unmount();
+    const runAppendToTests = (
+      appendTo: AppendTo,
+      getExpectedAppendToElement: () => Element,
+      getExpectedContentParent: () => Element,
+      mountPopover: (props: Partial<PopoverProps>) => {wrapper: ReactWrapper<PopoverProps,{}>, driver}
+    ) => {
+      it('should append new div when initially open', () => {
+        const prevChildren = getExpectedAppendToElement().children.length;
+        const {driver} = mountPopover({shown: true});
+        const g = getExpectedAppendToElement().children.length;
+        expect(getExpectedAppendToElement().children.length).toBe(prevChildren + 1);
+        expect(driver.getContentElement().parentElement).toBe(getExpectedContentParent());
       });
 
-      it('should attach and detach styles to body when appended to window', () => {
-        const {wrapper, driver} = renderWithEnzyme(createPopover({shown: true, appendTo: 'window'}));
-        expect(document.body.classList).toContain(styles.root);
+      it('should append new div when initially closed', () => {
+        const prevChildren = getExpectedAppendToElement().children.length;
+        mountPopover({shown: false});
+        expect(getExpectedAppendToElement().children.length).toBe(prevChildren + 1);
+      });
+
+      it('should attach styles to content parent when initially open', () => {
+        mountPopover({shown: true});
+        expect(getExpectedContentParent().className).toBe(styles.root);
+      });
+
+      it('should remove styles from content parent when closed', () => {
+        mountPopover({shown: true});
         wrapper.setProps({shown: false});
-        expect(document.body.classList).not.toContain(styles.root);
-        wrapper.unmount();
-      });
-    });
-
-    describe('viewport', () => {
-      it('should append popover to body when appendTo is viewport', () => {
-        const {wrapper, driver} = renderWithEnzyme(createPopover({shown: true, appendTo: 'viewport'}));
-        const contentElement = driver.getContentElement();
-        expect(contentElement.parentElement).toBe(document.body);
-        wrapper.unmount();
+        expect(getExpectedContentParent().className).not.toBe(styles.root);
       });
 
-      it('should attach and detach styles to body when appended to viewport', () => {
-        const {wrapper, driver} = renderWithEnzyme(createPopover({shown: true, appendTo: 'viewport'}));
-        expect(document.body.classList).toContain(styles.root);
-        wrapper.setProps({shown: false});
-        expect(document.body.classList).not.toContain(styles.root);
-        wrapper.unmount();
-      });
-    });
-
-    describe('node', () => {
-      it('should append popover to given element when appendTo is an element', () => {
-        const {wrapper, driver} = renderWithEnzyme(
-          createPopover({shown: true, appendTo: container.node})
-        );
-        const contentElement = driver.getContentElement();
-        expect(contentElement.parentElement).toBe(container.node);
-        wrapper.unmount();
+      it('should NOT attach styles to content parent when initially closed', () => {
+        mountPopover({shown: false});
+        expect(getExpectedContentParent().className).not.toBe(styles.root);
       });
 
-      it('should attach and detach styles to the element appended to', () => {
-        const {wrapper, driver} = renderWithEnzyme(createPopover(
-          {shown: true, appendTo: container.node}
-        ));
-        expect(container.node.classList).toContain(styles.root);
-        wrapper.setProps({shown: false});
-        expect(container.node.classList).not.toContain(styles.root);
+      it('should remove default div when unmounted', () => {
+        const prevChildren = getExpectedAppendToElement().children.length;
+        mountPopover({shown: false});
+        expect(getExpectedAppendToElement().children.length).toBe(prevChildren + 1);
         wrapper.unmount();
+        wrapper = null;
+        expect(getExpectedAppendToElement().children.length).toBe(prevChildren);
+      });
+    };
+
+    describe('window & viewport :', () => {
+      const boundaryValues: Boundary[] = ['window'];//, 'viewport'];
+      boundaryValues.forEach(boundary => {
+        describe(boundary, () => {
+          const appendTo = boundary;
+          let popoverContainer: HTMLElement;
+          const getExpectedAppendToElement = () => document.body;
+          const getExpectedContentParent = () => document.body.children[1];
+          const mountPopover = (props: Partial<PopoverProps>) => renderWithEnzyme(createPopover({...props, appendTo}), {attachTo: popoverContainer});
+          
+          beforeEach(() => {
+            popoverContainer = document.createElement('div');
+            container.node.appendChild(popoverContainer);
+          });
+
+          runAppendToTests(appendTo, getExpectedAppendToElement, getExpectedContentParent, mountPopover);
+        });
       });
     });
 
     describe('scrollParent', () => {
-      const intoScrollable = jsx =>
-        <div style={{overflow: 'auto'}}><div>{jsx}</div></div>;
+      const appendTo = 'scrollParent';
+      let popoverContainer: HTMLElement;
+      let scrollContainer: HTMLElement;
+      const getExpectedAppendToElement = () => scrollContainer;
+      const getExpectedContentParent = () => scrollContainer.children[1];
+      const mountPopover = (props: Partial<PopoverProps>) => renderWithEnzyme(createPopover({...props, appendTo}), {attachTo: popoverContainer});
 
-      it('should append popover to first scrollable parent when appendTo is scrollParent', () => {
-        const {wrapper, driver} = renderWithEnzyme(intoScrollable(
-          createPopover({shown: true, appendTo: 'scrollParent'})
-        ));
-        const contentElement = driver.getContentElement();
-        expect(contentElement.parentElement).toBe(wrapper.getDOMNode());
-        wrapper.unmount();
+      beforeEach(() => {
+        popoverContainer = document.createElement('div');
+        scrollContainer = document.createElement('div');
+        scrollContainer.style.overflow ='auto';
+        scrollContainer.appendChild(popoverContainer);
+        container.node.appendChild(scrollContainer);
       });
 
-      it('should attach and detach styles to the scrollable parent container', () => {
-        let {wrapper} = renderWithEnzyme(intoScrollable(
-          createPopover({shown: true, appendTo: 'scrollParent'})
-        ));
-        expect(wrapper.getDOMNode().className).toBe(styles.root);
+      runAppendToTests(appendTo, getExpectedAppendToElement, getExpectedContentParent, mountPopover);
+    });
 
-        ({wrapper} = renderWithEnzyme(intoScrollable(
-          createPopover({shown: false, appendTo: 'scrollParent'})
-        )));
-        expect(wrapper.getDOMNode().className).toBe('');
+    describe('node', () => {
+      let appendTo: HTMLElement;
+      let popoverContainer: HTMLElement;
+      const getExpectedAppendToElement = () => popoverContainer;
+      const getExpectedContentParent = () => appendTo.children[0];
+      const mountPopover = (props: Partial<PopoverProps>) => renderWithEnzyme(createPopover({...props, appendTo}), {attachTo: popoverContainer});
 
-        wrapper.unmount();
+      beforeEach(() => {
+        popoverContainer = document.createElement('div');
+        container.node.appendChild(popoverContainer);
+
+        appendTo = document.createElement('div');
+        container.node.appendChild(appendTo);
       });
 
+      runAppendToTests(appendTo, getExpectedAppendToElement, getExpectedContentParent, mountPopover);
     });
   });
 

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -11,9 +11,8 @@ import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
 import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
 import {popoverTestkitFactory} from '../../testkit';
 import styles from './Popover.st.css';
-import {PopoverDriver} from '../../testkit/protractor';
 
-fdescribe('Popover', () => {
+describe('Popover', () => {
   let wrapper;
   
   afterEach(() => {

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -5,10 +5,10 @@ import {Popover, PopoverProps} from './';
 import {mount} from 'enzyme';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
 import * as eventually from 'wix-eventually';
-import {popoverTestkitFactory as enzymePopoverTestkitFactory} from '../../testkit/enzyme';
-import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
-import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
-import {popoverTestkitFactory} from '../../testkit';
+import { popoverTestkitFactory as enzymePopoverTestkitFactory } from '../../testkit/enzyme';
+import { isEnzymeTestkitExists } from 'wix-ui-test-utils/enzyme';
+import { isTestkitExists } from 'wix-ui-test-utils/vanilla';
+import { popoverTestkitFactory } from '../../testkit';
 import styles from './Popover.st.css';
 
 describe('Popover', () => {
@@ -173,7 +173,6 @@ describe('Popover', () => {
         wrapper.unmount();
       });
     });
-
   });
 
   describe('testkit', () => {

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -106,6 +106,7 @@ describe('Popover', () => {
         expect(document.body.classList).not.toContain(styles.root);
         wrapper.unmount();
       });
+
     });
 
     describe('viewport', () => {

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -25,7 +25,7 @@ describe('Popover', () => {
 
   const render = container.createLegacyRenderer(popoverDriverFactory);
 
-  const renderWithEnzyme = (jsx, {attachTo}) => {
+  const renderWithEnzyme = (jsx, {attachTo} = {attachTo: container.node}) => {
     wrapper = mount<PopoverProps,{}>(jsx, {attachTo});
     const driver = popoverDriverFactory({
       element: wrapper.find(Popover).getDOMNode(),
@@ -83,20 +83,18 @@ describe('Popover', () => {
   });
 
   it('should animate given timeout', async () => {
-    wrapper = mount(createPopover({shown: true, timeout: 100}));
-    const driver = popoverDriverFactory({element: wrapper.children().at(0).getDOMNode(), eventTrigger: null});
+    const {driver} = renderWithEnzyme(createPopover({shown: true, timeout: 100}));
     wrapper.setProps({shown: false});
     expect(driver.isContentElementExists()).toBeTruthy();
     await eventually(() => expect(driver.isContentElementExists()).toBeFalsy());
   });
 
   it('should not animate in case timeout is set to 0', async () => {
-    wrapper = mount(createPopover({shown: true, timeout: 0}));
+    renderWithEnzyme(createPopover({shown: true, timeout: 0}));
     const driver = popoverDriverFactory({element: wrapper.children().at(0).getDOMNode(), eventTrigger: null});
     wrapper.setProps({shown: false});
     expect(driver.isContentElementExists()).toBeFalsy();
     expect(wrapper.text()).toBe('Element');
-    wrapper.unmount();
   });
 
   describe('appendTo', () => {

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -5,10 +5,10 @@ import {Popover, PopoverProps} from './';
 import {mount} from 'enzyme';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
 import * as eventually from 'wix-eventually';
-import { popoverTestkitFactory as enzymePopoverTestkitFactory } from '../../testkit/enzyme';
-import { isEnzymeTestkitExists } from 'wix-ui-test-utils/enzyme';
-import { isTestkitExists } from 'wix-ui-test-utils/vanilla';
-import { popoverTestkitFactory } from '../../testkit';
+import {popoverTestkitFactory as enzymePopoverTestkitFactory} from '../../testkit/enzyme';
+import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
+import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
+import {popoverTestkitFactory} from '../../testkit';
 import styles from './Popover.st.css';
 
 describe('Popover', () => {

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -210,7 +210,7 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     return this.wrapWithAnimations(popper);
   }
 
-  applyStylesToAppendedNode() {
+  applyStylesToPortaledNode() {
     const {shown} = this.props;
     const shouldAnimate = shouldAnimatePopover(this.props);
 
@@ -265,12 +265,14 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
       // Why do we do this here ?(in componentDidMount and not ONLY in render? or when we actually attachStylesToNode)
       this.stylesObj = style('root', {}, this.props);
       // TODO: remove this, it is called in render
-      this.applyStylesToAppendedNode();
+      this.applyStylesToPortaledNode();
     }
   }
 
   componentWillUnmount() {
     if (this.portalNode) {
+      // FIXME: What if component is updated with a different appendTo? It is a far-fetched use-case,
+      // but we would need to remove the portaled node, and created another one.
       this.appendToNode.removeChild(this.portalNode);
     }
     this.portalNode = null;
@@ -285,7 +287,7 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     const shouldRenderPopper = isMounted && (shouldAnimate || shown);
 
     if (this.portalNode) {
-      this.applyStylesToAppendedNode();
+      this.applyStylesToPortaledNode();
     }
 
     return (

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -181,22 +181,6 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     style: object
   };
 
-  getOrCreateAppendToNode({appendTo, targetRef}) {
-    let appendToNode;
-    if (appendTo === 'window' || appendTo === 'viewport') {
-      this.defaultNode = document.createElement('div');
-      document.body.appendChild(this.defaultNode);
-      appendToNode = this.defaultNode;
-    } else if (appendTo === 'scrollParent') {
-      appendToNode = getScrollParent(targetRef);
-    } else if (isElement(appendTo)) {
-      appendToNode = appendTo;
-    } else {
-      appendToNode = null;
-    }
-    return appendToNode;
-  };
-  
   getPopperContentStructure(childrenObject) {
     const {appendTo, placement, showArrow, moveArrowTo} = this.props;
     const modifiers = createModifiers({moveBy, appendTo});
@@ -268,6 +252,11 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     );
   }
 
+  componentDidMount() {
+    this.initAppendToNode();
+    this.setState({isMounted: true});
+  }
+
   initAppendToNode() {
     const {appendTo} = this.props;
     this.appendToNode = this.getOrCreateAppendToNode({appendTo, targetRef: this.targetRef});
@@ -282,11 +271,22 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     }
   }
 
-  componentDidMount() {
-    this.initAppendToNode();
-    this.setState({isMounted: true});
-  }
-  
+  getOrCreateAppendToNode({appendTo, targetRef}) {
+    let appendToNode;
+    if (appendTo === 'window' || appendTo === 'viewport') {
+      this.defaultNode = document.createElement('div');
+      document.body.appendChild(this.defaultNode);
+      appendToNode = this.defaultNode;
+    } else if (appendTo === 'scrollParent') {
+      appendToNode = getScrollParent(targetRef);
+    } else if (isElement(appendTo)) {
+      appendToNode = appendTo;
+    } else {
+      appendToNode = null;
+    }
+    return appendToNode;
+  };
+
   componentWillUnmount() {
     if (this.defaultNode) {
       document.body.removeChild(this.defaultNode);

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -126,19 +126,6 @@ const createModifiers = ({moveBy, appendTo}) => {
   return modifiers;
 };
 
-const getAppendedNode = ({appendTo, targetRef}) => {
-  let appendToNode;
-  if (appendTo === 'window' || appendTo === 'viewport') {
-    appendToNode = document.body;
-  } else if (appendTo === 'scrollParent') {
-    appendToNode = getScrollParent(targetRef);
-  } else if (isElement(appendTo)) {
-    appendToNode = appendTo;
-  } else {
-    appendToNode = null;
-  }
-  return appendToNode;
-};
 
 const shouldAnimatePopover = ({timeout}: PopoverProps) => !!timeout;
 
@@ -193,6 +180,20 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     style: object
   };
 
+  getAppendedNode({appendTo, targetRef}) {
+    let appendToNode;
+    if (appendTo === 'window' || appendTo === 'viewport') {
+      appendToNode = document.body;
+    } else if (appendTo === 'scrollParent') {
+      appendToNode = getScrollParent(targetRef);
+    } else if (isElement(appendTo)) {
+      appendToNode = appendTo;
+    } else {
+      appendToNode = null;
+    }
+    return appendToNode;
+  };
+  
   getPopperContentStructure(childrenObject) {
     const {appendTo, placement, showArrow, moveArrowTo} = this.props;
     const modifiers = createModifiers({moveBy, appendTo});
@@ -264,17 +265,17 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     );
   }
 
-  handlePortaledPopoverNode(props) {
-    const {appendTo} = props;
-    this.appendToNode = getAppendedNode({appendTo, targetRef: this.targetRef});
+  handlePortaledPopoverNode() {
+    const {appendTo} = this.props;
+    this.appendToNode = this.getAppendedNode({appendTo, targetRef: this.targetRef});
     if (this.appendToNode) {
-      this.stylesObj = style('root', {}, props);
-      this.applyStylesToAppendedNode(props);
+      this.stylesObj = style('root', {}, this.props);
+      this.applyStylesToAppendedNode(this.props);
     }
   }
 
   componentDidMount() {
-    this.handlePortaledPopoverNode(this.props);
+    this.handlePortaledPopoverNode();
     this.setState({isMounted: true});
   }
 

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -211,9 +211,9 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     return this.wrapWithAnimations(popper);
   }
 
-  applyStylesToAppendedNode(props) {
-    const {shown} = props;
-    const shouldAnimate = shouldAnimatePopover(props);
+  applyStylesToAppendedNode() {
+    const {shown} = this.props;
+    const shouldAnimate = shouldAnimatePopover(this.props);
 
     if (shouldAnimate || shown) {
       attachStylesToNode(this.appendToNode, this.stylesObj);
@@ -267,7 +267,7 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
       // Why do we do this here ?(in componentDidMount and not ONLY in render? or when we actually attachStylesToNode)
       this.stylesObj = style('root', {}, this.props);
       // TODO: remove this, it is called in render
-      this.applyStylesToAppendedNode(this.props);
+      this.applyStylesToAppendedNode();
     }
   }
 
@@ -304,7 +304,7 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
 
     // TODO: Should we do this also if shouldRenderPopper === false ?
     if (this.appendToNode) {
-      this.applyStylesToAppendedNode(this.props);
+      this.applyStylesToAppendedNode();
     }
 
     return (

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -265,17 +265,18 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     );
   }
 
-  handlePortaledPopoverNode() {
+  initAppendToNode() {
     const {appendTo} = this.props;
     this.appendToNode = this.getAppendedNode({appendTo, targetRef: this.targetRef});
     if (this.appendToNode) {
       this.stylesObj = style('root', {}, this.props);
+      // TODO: remove this, it is called in render
       this.applyStylesToAppendedNode(this.props);
     }
   }
 
   componentDidMount() {
-    this.handlePortaledPopoverNode();
+    this.initAppendToNode();
     this.setState({isMounted: true});
   }
 
@@ -287,6 +288,7 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     const shouldAnimate = shouldAnimatePopover(this.props);
     const shouldRenderPopper = isMounted && (shouldAnimate || shown);
 
+    // TODO: Should we do this also if shouldRenderPopper === false ?
     if (this.appendToNode) {
       this.applyStylesToAppendedNode(this.props);
     }

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -302,7 +302,6 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
     const shouldAnimate = shouldAnimatePopover(this.props);
     const shouldRenderPopper = isMounted && (shouldAnimate || shown);
 
-    // TODO: Should we do this also if shouldRenderPopper === false ?
     if (this.appendToNode) {
       this.applyStylesToAppendedNode();
     }

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -151,33 +151,19 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
 
   static propTypes = {
     className: string,
-    /** The location to display the content */
     placement: PlacementsType,
-    /** Is the content shown or not */
     shown: bool,
-    /** onClick on the component */
     onClick: func,
-    /** onMouseEnter on the component */
     onMouseEnter: func,
-    /** onMouseLeave on the component */
     onMouseLeave: func,
-    /** onKeyDown on the target component */
     onKeyDown: func,
-    /** Show show arrow from the content */
     showArrow: bool,
-    /** Moves popover relative to the parent */
     moveBy: shape({x: number, y: number}),
-    /** Fade Delay */
     hideDelay: number,
-    /** Show Delay */
     showDelay: number,
-    /** Moves arrow by amount */
     moveArrowTo: number,
-    /** Enables calculations in relation to a dom element */
     appendTo: AppendToPropType,
-    /** Animation timer */
     timeout: number,
-    /** Inline styles */
     style: object
   };
 
@@ -260,9 +246,6 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
   initAppendToNode() {
     const {appendTo} = this.props;
     this.appendToNode = this.getOrCreateAppendToNode({appendTo, targetRef: this.targetRef});
-    // TODO: I think we should throw an error is this.appendToNode is undefined, since 
-    // react-portal will attach it to a new default div under document.body,
-    // and we could not add the stylable styles to that div.
     if (this.appendToNode) {
       // Why do we do this here ?(in componentDidMount and not ONLY in render? or when we actually attachStylesToNode)
       this.stylesObj = style('root', {}, this.props);

--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -1,6 +1,32 @@
 import * as React from 'react';
-import {Popover} from '../src/components/Popover';
+import {Popover, PopoverProps} from '../src/components/Popover';
 import {Option} from '../src/baseComponents/DropdownOption';
+
+// Click target to open close
+class PopoverWithState extends React.Component<Partial<PopoverProps>,{shown: boolean}> {
+  state = {shown: true};
+  
+  render() {
+    const props: PopoverProps & {children?: any} = {
+      ...this.props, 
+      placement: 'right',
+      showArrow: true,
+      shown: this.state.shown,
+      onClick:()=> this.setState({shown: !this.state.shown})
+    }
+    return (
+      <Popover {...props}>
+        <Popover.Element>
+          The Element
+        </Popover.Element>
+        <Popover.Content>
+            The content
+        </Popover.Content>
+      </Popover>
+    )
+  }
+}
+
 
 export default {
   category: 'Components',
@@ -16,5 +42,38 @@ export default {
     appendTo: null, // window, null, 'scrollParent', 'viewport'
     showArrow: true,
     timeout: 150
-  }
+  },
+  examples: (
+    <div>
+      <h1>Examples</h1>
+      <p>The examples here have a wrapping component with open/close state. Click the target or the content to toggle open/close</p>
+      <div>
+        <h2>AppendTo = 'window'</h2>
+        <p>If you inspect the content, you'll see it is attached to a new div under the body.</p>
+        <PopoverWithState appendTo="window"/>
+      </div>
+      <div>
+        <h2>AppendTo = 'scrollParent'</h2>
+        <p>If you inspect the content, you'll see it is attached to a new div under the list container.</p>
+        <div style={{overflow: 'auto', height: '100px', width: '400px', border: '1px solid black'}}>
+          <ul>
+            <li>item</li>
+            <PopoverWithState appendTo="scrollParent"/>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
 };
+
+

--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -50,7 +50,7 @@ export default {
       <div>
         <h2>AppendTo = 'window'</h2>
         <p>If you inspect the content, you'll see it is attached to a new div under the body.</p>
-        <PopoverWithState appendTo="window"/>
+        <PopoverWithState appendTo="window" data-hook="popover-appendto-window"/>
       </div>
       <div>
         <h2>AppendTo = 'scrollParent'</h2>
@@ -58,7 +58,7 @@ export default {
         <div style={{overflow: 'auto', height: '100px', width: '400px', border: '1px solid black'}}>
           <ul>
             <li>item</li>
-            <PopoverWithState appendTo="scrollParent"/>
+            <PopoverWithState appendTo="scrollParent" data-hook="popover-appendto-scroll-parent"/>
             <li>item</li>
             <li>item</li>
             <li>item</li>


### PR DESCRIPTION
Fixes #523 

Also fixes issue with React 15, where setting the attachTo to `document.body` is casing the popover to overwrite the `body` instead of appending to it.