### PR TITLE
Add missed info about mouseEnter and mouseLeave protractor helpers to the readme

### DIFF
--- a/packages/wix-ui-test-utils/README.md
+++ b/packages/wix-ui-test-utils/README.md
@@ -98,6 +98,26 @@ waitForVisibilityOf(
 );
 ```
 
+### `mouseEnter`
+
+Move the mouse on the element.
+
+```javascript
+import {mouseEnter} from 'wix-ui-test-utils/protractor';
+
+mouseEnter(element);
+```
+
+### `mouseLeave`
+
+Move the mouse out of the element.
+
+```javascript
+import {mouseLeave} from 'wix-ui-test-utils/protractor';
+
+mouseLeave(element);
+```
+
 ## Testkit helpers
 
 ### `createDriverFactory`


### PR DESCRIPTION
Related to this talk https://github.com/wix/wix-style-react/pull/1820#discussion_r196351060