### PR TITLE
revert svg2react-icon to version 2.*

### DIFF
--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -46,7 +46,7 @@
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "typescript": "~2.8.3",
-    "svg2react-icon": "^3.0.1",
+    "svg2react-icon": "^2.0.0",
     "wix-storybook-utils": "^1.0.0",
     "wix-ui-test-utils": "^1.0.0",
     "yoshi": "^1.2.0"


### PR DESCRIPTION
@ronenst @odedcagan this should be a quick & dirty fix in order not to break wsr v3.
I will add the ability to support several release branches simultaneously and then I will return the updated svg2react-icon version only for wsr 4