### PR TITLE
Add WSR Lint Plugins

### DIFF
--- a/packages/eslint-plugin-wix-style-react/.gitignore
+++ b/packages/eslint-plugin-wix-style-react/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/eslint-plugin-wix-style-react/README.md
+++ b/packages/eslint-plugin-wix-style-react/README.md
@@ -1,0 +1,51 @@
+# eslint-plugin-wix-style-react
+
+Wix Style React Lint Plugin
+
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org):
+
+```
+$ npm i eslint --save-dev
+```
+
+Next, install `eslint-plugin-wix-style-react`:
+
+```
+$ npm install eslint-plugin-wix-style-react --save-dev
+```
+
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-wix-style-react` globally.
+
+## Usage
+
+Add `wix-style-react` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+
+```json
+{
+    "plugins": [
+        "wix-style-react"
+    ]
+}
+```
+
+
+Then configure the rules you want to use under the rules section.
+
+```json
+{
+    "rules": {
+        "wix-style-react/no-full-wsr-lib": 2
+    }
+}
+```
+
+## Supported Rules
+
+* Fill in provided rules here
+
+
+
+
+

--- a/packages/eslint-plugin-wix-style-react/docs/rules/no-full-wsr-lib.md
+++ b/packages/eslint-plugin-wix-style-react/docs/rules/no-full-wsr-lib.md
@@ -1,0 +1,36 @@
+# Fail if importing all of WSR (no-full-wsr-lib)
+
+Please describe the origin of the rule here.
+
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+### Options
+
+If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+Give a short description of when it would be appropriate to turn off this rule.
+
+## Further Reading
+
+If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/packages/eslint-plugin-wix-style-react/docs/rules/no-full-wsr-lib.md
+++ b/packages/eslint-plugin-wix-style-react/docs/rules/no-full-wsr-lib.md
@@ -1,36 +1,25 @@
 # Fail if importing all of WSR (no-full-wsr-lib)
 
-Please describe the origin of the rule here.
-
-
 ## Rule Details
 
-This rule aims to...
+This rule aims to prevent importing all of WSR.
 
 Examples of **incorrect** code for this rule:
 
 ```js
-
-// fill me in
-
+import { Button } from 'wix-style-react';
+const Button2 = require('wix-style-react').Button;
+const { Button, Panel } = require('wix-style-react');
+const WSAR = require('wix-style-react');
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-
-// fill me in
-
+import Button from 'wix-style-react/Button';
+import Panel from 'wix-style-react/Panel';
 ```
-
-### Options
-
-If there are any options, describe them here. Otherwise, delete this section.
 
 ## When Not To Use It
 
-Give a short description of when it would be appropriate to turn off this rule.
-
-## Further Reading
-
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.
+Turn off this rule when WSR supports tree shaking.

--- a/packages/eslint-plugin-wix-style-react/lib/index.js
+++ b/packages/eslint-plugin-wix-style-react/lib/index.js
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview Wix Style React Lint Plugin
+ * @author YairH
+ */
+"use strict";
+
+var requireIndex = require("requireindex");
+
+module.exports.rules = requireIndex(__dirname + "/rules");
+
+module.exports.config = {
+  recommended: {
+    rules: {
+      'wix-style-react/no-full-wsr-lib': 2
+    }
+  }
+}
+

--- a/packages/eslint-plugin-wix-style-react/lib/rules/no-full-wsr-lib.js
+++ b/packages/eslint-plugin-wix-style-react/lib/rules/no-full-wsr-lib.js
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview Fail if importing all of WSR
+ * @author YairH
+ */
+
+const LIB_NAME = 'wix-style-react';
+const ERROR =
+  "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';`";
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Fail if importing all of WSR',
+      category: '',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: []
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (isDestructuredImportStatement(node)) {
+          context.report({
+            node,
+            message: ERROR,
+            fix(fixer) {
+              const specifiers = node.specifiers.map(specifier => specifier.imported.name);
+              const imports = specifiers.map(specifier => composeImportStatement(specifier));
+              return fixer.replaceText(node, imports.join('\n'));
+            }
+          });
+        }
+      },
+      VariableDeclaration(node) {
+        // iterate list since we can have more than one variable declared in a single declaration
+        node.declarations.forEach(variableDeclarator => {
+          if (isRequireWithPropertyAccess(variableDeclarator)) {
+            context.report({
+              node,
+              message: ERROR,
+              fix(fixer) {
+                const importedLabel = variableDeclarator.id.name;
+                const importedObject = variableDeclarator.init.property.name;
+                const fixString = composeImportStatement(importedLabel, importedObject);
+                return fixer.replaceText(node, fixString);
+              }
+            });
+          } else if (isRequiringWSR(variableDeclarator)) {
+            if (isDestructured(variableDeclarator)) {
+              context.report({
+                node,
+                message: ERROR,
+                fix(fixer) {
+                  const specifiers = variableDeclarator.id.properties
+                    .filter(
+                      specifier =>
+                        // can only fix when destructured object isnt aliased
+                        specifier.value.name === specifier.key.name
+                    )
+                    .map(specifier => specifier.key.name);
+
+                  if (specifiers.length !== variableDeclarator.id.properties.length) {
+                    // do not fix if we have destructured aliased properties
+                    // Example: const {Button: Button2} = require('wix-style-react');
+                    return;
+                  }
+
+                  const imports = specifiers.map(specifier => composeImportStatement(specifier));
+                  return fixer.replaceText(node, imports.join('\n'));
+                }
+              });
+            } else if (isRequiringAllWSR(variableDeclarator)) {
+              context.report({
+                node,
+                message: ERROR
+              });
+            }
+          }
+        });
+      }
+    };
+  }
+};
+
+function composeImportStatement(importLabel, importObject = importLabel) {
+  return `import ${importLabel} from '${LIB_NAME}/${importObject}';`;
+}
+
+// EXAMPLE: const WSR = require('wix-style-react');
+function isRequiringAllWSR(variableDeclarator) {
+  return variableDeclarator.id && variableDeclarator.id.type === 'Identifier';
+}
+
+// EXAMPLE: const {Button4, Button2} = require('wix-style-react');
+function isDestructured(variableDeclarator) {
+  return variableDeclarator.id && variableDeclarator.id.type === 'ObjectPattern';
+}
+
+// EXAMPLE: require('wix-style-react')
+function isRequiringWSR(variableDeclarator) {
+  return (
+    variableDeclarator.init &&
+    variableDeclarator.init.type === 'CallExpression' &&
+    variableDeclarator.init.callee &&
+    variableDeclarator.init.callee.name === 'require' &&
+    variableDeclarator.init.arguments &&
+    variableDeclarator.init.arguments.length &&
+    variableDeclarator.init.arguments[0].value === LIB_NAME
+  );
+}
+
+// EXAMPLE: const Button = require('wix-style-react').Button;
+function isRequireWithPropertyAccess(variableDeclarator) {
+  return (
+    variableDeclarator.init &&
+    variableDeclarator.init.type === 'MemberExpression' &&
+    variableDeclarator.init.object &&
+    variableDeclarator.init.object.callee &&
+    variableDeclarator.init.object.callee.name === 'require' &&
+    variableDeclarator.init.object.arguments &&
+    variableDeclarator.init.object.arguments.length &&
+    variableDeclarator.init.object.arguments[0].value === LIB_NAME
+  );
+}
+
+// EXAMPLE: import { Button3, Frame, Panel } from 'wix-style-react';
+function isDestructuredImportStatement(node) {
+  return (
+    node.source.value === LIB_NAME &&
+    node.specifiers &&
+    node.specifiers.length &&
+    node.specifiers[0].type === 'ImportSpecifier'
+  );
+}

--- a/packages/eslint-plugin-wix-style-react/package.json
+++ b/packages/eslint-plugin-wix-style-react/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "eslint-plugin-wix-style-react",
+  "version": "0.0.0",
+  "description": "Wix Style React Lint Plugin",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "author": "yairhaimo",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "mocha tests --recursive"
+  },
+  "dependencies": {
+    "requireindex": "~1.1.0"
+  },
+  "devDependencies": {
+    "eslint": "~3.9.1",
+    "mocha": "^3.1.2"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "license": "ISC"
+}

--- a/packages/eslint-plugin-wix-style-react/tests/lib/rules/no-full-wsr-lib.js
+++ b/packages/eslint-plugin-wix-style-react/tests/lib/rules/no-full-wsr-lib.js
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Fail if importing all of WSR
+ * @author YairH
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-full-wsr-lib'),
+  RuleTester = require('eslint').RuleTester;
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  }
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+ruleTester.run('no-full-wsr-lib', rule, {
+  valid: [`import Button from 'wix-style-react/Button';`],
+
+  invalid: [
+    {
+      code: "import {Button, Panel} from 'wix-style-react';",
+      errors: [
+        {
+          message:
+            "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';`",
+          type: 'ImportDeclaration'
+        }
+      ]
+    },
+    {
+      code: "const Button = require('wix-style-react').Button;",
+      errors: [
+        {
+          message:
+            "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';`",
+          type: 'VariableDeclaration'
+        }
+      ]
+    },
+    {
+      code: "const WSR = require('wix-style-react');",
+      errors: [
+        {
+          message:
+            "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';`",
+          type: 'VariableDeclaration'
+        }
+      ]
+    },
+    {
+      code: "const {Button} = require('wix-style-react');",
+      errors: [
+        {
+          message:
+            "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';`",
+          type: 'VariableDeclaration'
+        }
+      ]
+    }
+  ]
+});

--- a/packages/tslint-plugin-wix-style-react/.gitignore
+++ b/packages/tslint-plugin-wix-style-react/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/tslint-plugin-wix-style-react/package.json
+++ b/packages/tslint-plugin-wix-style-react/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "tslint-plugin-wix-style-react",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "tslint": "^5.10.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^23.0.0",
+    "@types/node": "^10.5.2",
+    "jest": "^23.1.0",
+    "ts-jest": "^22.4.6",
+    "typescript": "^2.9.2"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    },
+    "testMatch": [
+      "**/**/*.spec.(ts|tsx)"
+    ]
+  }
+}

--- a/packages/tslint-plugin-wix-style-react/src/lintRunner.ts
+++ b/packages/tslint-plugin-wix-style-react/src/lintRunner.ts
@@ -1,0 +1,17 @@
+import {Configuration, Linter, Replacement} from 'tslint';
+
+export const helper = ({src, rule}) => {
+    const linter = new Linter({fix: false});
+    linter.lint('', src, Configuration.parseConfigFile({
+        rules: {
+            [rule.name || rule]: [true, ...rule.options]
+        },
+        rulesDirectory: 'src'
+    }));
+    return linter.getResult();
+};
+
+export const getFixedResult = ({src, rule}) => {
+    const result = helper({src, rule});
+    return Replacement.applyFixes(src, [result.failures[0].getFix()]);
+};

--- a/packages/tslint-plugin-wix-style-react/src/noFullWsrLibRule.spec.ts
+++ b/packages/tslint-plugin-wix-style-react/src/noFullWsrLibRule.spec.ts
@@ -1,0 +1,75 @@
+import { getFixedResult, helper } from './lintRunner';
+
+const rule = 'no-full-wsr-lib';
+
+describe('no-full-wsr-lib', () => {
+  it(`should not fail`, () => {
+    const src = `import Button from 'wix-style-react/Button';`;
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(0);
+  });
+
+  it(`should fail on a destructured import statement`, () => {
+    const src = `import { Button } from 'wix-style-react';`;
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(1);
+    const failure = helper({ src, rule }).failures[0];
+    expect(failure.getFailure()).toBe(
+      "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';`"
+    );
+  });
+
+  it(`should fail on a destructured require statement`, () => {
+    const src = `const { Button } = require('wix-style-react');`;
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(1);
+  });
+
+  it(`should fail on a property access require statement`, () => {
+    const src = `const Button2 = require('wix-style-react').Button;`;
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(1);
+  });
+
+  it(`should fail on a whole lib require statement`, () => {
+    const src = `const WSR = require('wix-style-react');`;
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(1);
+  });
+
+  it('should fix destructured import statement', () => {
+    const src = `import { Button, Panel } from 'wix-style-react';`;
+    const output = `import Button from 'wix-style-react/Button';\nimport Panel from 'wix-style-react/Panel';`;
+
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(1);
+    expect(getFixedResult({ src, rule })).toEqual(output);
+  });
+
+  it('should fix destructured require statement', () => {
+    const src = `const { Button } = require('wix-style-react');`;
+    const output = `import Button from 'wix-style-react/Button';`;
+
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(1);
+    expect(getFixedResult({ src, rule })).toEqual(output);
+  });
+
+  it('should fix property access require statement', () => {
+    const src = `const Button2 = require('wix-style-react').Button;`;
+    const output = `import Button2 from 'wix-style-react/Button';`;
+
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(1);
+    expect(getFixedResult({ src, rule })).toEqual(output);
+  });
+
+  it('should not fix requiring all the lib', () => {
+    const src = `const WSR = require('wix-style-react');`;
+    const output = `const WSR = require('wix-style-react');`;
+
+    const result = helper({ src, rule });
+    expect(result.errorCount).toBe(1);
+    expect(getFixedResult({ src, rule })).toEqual(output);
+  });
+});

--- a/packages/tslint-plugin-wix-style-react/src/noFullWsrLibRule.ts
+++ b/packages/tslint-plugin-wix-style-react/src/noFullWsrLibRule.ts
@@ -1,0 +1,148 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  static FAILURE_STRING =
+    "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';`";
+  static LIB_NAME = 'wix-style-react';
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new Walk(sourceFile, this.getOptions()));
+  }
+}
+
+class Walk extends Lint.RuleWalker {
+  visitImportDeclaration(node: ts.ImportDeclaration) {
+    if (this.isWSRImport(node)) {
+      this.addFailureAt(
+        node.getStart(),
+        node.getEnd() - node.getStart(),
+        Rule.FAILURE_STRING,
+        this.fixSelectiveImports(node)
+      );
+    }
+    super.visitImportDeclaration(node);
+  }
+
+  visitVariableStatement(node: ts.VariableStatement) {
+    // iterate list since we can have more than one variable declared in a single declaration
+    node.declarationList.declarations.forEach(variableDeclaration => {
+      if (this.isWSRRequireStatement(variableDeclaration)) {
+        if (this.isRequireAllLib(variableDeclaration)) {
+          this.addFailureAt(
+            variableDeclaration.getStart(),
+            variableDeclaration.getEnd() - variableDeclaration.getStart(),
+            Rule.FAILURE_STRING
+          );
+        } else if (this.isRequireWithDestructure(variableDeclaration)) {
+          this.addFailureAt(
+            variableDeclaration.parent.getStart(),
+            variableDeclaration.parent.getEnd() - variableDeclaration.parent.getStart(),
+            Rule.FAILURE_STRING,
+            // fix only if only one variableDeclaration in variableDeclarationList
+            node.declarationList.declarations && node.declarationList.declarations.length === 1
+              ? this.fixSelectiveRequire(node, variableDeclaration)
+              : undefined
+          );
+        }
+      } else if (this.isWSRRequireWithProperty(variableDeclaration)) {
+        this.addFailureAt(
+          variableDeclaration.parent.getStart(),
+          variableDeclaration.parent.getEnd() - variableDeclaration.parent.getStart(),
+          Rule.FAILURE_STRING,
+          // fix only if only one variableDeclaration in variableDeclarationList
+          node.declarationList.declarations && node.declarationList.declarations.length === 1
+            ? this.fixPropertyRequire(node, variableDeclaration)
+            : undefined
+        );
+      }
+    });
+    super.visitVariableStatement(node);
+  }
+
+  // const {Button, Panel} = require('wix-style-react');
+  private isRequireWithDestructure(variableDeclaration: ts.VariableDeclaration) {
+    return ts.isObjectBindingPattern(variableDeclaration.name);
+  }
+
+  // const WSR = require('wix-style-react');
+  private isRequireAllLib(variableDeclaration: ts.VariableDeclaration) {
+    return ts.isIdentifier(variableDeclaration.name);
+  }
+
+  // const Button2 = require('wix-style-react').Button;
+  private isWSRRequireWithProperty(variableDeclaration: ts.VariableDeclaration) {
+    return (
+      ts.isPropertyAccessExpression(variableDeclaration.initializer) &&
+      ts.isCallExpression(variableDeclaration.initializer.expression) &&
+      variableDeclaration.initializer.expression.expression.getText() === 'require' &&
+      variableDeclaration.initializer.expression.arguments &&
+      variableDeclaration.initializer.expression.arguments.length &&
+      (variableDeclaration.initializer.expression.arguments[0] as any).text === Rule.LIB_NAME
+    );
+  }
+
+  private isWSRImport(node: ts.ImportDeclaration) {
+    return (
+      node.moduleSpecifier &&
+      (node.moduleSpecifier as any).text === Rule.LIB_NAME &&
+      node.importClause &&
+      (node.importClause.namedBindings as any).elements &&
+      (node.importClause.namedBindings as any).elements.length
+    );
+  }
+
+  private isWSRRequireStatement(variableDeclaration: ts.VariableDeclaration) {
+    return (
+      ts.isCallExpression(variableDeclaration.initializer) &&
+      ts.isIdentifier(variableDeclaration.initializer.expression) &&
+      variableDeclaration.initializer.expression.getText() === 'require' &&
+      variableDeclaration.initializer.arguments &&
+      variableDeclaration.initializer.arguments.length &&
+      (variableDeclaration.initializer.arguments[0] as any).text === Rule.LIB_NAME
+    );
+  }
+
+  private fixSelectiveImports(node: ts.ImportDeclaration): Lint.Fix {
+    const specifiers = (node.importClause.namedBindings as any).elements.map(specifier => specifier.name.text);
+    const importStatements = specifiers.map(specifier => this.compileImportStatement(specifier));
+    return new Lint.Replacement(node.getStart(), node.getWidth(), importStatements.join('\n'));
+  }
+
+  private fixSelectiveRequire(
+    variableStatementNode: ts.VariableStatement,
+    variableDeclarationNode: ts.VariableDeclaration
+  ): Lint.Fix {
+    if (ts.isObjectBindingPattern(variableDeclarationNode.name)) {
+      const specifiers = variableDeclarationNode.name.elements.map(element => element.name.getText());
+      const importStatements = specifiers.map(specifier => this.compileImportStatement(specifier));
+      return new Lint.Replacement(
+        variableStatementNode.getStart(),
+        variableStatementNode.getWidth(),
+        importStatements.join('\n')
+      );
+    }
+  }
+
+  // const Button2 = require('wix-style-react').Button;
+  private fixPropertyRequire(
+    variableStatementNode: ts.VariableStatement,
+    variableDeclarationNode: ts.VariableDeclaration
+  ): Lint.Fix {
+    if (
+      ts.isPropertyAccessExpression(variableDeclarationNode.initializer) &&
+      ts.isIdentifier(variableDeclarationNode.initializer.name)
+    ) {
+      const identifier = variableDeclarationNode.name.getText();
+      const specifier = variableDeclarationNode.initializer.name.getText();
+      return new Lint.Replacement(
+        variableStatementNode.getStart(),
+        variableStatementNode.getWidth(),
+        this.compileImportStatement(identifier, specifier)
+      );
+    }
+  }
+
+  private compileImportStatement(name, source = name) {
+    return `import ${name} from '${Rule.LIB_NAME}/${source}';`;
+  }
+}

--- a/packages/tslint-plugin-wix-style-react/tsconfig.json
+++ b/packages/tslint-plugin-wix-style-react/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "sourceMap": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "lib": [
+      "es6"
+    ]
+  },
+    "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
This PR adds an `eslint` and a `tslint` plugin.
Both have only one rule, `no-full-wsr-lib`. 
This rule checks that a user does not import the entire `wix-style-react` library.
In the future, when WSR will support tree shaking, this rule can be removed.