### PR TITLE
`<Popover/>` - Fix Popover.spec to use Popover.driver

### DIFF
--- a/packages/wix-ui-core/src/common/BaseDriver.tests.ts
+++ b/packages/wix-ui-core/src/common/BaseDriver.tests.ts
@@ -1,0 +1,29 @@
+import { BaseDriver } from './BaseDriver';
+export function runBaseDriverTests(createElement: ()=> HTMLElement) {
+
+  describe('BaseDriver', () => {
+    let driver: BaseDriver;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+      element = createElement();
+      driver = new BaseDriver({element});
+    });
+
+    it('exists', () => {
+      expect(driver.exists()).toBeTruthy();
+    });
+
+    it('mouseEnter', () => {
+      expect(driver.mouseEnter).toBeDefined();
+    });
+
+    it('mouseLeave', () => {
+      expect(driver.mouseLeave).toBeDefined();
+    });
+
+    it('click', () => {
+      expect(driver.click).toBeDefined();
+    });
+  });
+}

--- a/packages/wix-ui-core/src/common/BaseDriver.tests.ts
+++ b/packages/wix-ui-core/src/common/BaseDriver.tests.ts
@@ -14,16 +14,5 @@ export function runBaseDriverTests(createElement: ()=> HTMLElement) {
       expect(driver.exists()).toBeTruthy();
     });
 
-    it('mouseEnter', () => {
-      expect(driver.mouseEnter).toBeDefined();
-    });
-
-    it('mouseLeave', () => {
-      expect(driver.mouseLeave).toBeDefined();
-    });
-
-    it('click', () => {
-      expect(driver.click).toBeDefined();
-    });
   });
 }

--- a/packages/wix-ui-core/src/common/BaseDriver.ts
+++ b/packages/wix-ui-core/src/common/BaseDriver.ts
@@ -1,0 +1,21 @@
+import { Simulate } from 'react-dom/test-utils';
+
+export interface DriverArgs {
+  element: HTMLElement;
+  eventTrigger: typeof Simulate;
+}
+
+export class BaseDriver {
+  readonly element : HTMLElement;
+  readonly eventTrigger: typeof Simulate;
+
+  constructor({element, eventTrigger}: DriverArgs) {
+    this.element = element;
+    this.eventTrigger = eventTrigger || Simulate;
+  }
+
+  exists = () => !!this.element;
+  mouseEnter = () =>  this.eventTrigger.mouseEnter(this.element);
+  mouseLeave = () =>  this.eventTrigger.mouseLeave(this.element);
+  click = () => this.eventTrigger.click(this.element);
+}

--- a/packages/wix-ui-core/src/common/BaseDriver.ts
+++ b/packages/wix-ui-core/src/common/BaseDriver.ts
@@ -2,7 +2,7 @@ import { Simulate } from 'react-dom/test-utils';
 
 export interface DriverArgs {
   element: HTMLElement;
-  eventTrigger: typeof Simulate;
+  eventTrigger?: typeof Simulate;
 }
 
 export class BaseDriver {

--- a/packages/wix-ui-core/src/common/BaseDriver.ts
+++ b/packages/wix-ui-core/src/common/BaseDriver.ts
@@ -1,21 +1,21 @@
 import { Simulate } from 'react-dom/test-utils';
 
-export interface DriverArgs {
+export interface DriverBuilderParams {
   element: HTMLElement;
   eventTrigger?: typeof Simulate;
 }
 
+/**
+ * Base class for public drivers (exposed to consumers)
+ */
 export class BaseDriver {
-  readonly element : HTMLElement;
-  readonly eventTrigger: typeof Simulate;
+  protected readonly element : HTMLElement;
+  protected readonly eventTrigger: typeof Simulate;
 
-  constructor({element, eventTrigger}: DriverArgs) {
+  constructor({element, eventTrigger}: DriverBuilderParams) {
     this.element = element;
     this.eventTrigger = eventTrigger || Simulate;
   }
 
   exists = () => !!this.element;
-  mouseEnter = () =>  this.eventTrigger.mouseEnter(this.element);
-  mouseLeave = () =>  this.eventTrigger.mouseLeave(this.element);
-  click = () => this.eventTrigger.click(this.element);
 }

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.private.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.private.ts
@@ -1,20 +1,30 @@
+import { Simulate } from 'react-dom/test-utils';
 const queryDocumentOrElement = (element, query) => ((element && element.querySelectorAll(query)[0]) || document && document.querySelector(query));
 const getTargetElement = (element: Element | undefined) => element && element.querySelectorAll('[data-hook="popover-element"]')[0];
 const getContentElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-content"]');
 const getArrowElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-arrow"]');
 const getPortalElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-portal"]');
 
-export const popoverPrivateDriverFactory = ({element, eventTrigger}) => ({
-  getTargetElement: () => getTargetElement(element),
-  getContentElement: () => getContentElement(element),
-  isTargetElementExists: () => !!getTargetElement(element),
-  isContentElementExists: () => !!getContentElement(element),
-  mouseEnter: () => eventTrigger.mouseEnter(element),
-  mouseLeave: () => eventTrigger.mouseLeave(element),
-  inlineStyles: () => element.style,
-  getArrowOffset: () => {
-    const {top, left, right, bottom} = (getArrowElement(element) as HTMLElement).style;
+export class PopoverDriverPrivate {
+  readonly element:HTMLElement;
+  readonly eventTrigger: typeof Simulate;
+
+  constructor({element, eventTrigger}) {
+    this.element = element;
+    this.eventTrigger = eventTrigger || Simulate;
+  }
+
+  getTargetElement = () =>  getTargetElement(this.element);
+  getContentElement = () =>  getContentElement(this.element);
+  isTargetElementExists = () =>  !!getTargetElement(this.element);
+  isContentElementExists = () =>  !!getContentElement(this.element);
+  mouseEnter = () =>  this.eventTrigger.mouseEnter(this.element);
+  mouseLeave = () =>  this.eventTrigger.mouseLeave(this.element);
+  inlineStyles = () =>  this.element.style;
+  getArrowOffset = () => {
+    const {top, left, right, bottom} = (getArrowElement(this.element) as HTMLElement).style;
     return {top, left, right, bottom};
-  },
-  getPortalElement: () => getPortalElement(element),
-});
+  }
+  getPortalElement = () =>  getPortalElement(this.element);
+
+};

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.private.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.private.ts
@@ -1,25 +1,21 @@
-import { Simulate } from 'react-dom/test-utils';
+import { BaseDriver , DriverArgs} from './../../common/BaseDriver';
+
 const queryDocumentOrElement = (element, query) => ((element && element.querySelectorAll(query)[0]) || document && document.querySelector(query));
 const getTargetElement = (element: Element | undefined) => element && element.querySelectorAll('[data-hook="popover-element"]')[0];
 const getContentElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-content"]');
 const getArrowElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-arrow"]');
 const getPortalElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-portal"]');
 
-export class PopoverDriverPrivate {
-  readonly element:HTMLElement;
-  readonly eventTrigger: typeof Simulate;
+export class PopoverDriverPrivate extends BaseDriver {
 
-  constructor({element, eventTrigger}) {
-    this.element = element;
-    this.eventTrigger = eventTrigger || Simulate;
+  constructor(driverArgs: DriverArgs) {
+    super(driverArgs)
   }
 
   getTargetElement = () =>  getTargetElement(this.element);
   getContentElement = () =>  getContentElement(this.element);
   isTargetElementExists = () =>  !!getTargetElement(this.element);
   isContentElementExists = () =>  !!getContentElement(this.element);
-  mouseEnter = () =>  this.eventTrigger.mouseEnter(this.element);
-  mouseLeave = () =>  this.eventTrigger.mouseLeave(this.element);
   inlineStyles = () =>  this.element.style;
   getArrowOffset = () => {
     const {top, left, right, bottom} = (getArrowElement(this.element) as HTMLElement).style;

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.private.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.private.ts
@@ -1,0 +1,12 @@
+const queryDocumentOrElement = (element, query) => ((element && element.querySelectorAll(query)[0]) || document && document.querySelector(query));
+
+const getArrowElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-arrow"]');
+const getPortalElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-portal"]');
+
+export const popoverPrivateDriverFactory = ({element, eventTrigger}) => ({
+  getArrowOffset: () => {
+    const {top, left, right, bottom} = (getArrowElement(element) as HTMLElement).style;
+    return {top, left, right, bottom};
+  },
+  getPortalElement: () => getPortalElement(element),
+});

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.private.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.private.ts
@@ -1,9 +1,17 @@
 const queryDocumentOrElement = (element, query) => ((element && element.querySelectorAll(query)[0]) || document && document.querySelector(query));
-
+const getTargetElement = (element: Element | undefined) => element && element.querySelectorAll('[data-hook="popover-element"]')[0];
+const getContentElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-content"]');
 const getArrowElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-arrow"]');
 const getPortalElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-portal"]');
 
 export const popoverPrivateDriverFactory = ({element, eventTrigger}) => ({
+  getTargetElement: () => getTargetElement(element),
+  getContentElement: () => getContentElement(element),
+  isTargetElementExists: () => !!getTargetElement(element),
+  isContentElementExists: () => !!getContentElement(element),
+  mouseEnter: () => eventTrigger.mouseEnter(element),
+  mouseLeave: () => eventTrigger.mouseLeave(element),
+  inlineStyles: () => element.style,
   getArrowOffset: () => {
     const {top, left, right, bottom} = (getArrowElement(element) as HTMLElement).style;
     return {top, left, right, bottom};

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
@@ -1,17 +1,17 @@
-const queryDocumentOrElement = (element, query) => ((element && element.querySelectorAll(query)[0]) || document && document.querySelector(query));
-const getTargetElement = (element: Element | undefined) => element && element.querySelectorAll('[data-hook="popover-element"]')[0];
-const getContentElement = (element: Element | undefined) => queryDocumentOrElement(element, '[data-hook="popover-content"]');
-const getArrowElement = (element: Element | undefined) => element && element.querySelectorAll('[data-hook="popover-arrow"]')[0];
+import {popoverPrivateDriverFactory} from './Popover.driver.private';
 
-export const popoverDriverFactory = ({element, eventTrigger}) => ({
-  exists: () => !!element,
-  getTargetElement: () => getTargetElement(element),
-  getContentElement: () => getContentElement(element),
-  isTargetElementExists: () => !!getTargetElement(element),
-  isContentElementExists: () => !!getContentElement(element),
-  mouseEnter: () => eventTrigger.mouseEnter(element),
-  mouseLeave: () => eventTrigger.mouseLeave(element),
-  click: () => eventTrigger.click(element),
+export const popoverDriverFactory = ({element, eventTrigger}) => {
+  const p = popoverPrivateDriverFactory({element, eventTrigger});
   
-  inlineStyles: () => element.style
-});
+  return {
+    exists: () => !!element,
+    getTargetElement: p.getTargetElement,
+    getContentElement: p.getContentElement,
+    isTargetElementExists: p.isTargetElementExists,
+    isContentElementExists: p.isContentElementExists,   
+    mouseEnter: () => eventTrigger.mouseEnter(element),
+    mouseLeave: () => eventTrigger.mouseLeave(element),
+    click: () => eventTrigger.click(element),
+    inlineStyles: () => element.style,
+  }
+};

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
@@ -1,7 +1,7 @@
-import {popoverPrivateDriverFactory} from './Popover.driver.private';
+import {PopoverDriverPrivate} from './Popover.driver.private';
 
 export const popoverDriverFactory = ({element, eventTrigger}) => {
-  const p = popoverPrivateDriverFactory({element, eventTrigger});
+  const p = new PopoverDriverPrivate({element, eventTrigger});
   
   return {
     exists: () => !!element,

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
@@ -1,17 +1,23 @@
 import {PopoverDriverPrivate} from './Popover.driver.private';
+import {BaseDriver, DriverArgs} from '../../common/BaseDriver';
+ 
+export class PopoverDriver extends BaseDriver {
+  private readonly p: PopoverDriverPrivate;
 
-export const popoverDriverFactory = ({element, eventTrigger}) => {
-  const p = new PopoverDriverPrivate({element, eventTrigger});
-  
-  return {
-    exists: () => !!element,
-    getTargetElement: p.getTargetElement,
-    getContentElement: p.getContentElement,
-    isTargetElementExists: p.isTargetElementExists,
-    isContentElementExists: p.isContentElementExists,   
-    mouseEnter: () => eventTrigger.mouseEnter(element),
-    mouseLeave: () => eventTrigger.mouseLeave(element),
-    click: () => eventTrigger.click(element),
-    inlineStyles: () => element.style,
+  constructor(driverArgs: DriverArgs) {
+    super(driverArgs);
+    this.p = new PopoverDriverPrivate(driverArgs);
   }
+
+  getTargetElement = () => this.p.getTargetElement();
+  getContentElement = () => this.p.getContentElement();
+  isTargetElementExists = () => this.p.isTargetElementExists();
+  isContentElementExists = () => this.p.isContentElementExists();   
+  inlineStyles = () => this.element.style
+}
+
+export const popoverDriverFactory = (driverArgs: DriverArgs) => {
+  return {
+    ...new PopoverDriver(driverArgs)
+  };
 };

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
@@ -1,6 +1,6 @@
 import {PopoverDriverPrivate} from './Popover.driver.private';
 import {BaseDriver, DriverArgs} from '../../common/BaseDriver';
- 
+
 export class PopoverDriver extends BaseDriver {
   private readonly p: PopoverDriverPrivate;
 
@@ -12,8 +12,8 @@ export class PopoverDriver extends BaseDriver {
   getTargetElement = () => this.p.getTargetElement();
   getContentElement = () => this.p.getContentElement();
   isTargetElementExists = () => this.p.isTargetElementExists();
-  isContentElementExists = () => this.p.isContentElementExists();   
-  inlineStyles = () => this.element.style
+  isContentElementExists = () => this.p.isContentElementExists();
+  inlineStyles = () => this.element.style;
 }
 
 export const popoverDriverFactory = (driverArgs: DriverArgs) => {

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
@@ -12,9 +12,6 @@ export const popoverDriverFactory = ({element, eventTrigger}) => ({
   mouseEnter: () => eventTrigger.mouseEnter(element),
   mouseLeave: () => eventTrigger.mouseLeave(element),
   click: () => eventTrigger.click(element),
-  getArrowOffset: () => {
-    const {top, left, right, bottom} = (getArrowElement(element) as HTMLElement).style;
-    return {top, left, right, bottom};
-  },
+  
   inlineStyles: () => element.style
 });

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
@@ -1,12 +1,19 @@
 import {PopoverDriverPrivate} from './Popover.driver.private';
 import {BaseDriver, DriverArgs} from '../../common/BaseDriver';
 
+const PRIVATE_DRIVER = Symbol('private driver');
+
 export class PopoverDriver extends BaseDriver {
-  private readonly p: PopoverDriverPrivate;
+
+  private readonly [PRIVATE_DRIVER]: PopoverDriverPrivate;
 
   constructor(driverArgs: DriverArgs) {
     super(driverArgs);
-    this.p = new PopoverDriverPrivate(driverArgs);
+    this[PRIVATE_DRIVER] = new PopoverDriverPrivate(driverArgs);
+  }
+
+  get p() {
+    return this[PRIVATE_DRIVER];
   }
 
   getTargetElement = () => this.p.getTargetElement();

--- a/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/Popover/Popover.driver.ts
@@ -1,29 +1,28 @@
-import {PopoverDriverPrivate} from './Popover.driver.private';
-import {BaseDriver, DriverArgs} from '../../common/BaseDriver';
-
-const PRIVATE_DRIVER = Symbol('private driver');
+import { queryHook } from 'wix-ui-test-utils/dom';
+import {BaseDriver, DriverBuilderParams} from '../../common/BaseDriver';
 
 export class PopoverDriver extends BaseDriver {
 
-  private readonly [PRIVATE_DRIVER]: PopoverDriverPrivate;
-
-  constructor(driverArgs: DriverArgs) {
+  constructor(driverArgs: DriverBuilderParams) {
     super(driverArgs);
-    this[PRIVATE_DRIVER] = new PopoverDriverPrivate(driverArgs);
   }
 
-  get p() {
-    return this[PRIVATE_DRIVER];
+  private byHook(dataHook: string) {
+    return queryHook<HTMLElement>(this.element, dataHook) || queryHook<HTMLElement>(document, dataHook) ;
   }
 
-  getTargetElement = () => this.p.getTargetElement();
-  getContentElement = () => this.p.getContentElement();
-  isTargetElementExists = () => this.p.isTargetElementExists();
-  isContentElementExists = () => this.p.isContentElementExists();
+  getTargetElement = () =>  this.byHook('popover-element');
+  getContentElement = () =>  this.byHook('popover-content');
+  isTargetElementExists = () =>  !!this.getTargetElement();
+  isContentElementExists = () =>  !!this.getContentElement();
+  
   inlineStyles = () => this.element.style;
+  mouseEnter = () =>  this.eventTrigger.mouseEnter(this.element);
+  mouseLeave = () =>  this.eventTrigger.mouseLeave(this.element);
+  click = () => this.eventTrigger.click(this.element);
 }
 
-export const popoverDriverFactory = (driverArgs: DriverArgs) => {
+export const popoverDriverFactory = (driverArgs: DriverBuilderParams) => {
   return {
     ...new PopoverDriver(driverArgs)
   };

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -22,14 +22,7 @@ const popoverWithProps = (props: PopoverProps) => (
 describe('Popover', () => {
   const container = new ReactDOMTestContainer().destroyAfterEachTest();
 
-  const createDriver = ()=> popoverDriverFactory(
-    {
-      element: container.componentNode, 
-      eventTrigger: Simulate
-    }
-  );
-
-  const createPrivateDriver = ()=> popoverPrivateDriverFactory(
+  const createDriver = ()=> popoverPrivateDriverFactory(
     {
       element: container.componentNode, 
       eventTrigger: Simulate
@@ -83,7 +76,7 @@ describe('Popover', () => {
         showArrow: true,
         moveArrowTo: 10
       }));
-      const driver = createPrivateDriver();
+      const driver = createDriver();
       expect(driver.getArrowOffset().left).toBe('10px');
     });
   });
@@ -138,7 +131,7 @@ describe('Popover', () => {
       }));
 
       const driver = createDriver();
-      const privateDriver = createPrivateDriver();
+      const privateDriver = createDriver();
       expect(driver.getContentElement().parentElement).toBe(privateDriver.getPortalElement());
       expect(privateDriver.getPortalElement().parentElement).toBe(portalContainer.node);
       expect(privateDriver.getPortalElement().classList).toContain(styles.root);
@@ -152,7 +145,7 @@ describe('Popover', () => {
       }));
 
       const driver = createDriver();
-      const privateDriver = createPrivateDriver();
+      const privateDriver = createDriver();
       expect(driver.isContentElementExists()).toBeFalsy();
       expect(privateDriver.getPortalElement().parentElement).toBe(portalContainer.node);
       expect(privateDriver.getPortalElement().classList).not.toContain(styles.root);
@@ -165,7 +158,7 @@ describe('Popover', () => {
         appendTo: portalContainer.node
       }));
 
-      const privateDriver = createPrivateDriver();
+      const privateDriver = createDriver();
       expect(privateDriver.getPortalElement()).toBeTruthy();
       container.unmount();
       expect(privateDriver.getPortalElement()).toBeNull();
@@ -178,7 +171,7 @@ describe('Popover', () => {
         appendTo: 'window'
       }));
 
-      const privateDriver = createPrivateDriver();
+      const privateDriver = createDriver();
       expect(privateDriver.getPortalElement().parentElement).toBe(document.body);
     });
 
@@ -195,7 +188,7 @@ describe('Popover', () => {
         </div>
       );
       
-      const privateDriver = createPrivateDriver();
+      const privateDriver = createDriver();
       expect(privateDriver.getPortalElement().parentElement).toBe(container.node.firstChild);
     });
   });

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -260,5 +260,20 @@ describe('Popover', () => {
       const driver = createPublicDriver();
       expect(driver.inlineStyles()['background-color']).toBe('green')
     });
+
+    it('mouseEnter', () => {
+      const driver = createPublicDriver();
+      expect(driver.mouseEnter).toBeDefined();
+    });
+
+    it('mouseLeave', () => {
+      const driver = createPublicDriver();
+      expect(driver.mouseLeave).toBeDefined();
+    });
+
+    it('click', () => {
+      const driver = createPublicDriver();
+      expect(driver.click).toBeDefined();
+    });
   });
 });

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -4,7 +4,7 @@ import {queryHook} from 'wix-ui-test-utils/dom';
 import * as eventually from 'wix-eventually';
 import {runBaseDriverTests} from '../../common/BaseDriver.tests';
 import {Popover, PopoverProps} from './';
-import {popoverDriverFactory} from './Popover.driver';
+import {popoverDriverFactory, PopoverDriver} from './Popover.driver';
 import {PopoverDriverPrivate} from './Popover.driver.private';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
 import styles from './Popover.st.css';
@@ -201,6 +201,56 @@ describe('Popover', () => {
         }));
         return container.componentNode;
     }
+
     runBaseDriverTests(createElement);
+
+    const createPublicDriver = ()=> popoverDriverFactory(
+      {
+        element: container.componentNode
+      }
+    );
+
+    const render = (props?:Partial<PopoverProps>) => container.render(popoverWithProps({
+      placement: 'bottom',
+      shown: false,
+      ...props
+    }));
+
+    it('getTargetElement', async () => {
+      render();  
+      const driver = createPublicDriver();
+      expect(driver.getTargetElement()).toBeDefined();
+    });
+
+    it('getContentElement', async () => {
+      render();  
+      const driver = createPublicDriver();
+      expect(driver.getContentElement()).toBeDefined();
+    });
+
+    it('isTargetElementExists', async () => {
+      render();  
+      const driver = createPublicDriver();
+      expect(driver.isTargetElementExists()).toBeTruthy();
+    });
+
+    it('isContentElementExists', async () => {
+      render({shown:true});  
+      const driver = createPublicDriver();
+      expect(driver.isContentElementExists()).toBeTruthy();
+    });
+
+    it('isTargetElementExists', async () => {
+      render();  
+      const driver = createPublicDriver();
+      expect(driver.inlineStyles()).toBeTruthy();
+    });
+
+    it('inlineStyles', async () => {
+      const style = {backgroundColor: 'green'};
+      render({style});  
+      const driver = createPublicDriver();
+      expect(driver.inlineStyles()['background-color']).toBe('green')
+    });
   });
 });

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -3,7 +3,7 @@ import {Simulate} from 'react-dom/test-utils';
 import {queryHook} from 'wix-ui-test-utils/dom';
 import {Popover, PopoverProps} from './';
 import {popoverDriverFactory} from './Popover.driver';
-import {popoverPrivateDriverFactory} from './Popover.driver.private';
+import {PopoverDriverPrivate} from './Popover.driver.private';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
 import * as eventually from 'wix-eventually';
 import styles from './Popover.st.css';
@@ -22,10 +22,9 @@ const popoverWithProps = (props: PopoverProps) => (
 describe('Popover', () => {
   const container = new ReactDOMTestContainer().destroyAfterEachTest();
 
-  const createDriver = ()=> popoverPrivateDriverFactory(
+  const createDriver = ()=> new PopoverDriverPrivate(
     {
-      element: container.componentNode, 
-      eventTrigger: Simulate
+      element: container.componentNode
     }
   );
 

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import {Simulate} from 'react-dom/test-utils';
 import {queryHook} from 'wix-ui-test-utils/dom';
+import * as eventually from 'wix-eventually';
+import {runBaseDriverTests} from '../../common/BaseDriver.tests';
 import {Popover, PopoverProps} from './';
 import {popoverDriverFactory} from './Popover.driver';
 import {PopoverDriverPrivate} from './Popover.driver.private';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
-import * as eventually from 'wix-eventually';
 import styles from './Popover.st.css';
 
 const popoverWithProps = (props: PopoverProps) => (
@@ -190,5 +191,16 @@ describe('Popover', () => {
       const privateDriver = createDriver();
       expect(privateDriver.getPortalElement().parentElement).toBe(container.node.firstChild);
     });
+  });
+
+  describe('public driver', () => {
+    const createElement = () => {
+        container.render(popoverWithProps({
+          placement: 'bottom',
+          shown: false
+        }));
+        return container.componentNode;
+    }
+    runBaseDriverTests(createElement);
   });
 });

--- a/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.spec.tsx
@@ -216,6 +216,14 @@ describe('Popover', () => {
       ...props
     }));
 
+    it('PopoverDriver class sanity', async () => {
+      render();  
+      const driver = new PopoverDriver({
+        element: container.componentNode
+      });
+      expect(driver.getTargetElement()).toBeDefined();
+    });
+
     it('getTargetElement', async () => {
       render();  
       const driver = createPublicDriver();


### PR DESCRIPTION
As part of mocha runner refactoring, @alisey rewrote the Popover specs, and removed the usage of the Popover.driver. 
I fixed it so it uses the driver, so that our driver is verified.
- moved the `getArrowOffest` driver method to a private driver (I didn't see anyone using it in core or backoffice, and I don't think consumers need it).