### PR TITLE
fixing the popover in ui-core

### DIFF
--- a/packages/wix-ui-core/src/components/Popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/Popover/Popover.tsx
@@ -22,7 +22,7 @@ import {oneOf, oneOfType, any, Requireable, string, bool, func, number, shape, o
 
 // This is here and not in the test setup because we don't want consumers to need to run it as well
 const isTestEnv = process.env.NODE_ENV === 'test';
-if (isTestEnv) {
+if (isTestEnv && typeof document !== 'undefined') {
   if (!document.createRange) {
     document.createRange = () => ({
       setStart: () => null,


### PR DESCRIPTION
`if (isTestEnv) {
  if (!document.createRange) {
    document.createRange = () => ({
      setStart: () => null,
      setEnd: () => null,
      commonAncestorContainer: document.documentElement.querySelector('body')
    } as any);
  }
}`
This throw an error 'document is undifiend' when running our server tests, I added a simple check to see if the document is defiend before using it.
