### PR TITLE
optional wrapper in protractor testkit factory

### DIFF
--- a/packages/wix-ui-test-utils/src/protractor/protractor.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor.ts
@@ -1,5 +1,6 @@
 import {$, ElementFinder} from 'protractor';
 
 export function protractorTestkitFactoryCreator<T> (driverFactory: (e: ElementFinder) => T) {
-  return (obj: {dataHook: string}) => driverFactory($(`[data-hook='${obj.dataHook}']`));
+  return (obj: {dataHook: string, wrapper?: ElementFinder}) => 
+    wrapper ? driverFactory(wrapper.$(`[data-hook='${obj.dataHook}']`)) : driverFactory($(`[data-hook='${obj.dataHook}']`));
 }


### PR DESCRIPTION
Add an optional `wrapper` when creating a testkit.
this is highly needed when there are multiple elements with the same data-hook (e.g., rows in a table) and you're aiming for a specific one.