### PR TITLE
Address input - managing input state

### DIFF
--- a/packages/wix-ui-core/src/components/AddressInput/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/AddressInput/AddressInput.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {Simulate} from 'react-dom/test-utils';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
 import {addressInputDriverFactory} from './AddressInput.driver';
 import {AddressInput, Handler} from './AddressInput';
@@ -247,6 +248,34 @@ describe('AddressInput', () => {
                 ]
             }]);
         }, {interval: 5});
+    });
+
+    describe('State management', () => {
+        it('Should update input value as user types, even if value is set', () => {
+            init({value: '1 Ibn Gabirol st.'});
+            driver.setValue('n');
+            expect(driver.getValue()).toBe('n');
+        });
+        
+        it('Should update input value upon value prop change', () => {
+            const wrapper = mount(<AddressInput
+                Client={GoogleMapsClientStub}
+                apiKey="a"
+                lang="en"
+                onSelect={() => null} value="123 Ibn Gabirol st."
+            />);
+            
+            const driver = addressInputDriverFactory({element: wrapper.getDOMNode(), eventTrigger: Simulate});
+            driver.setValue('n');
+            expect(driver.getValue()).toBe('n');
+            const newValue = '321 Ibn Gabirol st.';
+            wrapper.setProps({value: newValue});
+            expect(driver.getValue()).toBe(newValue);
+            driver.setValue('n');
+            expect(driver.getValue()).toBe('n');
+            wrapper.setProps({value: newValue});
+            expect(driver.getValue()).toBe('n');
+        });
     });
 
     describe('Fallback to manual', () => {

--- a/packages/wix-ui-core/src/components/AddressInput/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/AddressInput/AddressInput.tsx
@@ -192,9 +192,9 @@ export class AddressInput extends React.PureComponent<AddressInputProps, Address
         this._renderOption = this._renderOption.bind(this);
         this._createOptionFromAddress = this._createOptionFromAddress.bind(this);
         this.currentAddressRequest = Promise.resolve();
-    }
 
-    state = {options: [], inputValue: ''};
+        this.state = {options: [], inputValue: props.value || ''};
+    }
 
     componentDidMount() {
         this.client = new this.props.Client();
@@ -202,6 +202,12 @@ export class AddressInput extends React.PureComponent<AddressInputProps, Address
 
     componentWillUnmount() {
         this.unmounted = true;
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.value !== this.props.value) {
+            this.setState({inputValue: nextProps.value});
+        }
     }
 
     async _getAddressOptions(input: string) {
@@ -317,7 +323,7 @@ export class AddressInput extends React.PureComponent<AddressInputProps, Address
     }
 
     render() {
-        const {placeholder, onKeyDown, onFocus, value, forceContentElementVisibility, readOnly, style: inlineStyles, suffix, fixedFooter} = this.props;
+        const {placeholder, onKeyDown, onFocus, forceContentElementVisibility, readOnly, style: inlineStyles, suffix, fixedFooter} = this.props;
         const options = this._options();
 
         const inputProps = {
@@ -327,7 +333,7 @@ export class AddressInput extends React.PureComponent<AddressInputProps, Address
             onBlur: this._handleOnBlur,
             placeholder,
             disabled: readOnly,
-            value,
+            value: this.state.inputValue,
             suffix
         };
 

--- a/packages/wix-ui-core/stories/AddressInput/index.story.tsx
+++ b/packages/wix-ui-core/stories/AddressInput/index.story.tsx
@@ -15,11 +15,11 @@ export default {
   component: AddressInput,
   componentPath: '../../src/components/AddressInput',
 
-  componentProps: {
+  componentProps: setState => ({
     apiKey: '',
     lang: 'en',
     Client,
-    onSelect: () => null,
+    onSelect: (value) => setState({value: value.address.formatted}),
     'data-hook': 'storybook-addressInput'
-  }
+  })
 };


### PR DESCRIPTION
Maintaining `this.state.inputValue` instead of directly passing `this.props.value` to the `<Input/>` component. This is done in order to let the user see what they type as they go.