### PR TITLE
chore(Markdown): register only subset of highlight.js languages

### DIFF
--- a/packages/wix-storybook-utils/src/Markdown/index.js
+++ b/packages/wix-storybook-utils/src/Markdown/index.js
@@ -1,8 +1,38 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Remarkable from 'react-remarkable';
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/highlight.js';
 import './style.scss';
+
+hljs.registerLanguage(
+  'javascript',
+  require('highlight.js/lib/languages/javascript.js')
+);
+
+hljs.registerLanguage(
+  'typescript',
+  require('highlight.js/lib/languages/typescript.js')
+);
+
+hljs.registerLanguage(
+  'css',
+  require('highlight.js/lib/languages/css.js')
+);
+
+hljs.registerLanguage(
+  'scss',
+  require('highlight.js/lib/languages/scss.js')
+);
+
+hljs.registerLanguage(
+  'xml',
+  require('highlight.js/lib/languages/xml.js')
+);
+
+hljs.registerLanguage(
+  'shell',
+  require('highlight.js/lib/languages/shell.js')
+);
 
 export default class Markdown extends Component {
   static propTypes = {


### PR DESCRIPTION
otherwise all are included which blows bundle size.
all languages means 176 including real esoteric stuff

13735 less lines in preview.bundle.js