### PR TITLE
Mocha runner: run on Teamcity without sandbox

### DIFF
--- a/packages/wix-ui-mocha-runner/package.json
+++ b/packages/wix-ui-mocha-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wix-ui-mocha-runner",
   "description": "wix-ui-mocha-runner",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": false,
   "author": {
     "name": "Wix",

--- a/packages/wix-ui-mocha-runner/src/run-in-puppeteer.js
+++ b/packages/wix-ui-mocha-runner/src/run-in-puppeteer.js
@@ -49,7 +49,7 @@ function failOnPageError(page) {
   });
 }
 
-module.exports = async (testPageUrl) => {
+module.exports = async ({testPageUrl, noSandbox}) => {
   const loadTimeout = 20000;
   const testTimeout = 5000;
   const viewportWidth = 800;
@@ -57,7 +57,8 @@ module.exports = async (testPageUrl) => {
 
   let browser;
   try {
-    browser = await puppeteer.launch({headless: true});
+    const args = noSandbox ? ['--no-sandbox', '--disable-setuid-sandbox'] : [];
+    browser = await puppeteer.launch({headless: true, args});
     const page = await browser.newPage();
     await page.setViewport({width: viewportWidth, height: viewportHeight});
 


### PR DESCRIPTION
Chromium fails to launch on some of our EC2 instances with the following error:

FATAL:zygote_host_impl_linux.cc(127)] No usable sandbox!
Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md
for more information on developing with the SUID sandbox. If you want to live
dangerously and need an immediate workaround, you can try using --no-sandbox.