### PR TITLE
<ButtonNext> - using native disable pseudo-class instead of stylable state.

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.st.css
+++ b/packages/wix-ui-core/src/components/button-next/button-next.st.css
@@ -1,5 +1,5 @@
 .root {
-  -st-states: error;
+  -st-states: disabled;
   display: inline-flex;
   align-items: center;
   cursor: pointer;

--- a/packages/wix-ui-core/src/components/button-next/button-next.st.css
+++ b/packages/wix-ui-core/src/components/button-next/button-next.st.css
@@ -1,5 +1,4 @@
 .root {
-  -st-states: disabled;
   display: inline-flex;
   align-items: center;
   cursor: pointer;

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -41,21 +41,9 @@ export class ButtonNext extends React.Component<ButtonProps> {
     });
 
   render() {
-    const {
-      suffixIcon,
-      prefixIcon,
-      children,
-      onClick,
-      disabled,
-      ...rest
-    } = this.props;
+    const { suffixIcon, prefixIcon, children, onClick, ...rest } = this.props;
     return (
-      <button
-        {...rest}
-        disabled={disabled}
-        onClick={onClick}
-        {...style("root", {}, this.props)}
-      >
+      <button {...rest} onClick={onClick} {...style("root", {}, this.props)}>
         {this._addPrefix(prefixIcon)}
         <span className={style.content}>{children}</span>
         {this._addSuffix(suffixIcon)}

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -54,8 +54,9 @@ export class ButtonNext extends React.Component<ButtonProps> {
     return (
       <button
         {...rest}
+        disabled={disabled}
         onClick={disabled ? null : onClick}
-        {...style("root", { disabled }, this.props)}
+        {...style("root", {}, this.props)}
       >
         {this._addPrefix(prefixIcon)}
         <span className={style.content}>{children}</span>

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -55,7 +55,7 @@ export class ButtonNext extends React.Component<ButtonProps> {
       <button
         {...rest}
         disabled={disabled}
-        onClick={disabled ? null : onClick}
+        onClick={onClick}
         {...style("root", {}, this.props)}
       >
         {this._addPrefix(prefixIcon)}

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { string, node, bool, oneOf } from "prop-types";
+import { string, node, oneOf } from "prop-types";
 import { BaseProps } from "../../types/BaseProps";
 import style from "./button-next.st.css";
 

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -25,8 +25,6 @@ export class ButtonNext extends React.Component<ButtonProps> {
 
   static propTypes = {
     className: string,
-    disabled: bool,
-    error: bool,
     prefixIcon: node,
     suffixIcon: node,
     type: oneOf(["submit", "button", "reset"])

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -10,8 +10,6 @@ export interface ButtonProps
   prefixIcon?: React.ReactElement<any>;
   /** accepts suffix icon  */
   suffixIcon?: React.ReactElement<any>;
-  /** sets error state */
-  error?: boolean;
 }
 /**
  * ButtonNext

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -20,8 +20,6 @@ export class ButtonNext extends React.Component<ButtonProps> {
   static displayName = "ButtonNext";
 
   static defaultProps = {
-    disabled: false,
-    error: false,
     type: "button"
   };
 
@@ -53,14 +51,13 @@ export class ButtonNext extends React.Component<ButtonProps> {
       children,
       onClick,
       disabled,
-      error,
       ...rest
     } = this.props;
     return (
       <button
         {...rest}
         onClick={disabled ? null : onClick}
-        {...style("root", { error }, this.props)}
+        {...style("root", { disabled }, this.props)}
       >
         {this._addPrefix(prefixIcon)}
         <span className={style.content}>{children}</span>


### PR DESCRIPTION
Fixes: https://github.com/wix/wix-ui/issues/771

Removes `error` state. According to UX: buttons will not have error state. Check zeplin for reference.