### PR TITLE
Restrict typescript to < 2.9

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -84,7 +84,7 @@
     "ts-jest": "^22.0.3",
     "tslint-config-prettier": "^1.12.0",
     "tslint-react": "^3.5.1",
-    "typescript": "^2.6.2",
+    "typescript": "~2.8.3",
     "wait-for-cond": "^1.5.1",
     "wix-eventually": "latest",
     "wix-storybook-utils": "^1.0.0",

--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -42,7 +42,7 @@
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "svg2react-icon": "^2.0.0",
-    "typescript": "^2.6.2",
+    "typescript": "~2.8.3",
     "wix-storybook-utils": "^1.0.0",
     "yoshi": "^1.2.0"
   },

--- a/packages/wix-ui-jss/package.json
+++ b/packages/wix-ui-jss/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^16.3.1",
     "react-test-renderer": "^16.3.1",
     "ts-jest": "^22.0.3",
-    "typescript": "^2.4.0",
+    "typescript": "~2.8.3",
     "wix-ui-test-utils": "^1.0.0",
     "yoshi": "^1.2.0"
   },

--- a/packages/wix-ui-mocha-runner/package.json
+++ b/packages/wix-ui-mocha-runner/package.json
@@ -26,7 +26,7 @@
     "stylable-webpack-plugin": "^1.0.18",
     "style-loader": "^0.21.0",
     "ts-loader": "^4.3.0",
-    "typescript": "^2.8.3",
+    "typescript": "~2.8.3",
     "webpack": "^4.9.1",
     "webpack-serve": "^1.0.2"
   }

--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -55,7 +55,7 @@
     "react-dom": "^16.3.1",
     "react-test-renderer": "^16.3.1",
     "ts-jest": "^22.0.3",
-    "typescript": "^2.6.2",
+    "typescript": "~2.8.3",
     "yoshi": "^1.2.0"
   },
   "jest": {

--- a/packages/wix-ui-theme/package.json
+++ b/packages/wix-ui-theme/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^16.3.1",
     "react-test-renderer": "^16.3.1",
     "ts-jest": "^22.0.3",
-    "typescript": "^2.4.0",
+    "typescript": "~2.8.3",
     "wix-ui-test-utils": "^1.0.0",
     "yoshi": "^1.2.0"
   },


### PR DESCRIPTION
Typescript 2.9 introduces `import types`,
When building `wix-ui-core` with 2.9,
and trying to build `wix-ui-backoffice` (which uses 2.9) then I get this error:
```
node_modules/wix-ui-core/dist/src/components/Autocomplete/Autocomplete.d.ts(43,18): error TS2307: Cannot find module '../../../node_modules/@types/prop-types/index'.
```
on this line:
```
options: import("../../../node_modules/@types/prop-types/index").Validator<any>;
```

I don't want to handle this now. 
