### PR TITLE
Teamcity Surge Deploy failed. Temp fix.

### DIFF
--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -31,7 +31,7 @@
     "create-system-aliases": "node ./scripts/create-aliases.js ./dist/src/system/dist/components system ./dist/src/system/dist",
     "storybook": "start-storybook -p 6006",
     "generate-stylable-index": "stc --srcDir=\"./dist/src\" --diagnostics",
-    "pr-postbuild": "npx teamcity-surge-autorelease@^1.0.0 --dist=storybook-static --verbose"
+    "pr-postbuild": "npm install teamcity-surge-autorelease@^1.0.0 %% teamcity-surge-autorelease"
   },
   "devDependencies": {
     "@storybook/addon-options": "^3.3.15",

--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -31,7 +31,7 @@
     "create-system-aliases": "node ./scripts/create-aliases.js ./dist/src/system/dist/components system ./dist/src/system/dist",
     "storybook": "start-storybook -p 6006",
     "generate-stylable-index": "stc --srcDir=\"./dist/src\" --diagnostics",
-    "pr-postbuild": "npm install teamcity-surge-autorelease@^1.0.0 %% teamcity-surge-autorelease"
+    "pr-postbuild": "npm install teamcity-surge-autorelease@^1.0.0 && teamcity-surge-autorelease"
   },
   "devDependencies": {
     "@storybook/addon-options": "^3.3.15",

--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -31,7 +31,7 @@
     "create-system-aliases": "node ./scripts/create-aliases.js ./dist/src/system/dist/components system ./dist/src/system/dist",
     "storybook": "start-storybook -p 6006",
     "generate-stylable-index": "stc --srcDir=\"./dist/src\" --diagnostics",
-    "pr-postbuild": "npx teamcity-surge-autorelease@^1.0.0"
+    "pr-postbuild": "npx teamcity-surge-autorelease@^1.0.0 --dist=storybook-static --verbose=true"
   },
   "devDependencies": {
     "@storybook/addon-options": "^3.3.15",

--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -31,7 +31,7 @@
     "create-system-aliases": "node ./scripts/create-aliases.js ./dist/src/system/dist/components system ./dist/src/system/dist",
     "storybook": "start-storybook -p 6006",
     "generate-stylable-index": "stc --srcDir=\"./dist/src\" --diagnostics",
-    "pr-postbuild": "npx teamcity-surge-autorelease@^1.0.0 --dist=storybook-static --verbose=true"
+    "pr-postbuild": "npx teamcity-surge-autorelease@^1.0.0 --dist=storybook-static --verbose"
   },
   "devDependencies": {
     "@storybook/addon-options": "^3.3.15",


### PR DESCRIPTION
This is temp fix until we find out what is the reason of npx failure together with teamcity-surge-autorelease.