### PR TITLE
Browser test runner: the Yoshi way

### DIFF
--- a/packages/wix-ui-core/karma.conf.js
+++ b/packages/wix-ui-core/karma.conf.js
@@ -1,0 +1,10 @@
+module.exports = {
+  frameworks: ['mocha'],
+  reporter: 'spec',
+  browsers: ['ChromeHeadless'],
+  client: {
+    mocha: {
+      reporter: 'html',
+    }
+  }
+};

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -26,7 +26,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "posttest": "npm run lint",
     "test:watch": "yoshi test --jest --watch",
-    "test:unit": "yoshi test --jest",
+    "test:unit": "yoshi test --jest --karma",
     "test:e2e": "yoshi test --protractor",
     "lint": "yoshi lint",
     "yoshi-start": "yoshi start --no-test",
@@ -37,7 +37,7 @@
     "import-path": "node scripts/import-path.js",
     "transpile-mixins": "babel src/mixins -d dist/src/mixins",
     "generate-stylable-index": "stc --srcDir=\"./dist/src\" --diagnostics",
-    "test:browser": "wix-ui-mocha-runner"
+    "test:browser": "yoshi test --karma"
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -88,7 +88,6 @@
     "wix-eventually": "latest",
     "wix-storybook-utils": "^1.0.0",
     "wix-ui-icons-common": "^1.0.0",
-    "wix-ui-mocha-runner": "^0.1.0",
     "yoshi": "^2.7.0"
   },
   "license": "MIT",

--- a/packages/wix-ui-core/test/karma-setup.js
+++ b/packages/wix-ui-core/test/karma-setup.js
@@ -1,0 +1,12 @@
+import expect from 'expect';
+import JestMock from 'jest-mock';
+import Enzyme from 'enzyme';
+import EnzymeAdapter from 'enzyme-adapter-react-16';
+
+// Jest compatibility
+window.expect = expect;
+window.jest = JestMock;
+window.beforeAll = window.before;
+window.afterAll = window.after;
+
+Enzyme.configure({adapter: new EnzymeAdapter()});


### PR DESCRIPTION
So `wix-ui-mocha-runner` works fine when `wix-ui-core` installs all its dependencies, but when it's linked to the other `wix-ui-*` repos there is some issue with duplicate `.d.ts` files, probably related to how the monorepo is configured, I gave up on figuring out to solve it. Using Karma now.
