### PR TITLE
wix-ui-icons-common: removed FatChevronLeft and FatChevronRight

### DIFF
--- a/packages/wix-ui-icons-common/src/general/raw/FatChevronLeft.svg
+++ b/packages/wix-ui-icons-common/src/general/raw/FatChevronLeft.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <polygon points="13.75 8 15 9.251 12.249 12 15 14.751 13.75 16 9.75 12"/>
-</svg>

--- a/packages/wix-ui-icons-common/src/general/raw/FatChevronRight.svg
+++ b/packages/wix-ui-icons-common/src/general/raw/FatChevronRight.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <polygon points="10.25 8 9 9.251 11.751 12 9 14.751 10.25 16 14.25 12"/>
-</svg>


### PR DESCRIPTION
This PR resolves wix/wix-style-react#1973.