### PR TITLE
Mocha runner: use for unit tests, again

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -26,7 +26,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "posttest": "npm run lint",
     "test:watch": "yoshi test --jest --watch",
-    "test:unit": "yoshi test --jest --karma",
+    "test:unit": "yoshi test --jest && wix-ui-mocha-runner",
     "test:e2e": "yoshi test --protractor",
     "lint": "yoshi lint",
     "yoshi-start": "yoshi start --no-test",
@@ -37,7 +37,7 @@
     "import-path": "node scripts/import-path.js",
     "transpile-mixins": "babel src/mixins -d dist/src/mixins",
     "generate-stylable-index": "stc --srcDir=\"./dist/src\" --diagnostics",
-    "test:browser": "yoshi test --karma"
+    "test:browser": "wix-ui-mocha-runner"
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -88,6 +88,7 @@
     "wix-eventually": "latest",
     "wix-storybook-utils": "^1.0.0",
     "wix-ui-icons-common": "^1.0.0",
+    "wix-ui-mocha-runner": "^0.1.6",
     "yoshi": "^2.7.0"
   },
   "license": "MIT",


### PR DESCRIPTION
After working around the type definitions issue and adding source maps I think we're ready. Just need to see it passing on CI.