### PR TITLE
chore(*): add missing `displayName`s

### DIFF
--- a/packages/wix-ui-core/src/baseComponents/DropdownOption/DropdownOption.tsx
+++ b/packages/wix-ui-core/src/baseComponents/DropdownOption/DropdownOption.tsx
@@ -31,3 +31,5 @@ export const DropdownOption: DropdownOptionType = (props: DropdownOptionProps) =
     </div>
   );
 };
+
+DropdownOption.displayName = 'DropdownOption';

--- a/packages/wix-ui-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/wix-ui-core/src/components/Checkbox/Checkbox.tsx
@@ -27,6 +27,8 @@ export interface CheckboxState {
 }
 
 export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
+  static displayName = 'Checkbox';
+
   public static defaultProps: Partial<CheckboxProps> = {
     onChange: noop,
     checked: false,

--- a/packages/wix-ui-core/src/components/Input/Input.tsx
+++ b/packages/wix-ui-core/src/components/Input/Input.tsx
@@ -41,6 +41,8 @@ export interface InputState {
 }
 
 export class Input extends React.Component<InputProps, InputState> {
+  static displayName = 'Input';
+
   static propTypes = {
     /** Wrapper class name */
     className: PropTypes.string,

--- a/packages/wix-ui-core/src/components/Label/Label.tsx
+++ b/packages/wix-ui-core/src/components/Label/Label.tsx
@@ -28,6 +28,8 @@ export const Label: React.SFC<LabelProps> = props => {
   return <label {...style('root', {ellipsis, disabled}, props)} htmlFor={props.for} id={id}>{children}</label>;
 };
 
+Label.displayName = 'Label';
+
 Label.propTypes = {
   /** class name */
   className: string,

--- a/packages/wix-ui-core/src/components/LinearProgressBar/LinearProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/LinearProgressBar/LinearProgressBar.tsx
@@ -74,6 +74,8 @@ export const LinearProgressBar: React.SFC<LinearProgressBarProps> = (props: Line
     </div>);
 }
 
+LinearProgressBar.displayName = 'LinearProgressBar';
+
 LinearProgressBar.propTypes = {
   value: oneOfType([number, string]),
   error: bool,

--- a/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/Pagination/Pagination.tsx
@@ -55,6 +55,8 @@ export interface PaginationState {
 }
 
 export class Pagination extends React.Component<PaginationProps, PaginationState> {
+  static displayName = 'Pagination';
+
   // this is a technical debt - remove once we have support for typescript props in autodocs
   static propTypes: Object = {
     /** The number of pages available to paginate */

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -146,6 +146,8 @@ const shouldAnimatePopover = ({timeout}: PopoverProps) => !!timeout;
  * Popover
  */
 export class Popover extends React.Component<PopoverType, PopoverState> {
+  static displayName = 'Popover';
+
   static Element = createComponentThatRendersItsChildren('Popover.Element');
   static Content = createComponentThatRendersItsChildren('Popover.Content');
 

--- a/packages/wix-ui-core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/wix-ui-core/src/components/RadioButton/RadioButton.tsx
@@ -45,6 +45,7 @@ export interface RadioButtonState {
 }
 
 export class RadioButton extends React.Component<RadioButtonProps, RadioButtonState> {
+  static displayName = 'RadioButton';
 
   state = {
     focused: false

--- a/packages/wix-ui-core/src/components/Slider/Slider.tsx
+++ b/packages/wix-ui-core/src/components/Slider/Slider.tsx
@@ -45,6 +45,8 @@ export interface SliderState {
 const CONTINUOUS_STEP = 0.01;
 
 export class Slider extends React.PureComponent<SliderProps, SliderState> {
+  static displayName = 'Slider';
+
   root: HTMLDivElement;
   track: HTMLDivElement;
 

--- a/packages/wix-ui-core/src/components/Video/Video.tsx
+++ b/packages/wix-ui-core/src/components/Video/Video.tsx
@@ -80,6 +80,7 @@ const mapPropsToMethods = {
 };
 
 export class Video extends React.PureComponent<VideoProps, VideoState> {
+  static displayName = 'Video';
 
   containerRef: HTMLDivElement;
   player: any;


### PR DESCRIPTION
setting explicit `displayName` is required for automated documentation tools to show correct names.
this is because at the time of parsing, components are usually proxied, minified, decorated or similarly migneld and so it's unknown what the actual component name is. so, it's better and easier to just explicitly say the name