### PR TITLE
fix(createHOC): use class or function name when displayName is unavailable

### DIFF
--- a/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
+++ b/packages/wix-ui-core/src/createHOC/createHOC.spec.tsx
@@ -44,10 +44,7 @@ describe('createHOC function', () => {
     render() { return <div>Hello</div>; }
   }
 
-  // Stateless component
-  const StatelessChildComponent = () => (<div>stateless</div>);
-
-  describe('Regular components', () => {
+  describe('Stateful components', () => {
     const HOCComponent = createHOC(ChildComponent);
 
     it('should render the wrapped component', () => {
@@ -118,6 +115,7 @@ describe('createHOC function', () => {
   });
 
   describe('Stateless components', () => {
+    const StatelessChildComponent = () => (<div>stateless</div>);
     const HOCComponent = createHOC(StatelessChildComponent);
 
     it('should render the wrapped component', () => {
@@ -139,5 +137,39 @@ describe('createHOC function', () => {
     });
 
     // Nothing to hoist on stateless components
+  });
+
+  describe('displayName', () => {
+    it('should be inheritted from ChildComponent', () => {
+      class Component extends React.Component {
+        static displayName = "i'm batman";
+        render() {
+          return null;
+        }
+      }
+
+      const HocComponent = createHOC(Component);
+      const wrapper = render(<HocComponent/>);
+      expect(wrapper.name()).toEqual("i'm batman");
+    });
+
+    it('should be className when displayName is undefined', () => {
+      class Spiderman extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      const HocComponent = createHOC(Spiderman);
+      const wrapper = render(<HocComponent/>);
+      expect(wrapper.name()).toEqual('Spiderman');
+    });
+
+    it('should fallback to `WixComponent` when neither displayName nor className available', () => {
+      // component as anonymous function
+      const HocComponent = createHOC(() => null);
+      const wrapper = render(<HocComponent/>)
+      expect(wrapper.name()).toEqual('WixComponent');
+    });
   });
 });

--- a/packages/wix-ui-core/src/createHOC/index.tsx
+++ b/packages/wix-ui-core/src/createHOC/index.tsx
@@ -20,7 +20,7 @@ export const createHOC = Component => {
       dataClass: string
     };
 
-    static displayName = Component.displayName || 'WixComponent';
+    static displayName = Component.displayName || Component.name || 'WixComponent';
 
     componentDidMount() {
       const {dataHook, dataClass} = this.props;


### PR DESCRIPTION
1. some tests to cover displayName functionality of `createHOC`
1. use `Component.displayName || Component.name || 'WixComponent'`

this fixes displayName for components that don't explicitly set it.
However, for components that are anonymous functions, it's gonna
fallback to `'WixComponent'` which may or may not be desired behaviour.