### PR TITLE
wix-storybook-utils: Do not use the first option as a default in <List/>

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/components/list.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/list.js
@@ -81,7 +81,7 @@ export default class List extends React.Component {
 
   getSelectedId = () => {
     const selectedOption = this.state.options.find(option => option.id === this.state.currentValue.id) || {};
-    return selectedOption.id || 0;
+    return typeof selectedOption.id === 'undefined' ? null : selectedOption.id;
   }
 
   onOptionChange = ({id}) => {


### PR DESCRIPTION
The `<List/>` component (used in `<AutoExample/>`), uses the first option (`0` index) as the default option. This causes a small issue when trying to choose the first option, when the field is empty. 

For example, in: https://wix-wix-style-react.surge.sh/?selectedKind=1.%20Foundation&selectedStory=1.5%20Loader&full=0&addons=0&stories=1&panelRight=0, in order to select the `tiny` option, we first need to select a different option.

![screen shot 2018-07-29 at 15 46 00](https://user-images.githubusercontent.com/11786506/43366423-8773206c-9346-11e8-8196-1ca995f10c8b.png)
