### PR TITLE
Mocha runner: ts-loader cannot resolve certain dependencies, use ATL instead

### DIFF
--- a/packages/wix-ui-mocha-runner/package.json
+++ b/packages/wix-ui-mocha-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wix-ui-mocha-runner",
   "description": "wix-ui-mocha-runner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "author": {
     "name": "Wix",
@@ -19,6 +19,7 @@
     "wix-ui-mocha-runner": "bin/runner.js"
   },
   "dependencies": {
+    "awesome-typescript-loader": "^5.1.1",
     "chalk": "^2.4.1",
     "css-loader": "^0.28.11",
     "html-webpack-plugin": "^3.2.0",
@@ -26,7 +27,6 @@
     "stylable": "^5.3.9",
     "stylable-webpack-plugin": "^1.0.18",
     "style-loader": "^0.21.0",
-    "ts-loader": "^4.3.0",
     "typescript": "~2.8.3",
     "webpack": "^4.9.1",
     "webpack-serve": "^1.0.4"

--- a/packages/wix-ui-mocha-runner/src/server.js
+++ b/packages/wix-ui-mocha-runner/src/server.js
@@ -64,20 +64,12 @@ const webpackConfig = {
       {
         test: /\.tsx?$/,
         exclude: /node_modules/,
-        use: [
-          {
-            loader: 'ts-loader',
-            options: {
-              // wix-ui-core emits TypeScript errors related to Protractor
-              // during transpilation if wix-ui-test-utils is a linked
-              // dependency. Yoshi ts-loader config silences those errors,
-              // which allows the project to compile. Let's do the same here
-              // to get this thing up and running, and fix the repo in the
-              // distant future.
-              happyPackMode: true
-            }
+        use: {
+          loader: 'awesome-typescript-loader',
+          options: {
+            silent: true
           }
-        ]
+        }
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
I dug deeper into the problem with types in wix-ui, and it's pretty messy, there doesn't seem to be a single root cause of the problem. It arises from combination of ts-loader, webpack import resolution algorithm, linked packages, and certain self-referential type declarations.

I was able to replicate the bug outside of wix-ui by linking two repos that both depend on selenium-webdriver, and both import the same type from it. But the bug only occurs when ts-loader is used (which uses webpack to resolve imports instead of typescript compiler).

One possible solution is to hoist all dependencies into the root of the monorepo, and thus avoid duplicate type declarations, another is to use some alternative to ts-loader.

`awesome-typescript-loader` doesn't trigger the bug with types, so we don't need to silence the errors, which is strictly better than using `happyPackMode`. It's only used for browser tests, storybook and e2e tests use `ts-loader` provided by Yoshi.