### PR TITLE
feat(AutoExample): support `codeExample` config

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -87,7 +87,10 @@ export default class extends Component {
     exampleProps: PropTypes.object,
 
     /** when true, display only component preview without interactive props nor code example */
-    isInteractive: PropTypes.bool
+    isInteractive: PropTypes.bool,
+
+    /** currently only `false` possible. later same property shall be used for configuring code example */
+    codeExample: PropTypes.bool
   }
 
   static defaultProps = {
@@ -96,7 +99,8 @@ export default class extends Component {
     componentProps: {},
     parsedSource: {},
     exampleProps: {},
-    isInteractive: true
+    isInteractive: true,
+    codeExample: true
   }
 
   _initialPropsState = {};
@@ -353,10 +357,12 @@ export default class extends Component {
           children={React.createElement(this.props.component, componentProps)}
           />
 
-        <Code
-          dataHook="metadata-codeblock"
-          component={React.createElement(this.props.component, codeProps)}
-          />
+        { this.props.codeExample &&
+          <Code
+            dataHook="metadata-codeblock"
+            component={React.createElement(this.props.component, codeProps)}
+            />
+        }
       </Wrapper>
     );
   }

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import {Option} from './components';
+import {Option, Code} from './components';
 import AutoExample from './';
 
 class Driver {
@@ -13,7 +13,8 @@ class Driver {
   }
 
   get = {
-    options: () => this.component.find(Option)
+    options: () => this.component.find(Option),
+    codeBlock: () => this.component.find(Code)
   }
 }
 
@@ -99,6 +100,16 @@ describe('AutoExample', () => {
 
       const option = driver.get.options().props();
       expect(option.children).not.toBe(null);
+    });
+  });
+
+  describe('codeExample', () => {
+    it('should not render when `false`', () => {
+      const driver = new Driver();
+      driver.when.created({
+        codeExample: false
+      });
+      expect(driver.get.codeBlock().length).toEqual(0);
     });
   });
 });

--- a/packages/wix-storybook-utils/src/Story/index.js
+++ b/packages/wix-storybook-utils/src/Story/index.js
@@ -15,6 +15,7 @@ export default ({
   examples,
   exampleProps,
   exampleImport,
+  codeExample,
   _config,
   _metadata
 }) =>
@@ -44,6 +45,7 @@ export default ({
               exampleImport,
               displayName,
               examples,
+              codeExample,
               metadata: _metadata,
               config: _config
             }}

--- a/packages/wix-storybook-utils/src/StoryPage/index.js
+++ b/packages/wix-storybook-utils/src/StoryPage/index.js
@@ -49,7 +49,8 @@ const StoryPage = ({
   displayName,
   exampleProps,
   exampleImport,
-  examples
+  examples,
+  codeExample
 }) => {
   const visibleDisplayName = displayName || metadata.displayName;
   const visibleMetadata = {...metadata, displayName: visibleDisplayName};
@@ -87,6 +88,7 @@ const StoryPage = ({
           parsedSource={visibleMetadata}
           componentProps={componentProps}
           exampleProps={exampleProps}
+          codeExample={codeExample}
           />
 
         {examples}
@@ -117,7 +119,10 @@ StoryPage.propTypes = {
    * usually something like `import Component from 'module/Component';`
    */
   exampleImport: PropTypes.string,
-  examples: PropTypes.node
+  examples: PropTypes.node,
+
+  /** currently only `false` possible. later same property shall be used for configuring code example */
+  codeExample: PropTypes.bool
 };
 
 StoryPage.defaultProps = {

--- a/packages/wix-storybook-utils/src/StoryPage/index.test.js
+++ b/packages/wix-storybook-utils/src/StoryPage/index.test.js
@@ -22,7 +22,6 @@ describe('StoryPage', () => {
       const config = {
         importFormat: 'hey %moduleName, what\'s your name, %moduleName?',
         moduleName: 'dork'
-
       };
       testkit.when.created({config});
       expect(testkit.get.import()).toMatch('hey dork, what\'s your name, dork?');
@@ -90,13 +89,22 @@ describe('StoryPage', () => {
       };
 
       testkit.when.created(props);
-      expect(testkit.get.codeBlock()).toEqual(`\`\`\`js
+      expect(testkit.get.codeBlock().prop('source')).toEqual(`\`\`\`js
 <componentName>
   <div>
     <IShouldBeTheName />
   </div>
 </componentName>
 \`\`\``);
+    });
+
+    it('should not be rendered given `codeExample: false`', () => {
+      testkit.when.created({
+        component: () => '',
+        codeExample: false
+      });
+
+      expect(testkit.get.codeBlock().length).toEqual(0);
     });
   });
 });

--- a/packages/wix-storybook-utils/src/StoryPage/index.testkit.js
+++ b/packages/wix-storybook-utils/src/StoryPage/index.testkit.js
@@ -31,6 +31,6 @@ export default class {
       this.component.find('[dataHook="metadata-import"]').find(Markdown).prop('source'),
 
     codeBlock: () =>
-      this.component.find('[dataHook="metadata-codeblock"]').find(Markdown).prop('source')
+      this.component.find('[dataHook="metadata-codeblock"]').find(Markdown)
   }
 }


### PR DESCRIPTION
currently only `false` value supported. later on this property can be
used to configure code example (maybe pass a custom one or adjust some
display)