### PR TITLE
fix(ComponentSource): use correct name of component

### DIFF
--- a/packages/wix-storybook-utils/src/ComponentSource/index.js
+++ b/packages/wix-storybook-utils/src/ComponentSource/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import reactElementToJSXString from 'react-element-to-jsx-string';
 import CodeBlock from '../CodeBlock';
+import removeHOC from './remove-hoc';
 
 import functionToString from './function-to-string';
 
@@ -9,6 +10,10 @@ const componentToJSX = component =>
   reactElementToJSXString(
     component,
     {
+      displayName: element =>
+        element.type.displayName ?
+          removeHOC(element.type.displayName) :
+          element.type.name || element.type,
       showDefaultProps: false,
       showFunctions: false,
       functionValue: functionToString

--- a/packages/wix-storybook-utils/src/ComponentSource/remove-hoc.js
+++ b/packages/wix-storybook-utils/src/ComponentSource/remove-hoc.js
@@ -1,0 +1,7 @@
+const regex = /^.*?\((.+?)\)$/i;
+const removeHOC = (string = '') => {
+  const [, componentName = ''] = string.match(regex) || [];
+  return componentName || string;
+};
+
+export default removeHOC;

--- a/packages/wix-storybook-utils/src/ComponentSource/remove-hoc.test.js
+++ b/packages/wix-storybook-utils/src/ComponentSource/remove-hoc.test.js
@@ -1,0 +1,24 @@
+/* global describe expect it  */
+
+import removeHOC from './remove-hoc';
+
+describe('removeHOC() given', () => {
+  const assertsAndExpectations = [
+    ['', ''],
+    ['how are you', 'how are you'],
+    ['hey(there', 'hey(there'],
+    ['hello', 'hello'],
+    ['im)ok', 'im)ok'],
+    ['hello(world)', 'world'],
+    ['Hel+lo(world)', 'world'],
+    ['hello(w o r l d)', 'w o r l d'],
+    ['(hello)', 'hello']
+  ];
+
+  assertsAndExpectations.map(([assert, expectation]) =>
+    it(
+      `"${assert}" should return "${expectation}"`,
+      () => expect(removeHOC(assert)).toEqual(expectation)
+    )
+  );
+});

--- a/packages/wix-storybook-utils/src/StoryPage/index.test.js
+++ b/packages/wix-storybook-utils/src/StoryPage/index.test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import Testkit from './index.testkit';
 
 const testkit = new Testkit();
@@ -68,6 +69,34 @@ describe('StoryPage', () => {
 
       expect(testkit.get.readme()).toMatch(/<well hello there\/>/);
       expect(testkit.get.import()).toMatch(/well hello there/);
+    });
+  });
+
+  describe('code example', () => {
+    it('should show displayName without HOC', () => {
+      const component = ({children}) => <div>{children}</div>; // eslint-disable-line react/prop-types
+      component.displayName = 'someHOC(componentName)';
+
+      const IShouldBeTheName = () => null;
+
+      const props = {
+        component,
+        componentProps: {
+          children: <div><IShouldBeTheName/></div>
+        },
+        exampleProps: {
+          children: []
+        }
+      };
+
+      testkit.when.created(props);
+      expect(testkit.get.codeBlock()).toEqual(`\`\`\`js
+<componentName>
+  <div>
+    <IShouldBeTheName />
+  </div>
+</componentName>
+\`\`\``);
     });
   });
 });


### PR DESCRIPTION
if `displayName` exists then extract from HOC and use it
else use `type.name` or `type`