### PR TITLE
wix-ui-core: Don't create package-lock.json

### DIFF
--- a/packages/wix-ui-core/.npmrc
+++ b/packages/wix-ui-core/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
If you already ignoring `package-lock.json` in `.gitignore` it's better to not create this file at all.
After each git pull you need to remove local version of `package-lock.json` before `npm install/update` to have the actual dependencies. It's confusing and you can just forget to do it.