### PR TITLE
LinearProgressBar: fix test failing in browser environment

### DIFF
--- a/packages/wix-ui-core/src/components/LinearProgressBar/LinearProgressBar.driver.ts
+++ b/packages/wix-ui-core/src/components/LinearProgressBar/LinearProgressBar.driver.ts
@@ -23,13 +23,14 @@ export const linearProgressBarDriverFactory: DriverFactory<LinearProgressBarDriv
   const stylableDOMUtil = new StylableDOMUtil(style);
   
   const getElement = dataHook => element.querySelector(`[data-hook="${dataHook}"]`)
-  const getProgressBarForegroundStyle = () => !element ? {} as any : window.getComputedStyle(getElement('progressbar-foreground'));
-  const getProgressBarBackgroundStyle = () => !element ? {} as any : window.getComputedStyle(getElement('progressbar-background'));
   const getValue = () => !element ? null : getElement('progress-percentages').querySelector('span').innerHTML;
 
   const driver = {
     exists: () => !!element,
-    getWidth: () => getProgressBarForegroundStyle().width,
+    getWidth: () => {
+      const el = getElement('progressbar-foreground') as HTMLElement;
+      return el ? el.style.width : '0';
+    },
     isSuccessIconDisplayed: () => !!getElement('success-icon'),
     isErrorIconDisplayed: () => !!getElement('error-icon'),
     isPercentagesProgressDisplayed: () => !!getElement('progress-percentages'),


### PR DESCRIPTION
From MDN:

> The values returned by getComputedStyle are known as resolved values. These are usually the same as the CSS 2.1 computed values, but for some older properties like width, height or padding, they are instead the used values. Originally, CSS 2.0 defined the computed values to be the "ready to be used" final values of properties after cascading and inheritance, but CSS 2.1 redefined computed values as pre-layout, and used values as post-layout. For CSS 2.0 properties, the getComputedStyle function returns the old meaning of computed values, now called used values. An example of difference between pre- and post-layout values includes the resolution of percentages that represent the width or the height of an element (also known as its layout), as those will be replaced by their pixel equivalent only in the used value case.

The bottom line is that in browser environment `getComputedStyle(el).with` always returns the value in pixels regardless of how it's defined in CSS.