### PR TITLE
wix-ui-core: update typescript dep

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -96,7 +96,7 @@
     "ts-jest": "^22.0.3",
     "tslint-config-prettier": "^1.12.0",
     "tslint-react": "^3.5.1",
-    "typescript": "2.9.2",
+    "typescript": "~3.0.3",
     "wait-for-cond": "^1.5.1",
     "wix-eventually": "latest",
     "wix-storybook-utils": "^2.0.5",


### PR DESCRIPTION
Reasons why:
1. it's good to stay up to date anyway
2. When running locally `npm run build`, the output result is dependent on case-sensitive/insensitive systems.

on CI, Linux Machine (case sensitive) you get the right result:
```ts
//dist/src/testkit/protractor.d.ts

import { ButtonDriver } from "../components/Button/Button.protractor.driver";
export declare const buttonTestkitFactory: (obj: {
    dataHook: string;
    wrapper?: import("protractor/built/element").ElementFinder;
}) => ButtonDriver;
...
```

on mac:
```ts
//dist/src/testkit/protractor.d.ts

import { ButtonDriver } from "../components/Button/Button.protractor.driver";
export declare const buttonTestkitFactory: (obj: {
    dataHook: string;
    wrapper?: import("../../../../../../../../Users/ME/Documents/wix-ui/packages/wix-ui-core/node_modules/protractor/built/element").ElementFinder;
}) => ButtonDriver;
export { ButtonDriver };
...
```

This was the issue
https://github.com/Microsoft/TypeScript/issues/24599

and this was the fix
https://github.com/Microsoft/TypeScript/pull/25110

Happens in typescript 2.9.x and fixed in version 3

----

Worth adding some test to it - a very simple one can be just to run a simple `e2e` - something that runs `yoshi build` over a simple project and make sure that build passes with exit-code 0.