### PR TITLE
wix-ui-core: Add vscode debug launch configs

### DIFF
--- a/packages/wix-ui-core/.gitignore
+++ b/packages/wix-ui-core/.gitignore
@@ -7,7 +7,6 @@ maven
 .history
 test/e2e/screenshots
 package-lock.json
-.vscode
 .yo-rc.json
 npm-debug.log
 yarn.lock

--- a/packages/wix-ui-core/.vscode/launch.json
+++ b/packages/wix-ui-core/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Unit Test Debug",
+      "type": "node",
+      "request": "launch",
+      "args" : ["test", "--jest", "--debug"],
+      "port": 9229,
+      "program": "${workspaceFolder}/node_modules/.bin/yoshi"
+    },
+    {
+      "name": "e2e Test Debug",
+      "type": "node",
+      "request": "launch",
+      "args" : ["test", "--protractor", "--debug"],
+      "port": 9229,
+      "program": "${workspaceFolder}/node_modules/.bin/yoshi"
+    }
+  ]
+}

--- a/packages/wix-ui-core/.vscode/launch.json
+++ b/packages/wix-ui-core/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Unit Test Debug",
       "type": "node",
       "request": "launch",
-      "args" : ["test", "--jest", "--debug"],
+      "args" : ["test", "--jest", "--debug-brk"],
       "port": 9229,
       "program": "${workspaceFolder}/node_modules/.bin/yoshi"
     },
@@ -16,7 +16,7 @@
       "name": "e2e Test Debug",
       "type": "node",
       "request": "launch",
-      "args" : ["test", "--protractor", "--debug"],
+      "args" : ["test", "--protractor", "--debug-brk"],
       "port": 9229,
       "program": "${workspaceFolder}/node_modules/.bin/yoshi"
     }


### PR DESCRIPTION
I have been waiting a long time for this.
Now that we are using Yoshi2, we can easily debug our tests.

NOTE: For those of you who are not in favor off adding IDE specific config to the repo, I can only say: "Think of the new guy coming to contribute to wix-ui-core, how happy he will be to see that debugging works out of the box".

And if you have a concern that a user might want to add he's own launch configs (VS Code supports only one config file), then we can:
 -  name this file `launch.recommended.json`

This is ok solution, but we can doo better if we:
 - have a postclone hook that copies `launch.recommended.json` -> `launch.json` (while `.vscode/launch.json` is ignored)