### PR TITLE
add propTypes type to all classes using a static propTypes member.

### DIFF
--- a/packages/wix-ui-core/src/components/AddressInput/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/AddressInput/AddressInput.tsx
@@ -121,7 +121,7 @@ export class AddressInput extends React.PureComponent<AddressInputProps, Address
     inputRef;
     inputWithOptionsRef;
 
-    static propTypes = {
+    static propTypes: React.ValidationMap<AddressInputProps> = {
         /** Maps client, should implement autocomplete, geocode and placeDetails methods */
         Client: func.isRequired,
         /** Handler for when an option is selected */

--- a/packages/wix-ui-core/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/wix-ui-core/src/components/Autocomplete/Autocomplete.tsx
@@ -48,7 +48,7 @@ export interface AutocompleteState {
 
 export class Autocomplete extends React.PureComponent<AutocompleteProps, AutocompleteState> {
   static displayName = 'Autocomplete';
-  static propTypes = {
+  static propTypes: React.ValidationMap<AutocompleteProps> = {
     /** The dropdown options array */
     options: arrayOf(optionPropType).isRequired,
     /** Handler for when an option is selected */

--- a/packages/wix-ui-core/src/components/Input/Input.tsx
+++ b/packages/wix-ui-core/src/components/Input/Input.tsx
@@ -34,7 +34,7 @@ export interface InputState {
 export class Input extends React.Component<InputProps, InputState> {
   static displayName = 'Input';
 
-  static propTypes = {
+  static propTypes: React.ValidationMap<InputProps> = {
     /** Wrapper class name */
     className: PropTypes.string,
     /** Error state / Error message */

--- a/packages/wix-ui-core/src/components/InputWithOptions/InputWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/InputWithOptions/InputWithOptions.tsx
@@ -62,7 +62,7 @@ export class InputWithOptions extends React.PureComponent<InputWithOptionsProps>
     onInitialSelectedOptionsSet: () => null
   };
 
-  static propTypes = {
+  static propTypes: React.ValidationMap<InputWithOptionsProps> = {
     /** The location to display the content */
     placement: oneOf(['auto-start', 'auto', 'auto-end', 'top-start', 'top', 'top-end', 'right-start', 'right', 'right-end', 'bottom-end', 'bottom', 'bottom-start', 'left-end', 'left', 'left-start']),
     /** The dropdown options array */
@@ -96,7 +96,7 @@ export class InputWithOptions extends React.PureComponent<InputWithOptionsProps>
     /** Inline styles */
     style: object,
     /** Id */
-    Id: string
+    id: string
   };
 
   isEditing: boolean = false;

--- a/packages/wix-ui-core/src/components/LabelWithOptions/LabelWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/LabelWithOptions/LabelWithOptions.tsx
@@ -50,7 +50,7 @@ export interface LabelWithOptionsState {
  */
 export class LabelWithOptions extends React.PureComponent<LabelWithOptionsProps, LabelWithOptionsState> {
   static displayName = 'LabelWithOptions';
-  static propTypes = {
+  static propTypes: React.ValidationMap<LabelWithOptionsProps> = {
     /** The dropdown options array */
     options: arrayOf(optionPropType).isRequired,
     /** set true for multiple selection, false for single */

--- a/packages/wix-ui-core/src/components/Link/Link.tsx
+++ b/packages/wix-ui-core/src/components/Link/Link.tsx
@@ -14,7 +14,7 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLElement> {
 export class Link extends React.PureComponent<LinkProps> {
   static displayName = 'Link';
 
-  static propTypes = {
+  static propTypes: React.ValidationMap<LinkProps> = {
     children: node
   };
 

--- a/packages/wix-ui-core/src/components/NavStepper/NavStep.tsx
+++ b/packages/wix-ui-core/src/components/NavStepper/NavStep.tsx
@@ -10,7 +10,7 @@ export type ExternalNavStepProps = Partial<StepProps> & {
 export type NavStepProps = StepProps & ExternalNavStepProps;
 
 export class NavStep extends React.PureComponent<NavStepProps> {
-    static propTypes = {
+    static propTypes: React.ValidationMap<NavStepProps> = {
         disabled: bool
     }
     render () {

--- a/packages/wix-ui-core/src/components/NavStepper/NavStepper.tsx
+++ b/packages/wix-ui-core/src/components/NavStepper/NavStepper.tsx
@@ -16,7 +16,7 @@ export interface NavStepperProps {
 export class NavStepper extends React.PureComponent<NavStepperProps> {
     public static Step: React.ComponentClass<ExternalNavStepProps> = NavStep as any;
 
-    static propTypes = {
+    static propTypes: React.ValidationMap<NavStepperProps & {children: any}> = {
         activeStep: nonNegativeInteger,
         children: childrenOfType(NavStep)
     }

--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -147,7 +147,7 @@ const shouldAnimatePopover = ({timeout}: PopoverProps) => !!timeout;
 /**
  * Popover
  */
-export class Popover extends React.Component<PopoverType, PopoverState> {
+export class Popover extends React.Component<PopoverProps, PopoverState> {
   static displayName = 'Popover';
 
   static Element = createComponentThatRendersItsChildren('Popover.Element');
@@ -161,7 +161,7 @@ export class Popover extends React.Component<PopoverType, PopoverState> {
 
   state = {isMounted: false};
 
-  static propTypes = {
+  static propTypes: React.ValidationMap<PopoverProps> = {
     className: string,
     placement: PlacementsType,
     shown: bool,

--- a/packages/wix-ui-core/src/components/Slider/Thumb.tsx
+++ b/packages/wix-ui-core/src/components/Slider/Thumb.tsx
@@ -11,7 +11,7 @@ export interface ThumbProps {
 }
 
 export class Thumb extends React.Component<ThumbProps> {
-  static propTypes = {
+  static propTypes: React.ValidationMap<ThumbProps> = {
     shape: PropTypes.string.isRequired,
     thumbPosition: PropTypes.object.isRequired,
     thumbSize: PropTypes.object.isRequired,

--- a/packages/wix-ui-core/src/components/TimePicker/Tickers.tsx
+++ b/packages/wix-ui-core/src/components/TimePicker/Tickers.tsx
@@ -17,7 +17,7 @@ export interface TickersProps {
 }
 
 export class Tickers extends React.PureComponent<TickersProps> {
-  static propTypes = {
+  static propTypes: React.ValidationMap<TickersProps> = {
     className: string,
     /** set buttons as disabled */
     disabled: bool,

--- a/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/wix-ui-core/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -35,7 +35,7 @@ export interface ToggleSwitchState {
 export class ToggleSwitch extends React.PureComponent<ToggleSwitchProps, ToggleSwitchState> {
   static displayName = 'ToggleSwitch';
 
-  static propTypes = {
+  static propTypes: React.ValidationMap<ToggleSwitchProps> = {
     /** Is the toggleSwitch checked or not */
     checked: propTypes.bool,
     /** Is the toggleSwitch disabled or not */

--- a/packages/wix-ui-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/Tooltip/Tooltip.tsx
@@ -59,7 +59,7 @@ export class TooltipComponent extends React.PureComponent<TooltipProps & Injecte
     showArrow: true
   };
 
-  static propTypes = {
+  static propTypes: React.ValidationMap<TooltipProps & InjectedOnClickOutProps> = {
     /** tooltip's placement in relation to the target element */
     placement: PlacementsType,
     /** children to render that will be the target of the tooltip */

--- a/packages/wix-ui-core/src/components/Video/Video.tsx
+++ b/packages/wix-ui-core/src/components/Video/Video.tsx
@@ -85,7 +85,7 @@ export class Video extends React.PureComponent<VideoProps, VideoState> {
   containerRef: HTMLDivElement;
   player: any;
 
-  static propTypes = {
+  static propTypes: React.ValidationMap<VideoProps> = {
     /** Element ID */
     id: string,
     /** A string or array with source of the video. For more information see this [page](https://wix.github.io/playable/video-source) */

--- a/packages/wix-ui-core/src/createHOC/index.tsx
+++ b/packages/wix-ui-core/src/createHOC/index.tsx
@@ -14,7 +14,7 @@ export const createHOC = Component => {
   class WixComponent extends React.PureComponent<WixComponentProps> {
     private wrappedComponentRef: React.Component = null;
 
-    static propTypes = {
+    static propTypes: React.ValidationMap<WixComponentProps> = {
       ...Component.propTypes,
       dataHook: string,
       dataClass: string

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -39,7 +39,7 @@ class StateFullComponentWrap extends React.Component<StateFullComponentWrapProps
 }
 
 class EllipsedTooltip extends React.Component<EllipsedTooltipProps, EllipsedTooltipState> {
-  static propTypes = {
+  static propTypes: React.ValidationMap<EllipsedTooltipProps> = {
     component: node.isRequired,
     showTooltip: bool
   };

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
@@ -61,7 +61,7 @@ export const withFocusable = Component => {
 
   class FocusableHOC extends React.Component<any, IFocusableHOCState> {
     static displayName = wrapDisplayName(Component, 'WithFocusable');
-    static propTypes = Component.propTypes;
+    static propTypes: React.ValidationMap<any> = Component.propTypes;
     static defaultProps = Component.defaultProps;
 
     wrappedComponentRef = null;


### PR DESCRIPTION
React Typescript definitions do not apply for static `propTypes` class members.
We need to specify the type explicitly.
Not specifying them can lead to errors, for example, if we use `Omit` in a component's `IProps` interface,
then the inferred propTypes is not assignable to the `IProps`.

- This fixes an error which ocurres in `wix-ui-tpa` with `Input`.
- While adding type for propTypes in InputWithOptions, it found a typo bug `Id`->`id`.
