### PR TITLE
wix-storybook-utils - Add generic renderStory config

### DIFF
--- a/packages/wix-storybook-utils/src/Story/index.js
+++ b/packages/wix-storybook-utils/src/Story/index.js
@@ -16,6 +16,7 @@ export default ({
   exampleProps,
   exampleImport,
   codeExample,
+  renderStory,
   _config,
   _metadata
 }) =>
@@ -23,31 +24,52 @@ export default ({
     .storiesOf(category, module)
     .add(
       storyName || _metadata.displayName,
-      () =>
-        isE2E ?
-          <div>
-            <AutoExample
-              isInteractive={false}
-              ref={ref => global.autoexample = ref}
-              component={component}
-              componentProps={componentProps}
-              parsedSource={_metadata}
+      () => {
+        const manualStory = renderStory({
+          isTestMode: isE2E,
+          component,
+          displayName,
+          componentProps,
+          examples,
+          exampleProps,
+          exampleImport,
+          codeExample,
+          _config,
+          _metadata
+        });
+        if (manualStory) {
+          return manualStory;
+        }
+        if (isE2E) {
+          return (
+            <div>
+              <AutoExample
+                isInteractive={false}
+                ref={ref => global.autoexample = ref}
+                component={component}
+                componentProps={componentProps}
+                parsedSource={_metadata}
+                />
+
+              {queryString.parse(window.location.search).withExamples !== undefined && examples}
+            </div>
+          );
+        } else {
+          return (
+            <StoryPage
+              {...{
+                component,
+                componentProps,
+                exampleProps,
+                exampleImport,
+                displayName,
+                examples,
+                codeExample,
+                metadata: _metadata,
+                config: _config
+              }}
               />
-
-            {queryString.parse(window.location.search).withExamples !== undefined && examples}
-          </div> :
-
-          <StoryPage
-            {...{
-              component,
-              componentProps,
-              exampleProps,
-              exampleImport,
-              displayName,
-              examples,
-              codeExample,
-              metadata: _metadata,
-              config: _config
-            }}
-            />
+          );
+        }
+      }
       );

--- a/packages/wix-storybook-utils/src/Story/readme.md
+++ b/packages/wix-storybook-utils/src/Story/readme.md
@@ -1,3 +1,24 @@
 `story` is a function that calls `storiesOf` of storybook and passes
 relevant data to `StoryPage` - a dumb component that only renders received
-props
+props.
+
+## Usage
+* `renderManualStory` (()=>ReactElement): A function that return a manual story (overriding AutoDocs default template). It receives an object with all AutoDocs context, so you can manually build the story page from wix-storybokk-utils's components. In particular, the context includes an `isTestMode` which may be used for e2e tests. If it returns anything `falsy` then the AutoDocs default Story template (`<StoryPage/>`) would be rendered.
+
+```js
+export default {
+  ...
+  renderManualStory: ({
+    isTestMode: isE2E,
+    component,
+    displayName,
+    componentProps,
+    examples,
+    exampleProps,
+    exampleImport,
+    codeExample,
+    _config,
+    _metadata
+    }) => isTestMode ? <div>my test div</div> : undefined;
+}
+```


### PR DESCRIPTION
## Main motivation:
Allow rendering a test page instead of the AutoDocs story (for e2e tests)

## Secondary outcome
As an outcome of opening a `renderStory` property, it makes sense to pass the `renderStory` all the AutoDocs "context" , this object:
```js
{
    isTestMode: isE2E,
    component,
    displayName,
    componentProps,
    examples,
    exampleProps,
    exampleImport,
    codeExample,
    _config,
    _metadata
    }
```
So that we give total freedom to render a custom story page which may or may not use wix-storybook-utils component such as `<AutoExample/>`.