### PR TITLE
EllipsedTooltip - fix text overflow issues

### DIFF
--- a/packages/wix-ui-core/src/components/Popover/Popover.st.css
+++ b/packages/wix-ui-core/src/components/Popover/Popover.st.css
@@ -108,3 +108,5 @@
   margin-bottom: value(contentArrowSize);
   border-color: value(contentBorderColor) transparent transparent transparent;
 }
+
+.popoverElement {}

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -300,7 +300,12 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
         style={inlineStyles}
         id={id}
       >
-        <Target onKeyDown={onKeyDown} data-hook="popover-element" innerRef={r => this.targetRef = r}>
+        <Target
+          onKeyDown={onKeyDown}
+          data-hook="popover-element"
+          className={style.popoverElement}
+          innerRef={r => this.targetRef = r}
+        >
           {childrenObject.Element}
         </Target>
         {shouldRenderPopper && this.renderPopperContent(childrenObject)}

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/EllipsedTooltip.st.css
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/EllipsedTooltip.st.css
@@ -6,4 +6,9 @@
 .root {
   -st-extends: Tooltip;
   display: inherit;
+  overflow: hidden;
+}
+
+.root::popoverElement {
+  max-width: 100%;
 }

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/Text.st.css
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/Text.st.css
@@ -2,5 +2,5 @@
   display: inline-block;
   text-overflow: ellipsis;
   overflow: hidden;
-  width: 100%;
+  max-width: 100%;
 }

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -10,7 +10,8 @@ import debounce = require('lodash/debounce');
 
 type EllipsedTooltipProps = {
   component: React.ReactElement<any>,
-  showTooltip?: boolean
+  showTooltip?: boolean,
+  [propName: string]: any
 }
 
 type EllipsedTooltipState = {
@@ -76,11 +77,14 @@ class EllipsedTooltip extends React.Component<EllipsedTooltipProps, EllipsedTool
   _debouncedUpdate = debounce(this._updateEllipsisState, 100);
 
   _renderText() {
-    const {component} = this.props;
+    const {component, style} = this.props;
     return (
       <StateFullComponentWrap
         {...textStyle('root', {}, component.props)}
-        style={{ whiteSpace: 'nowrap' }}
+        style={{
+          ...style,
+          whiteSpace: 'nowrap' 
+        }}
         ref={n => this.textNode = ReactDOM.findDOMNode(n) as HTMLElement}
       >
         {component}

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -11,7 +11,7 @@ import debounce = require('lodash/debounce');
 type EllipsedTooltipProps = {
   component: React.ReactElement<any>,
   showTooltip?: boolean,
-  [propName: string]: any
+  style?: object
 }
 
 type EllipsedTooltipState = {


### PR DESCRIPTION
This PR fixes an issue with the ellipsed tooltip: when using the ellipsed tooltip within a container with `display: flex`, the ellipsed test would overflow out of the container.

![screen shot 2018-08-07 at 15 08 50](https://user-images.githubusercontent.com/11786506/43775025-d798f526-9a53-11e8-971f-811af43917f3.png)