### PR TITLE
wix-ui-core: <Video> Fix TS error in Video driver private

### DIFF
--- a/packages/wix-ui-core/src/components/Video/Video.driver.private.ts
+++ b/packages/wix-ui-core/src/components/Video/Video.driver.private.ts
@@ -1,3 +1,4 @@
+import { VideoProps } from './Video';
 /**
  * Private driver, will not be exposed in testkit
  */
@@ -5,7 +6,7 @@
 import * as React from 'react';
 import {mount, ReactWrapper} from 'enzyme';
 
-export const createDriver = Component => {
+export const createDriver = (Component: React.ReactElement<VideoProps>) => {
   let player;
 
   const ClonedComponent = React.cloneElement(Component, {


### PR DESCRIPTION
I got this TS error:
```
src/components/Video/Video.driver.private.ts(30,48): error TS2345: Argument of type '{ [x: number]: any; }' is not assignable to parameter of type 'Pick<{ playableRef: (r: any) => any; }, "playableRef">'.
```
When running `npm run  build`, in `wix-ui` (lerna).