### PR TITLE
Add onStepClick callback to NavStepper

### DIFF
--- a/packages/wix-ui-core/src/components/NavStepper/NavStep.tsx
+++ b/packages/wix-ui-core/src/components/NavStepper/NavStep.tsx
@@ -14,12 +14,12 @@ export class NavStep extends React.PureComponent<NavStepProps> {
         disabled: bool
     }
     render () {
-        const {active, disabled, visited, children} = this.props;
+        const {active, disabled, visited, children, ...rest} = this.props;
         const ariaProps: any = {}
         active && (ariaProps['aria-current'] = 'page');
 
         return (
-            <li {...style('root', {active, visited, disabled}, this.props)} {...ariaProps}>
+            <li {...ariaProps} {...rest} {...style('root', {active, visited, disabled}, this.props)}>
                 {children}
             </li>
         );

--- a/packages/wix-ui-core/src/components/NavStepper/NavStepper.driver.ts
+++ b/packages/wix-ui-core/src/components/NavStepper/NavStepper.driver.ts
@@ -1,4 +1,5 @@
 import { BaseDriver, ComponentFactory, DriverFactory } from 'wix-ui-test-utils/driver-factory';
+import {Simulate} from 'react-dom/test-utils';
 import {StylableDOMUtil} from 'stylable/test-utils';
 import stepStyle from './NavStep.st.css';
 
@@ -31,6 +32,8 @@ export class NavStepperDriver implements BaseDriver {
 
     /** returns text content of a step */
     stepContentAt = (index: number) => this.stepAt(index).textContent
+
+    clickOnStep = (index: number) => Simulate.click(this.stepAt(index));
 
     /** returns the active step element */
     get activeStep() { 

--- a/packages/wix-ui-core/src/components/NavStepper/NavStepper.spec.tsx
+++ b/packages/wix-ui-core/src/components/NavStepper/NavStepper.spec.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as eventually from 'wix-eventually';
 import { ReactDOMTestContainer } from "../../../test/dom-test-container";
 import {NavStepperDriver} from "./NavStepper.driver";
 import {NavStepper} from "./NavStepper";

--- a/packages/wix-ui-core/src/components/NavStepper/NavStepper.spec.tsx
+++ b/packages/wix-ui-core/src/components/NavStepper/NavStepper.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as eventually from 'wix-eventually';
 import { ReactDOMTestContainer } from "../../../test/dom-test-container";
 import {NavStepperDriver} from "./NavStepper.driver";
 import {NavStepper} from "./NavStepper";
@@ -72,5 +73,51 @@ describe('NavStepper', () => {
             </NavStepper>
         );
         expect(driver.isStepVisited(0)).toBe(false);
+    });
+    
+    it('should allow child to pass props to the dom element', async () => {
+        const driver = await render(
+            <NavStepper activeStep={0}>
+                <NavStepper.Step value={5}>First Step</NavStepper.Step>
+            </NavStepper>
+        );
+        expect(driver.activeStep.value).toBe(5);
+    });
+
+    it('notifies on step click', async () => {
+        const spy = jest.fn();
+        const driver = await render(
+            <NavStepper activeStep={0} onStepClick={spy}>
+                <NavStepper.Step>First Step</NavStepper.Step>
+                <NavStepper.Step>Second Step</NavStepper.Step>
+            </NavStepper>
+        );
+        expect(spy).not.toHaveBeenCalled();
+        driver.clickOnStep(1)
+        expect(spy.mock.calls[0]).toEqual(expect.arrayContaining([1]));
+    });
+    
+    it('should not notify when clicking on the active step', async () => {
+        const spy = jest.fn();
+        const driver = await render(
+            <NavStepper activeStep={0} onStepClick={spy}>
+                <NavStepper.Step>First Step</NavStepper.Step>
+                <NavStepper.Step>Second Step</NavStepper.Step>
+            </NavStepper>
+        );
+        driver.clickOnStep(0)
+        expect(spy).not.toHaveBeenCalled();
+    });
+    
+    it('should not notify when clicking on a disabled step', async () => {
+        const spy = jest.fn();
+        const driver = await render(
+            <NavStepper activeStep={0} onStepClick={spy}>
+                <NavStepper.Step>First Step</NavStepper.Step>
+                <NavStepper.Step disabled>Second Step</NavStepper.Step>
+            </NavStepper>
+        );
+        driver.clickOnStep(1)
+        expect(spy).not.toHaveBeenCalled();
     });
 });

--- a/packages/wix-ui-core/src/components/NavStepper/NavStepper.tsx
+++ b/packages/wix-ui-core/src/components/NavStepper/NavStepper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import style from './NavStepper.st.css';
-import {Stepper} from '../../baseComponents/Stepper';
+import {Stepper, StepProps} from '../../baseComponents/Stepper';
 import {NavStep, ExternalNavStepProps} from './NavStep';
 import {isReactElement} from '../../utils';
 import {childrenOfType, nonNegativeInteger} from 'airbnb-prop-types';
@@ -10,6 +10,7 @@ export {ExternalNavStepProps} from './NavStep';
 
 export interface NavStepperProps {
     activeStep: number;
+    onStepClick?: (stepIndex: number, e: any) => void
 }
 
 export class NavStepper extends React.PureComponent<NavStepperProps> {
@@ -30,7 +31,12 @@ export class NavStepper extends React.PureComponent<NavStepperProps> {
                             {
                                 React.Children.map(children, (child, index) => {
                                     if (React.isValidElement(child)) {
-                                        return React.cloneElement(child, getStepProps(index, {...child.props, className: style.step}));
+                                        const stepProps: any = getStepProps(index, {...child.props, className: style.step});
+
+                                        if (this.props.onStepClick && !(stepProps.active || stepProps.disabled)) {
+                                            stepProps.onClick = (e: any) => this.props.onStepClick(index, e)
+                                        }
+                                        return React.cloneElement(child, stepProps);
                                     }   
                                     return child;
                                 })


### PR DESCRIPTION
Adding support for a very common use case where the user of the component would like to react to a click on a step, in order to change the current active step. Also, incase a custom behaviour is needed fixed an issue where html props were not being passed to the underlying `li` element