### PR TITLE
<LiveCodeExample/> - add new component

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -60,6 +60,7 @@
     "react-collapse": "^4.0.3",
     "react-docgen": "^2.20.0",
     "react-element-to-jsx-string": "^13.2.0",
+    "react-live": "^1.12.0",
     "react-motion": "^0.5.2",
     "react-remarkable": "^1.1.3",
     "react-syntax-highlighter": "^9.0.0",

--- a/packages/wix-storybook-utils/src/AutoExample/components/styles.scss
+++ b/packages/wix-storybook-utils/src/AutoExample/components/styles.scss
@@ -1,3 +1,5 @@
+@import '../../mixins.scss';
+
 .wrapper {
   box-sizing: border-box;
   padding: 10px;
@@ -36,29 +38,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-}
-
-@mixin checkerboard($size, $color1, $color2) {
-  background:
-    linear-gradient(45deg,
-      $color1 25%,
-      transparent 25%,
-      transparent 75%,
-      $color1 75%,
-      $color1 0
-    ),
-    linear-gradient(45deg,
-      $color1 25%,
-      transparent 5%,
-      transparent 75%,
-      $color1 75%,
-      $color1 0
-    ),
-    $color2;
-  background-position: 0 0, ($size / 2) ($size / 2);
-  background-size: $size $size;
-  background-clip: border-box;
-  background-origin: padding-box;
 }
 
 .preview {

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -13,10 +13,6 @@ import Code from 'wix-ui-icons-common/Code';
 import Document from 'wix-ui-icons-common/Document';
 import TextButton from '../TextButton';
 
-const LiveCodeExamplesRow = props => (
-  <div className={styles.examplesContainer} {...props}/>
-);
-
 export default class LiveCodeExample extends Component {
 
   static propTypes = {
@@ -29,8 +25,6 @@ export default class LiveCodeExample extends Component {
   static defaultProps = {
     compact: false
   };
-
-  static Row = LiveCodeExamplesRow;
 
   resetCode = () => {
     this.setState({

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -1,8 +1,10 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {LiveProvider, LiveEditor, LiveError, LivePreview} from 'react-live';
+import classnames from 'classnames';
 import styles from './index.scss';
 
+import ToggleSwitch from 'wix-style-react/ToggleSwitch';
 import EmptyTrash from 'wix-ui-icons-common/EmptyTrash';
 import TextButton from '../TextButton';
 
@@ -26,15 +28,22 @@ export default class LiveCodeExample extends Component {
     });
   };
 
+  onToggleRtl = isRtl => this.setState({isRtl});
+  onToggleBackground = isDarkBackground => this.setState({isDarkBackground});
+
   constructor(props) {
     super(props);
 
     this.state = {
-      code: props.initialCode
+      code: props.initialCode,
+      isRtl: false,
+      isDarkBackground: false
     };
   }
 
   render() {
+    const {code, isRtl, isDarkBackground} = this.state;
+
     return (
       <div className={styles.wrapper}>
 
@@ -42,17 +51,45 @@ export default class LiveCodeExample extends Component {
           <h2>{this.props.title}</h2>
 
           <div className={styles.spacer}/>
+
+          <div className={styles.headerControl}>
+            Imitate RTL:&nbsp;
+
+            <ToggleSwitch
+              size="small"
+              checked={isRtl}
+              onChange={e => this.onToggleRtl(e.target.checked)}
+            />
+          </div>
+
+          <div className={styles.headerControl}>
+            Dark Background:&nbsp;
+
+            <ToggleSwitch
+              size="small"
+              checked={isDarkBackground}
+              onChange={e => this.onToggleBackground(e.target.checked)}
+            />
+          </div>
+
           <TextButton onClick={this.resetCode} prefixIcon={<EmptyTrash/>}>Reset</TextButton>
         </div>
 
-        <LiveProvider code={this.state.code.trim()} scope={this.props.scope} mountStylesheet={false}>
+        <LiveProvider code={code.trim()} scope={this.props.scope} mountStylesheet={false}>
           <div className={styles.liveExampleWrapper}>
 
             <div className={styles.editor}>
               <LiveEditor className={styles.editorView} onChange={this.onCodeChange}/>
             </div>
 
-            <div className={styles.preview}>
+            <div
+              className={classnames({
+                [styles.preview]: true,
+                rtl: isRtl,
+                [styles.darkPreview]: isDarkBackground
+              })}
+              dir={isRtl ? 'rtl' : ''}
+            >
               <LivePreview/>
               <LiveError className={styles.error}/>
             </div>

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -1,0 +1,65 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {LiveProvider, LiveEditor, LiveError, LivePreview} from 'react-live';
+import styles from './index.scss';
+
+import EmptyTrash from 'wix-ui-icons-common/EmptyTrash';
+import TextButton from '../TextButton';
+
+export default class LiveCodeExample extends Component {
+
+  static propTypes = {
+    initialCode: PropTypes.string,
+    title: PropTypes.string,
+    scope: PropTypes.object
+  };
+
+  resetCode = () => {
+    // We'll need to update the state twice in order to cause react-live to
+    // update the code
+    this.setState({
+      code: ''
+    }, () => {
+      this.setState({
+        code: this.props.initialCode
+      });
+    });
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      code: props.initialCode
+    };
+  }
+
+  render() {
+    return (
+      <div className={styles.wrapper}>
+
+        <div className={styles.header}>
+          <h2>{this.props.title}</h2>
+
+          <div className={styles.spacer}/>
+          <TextButton onClick={this.resetCode} prefixIcon={<EmptyTrash/>}>Reset</TextButton>
+        </div>
+
+        <LiveProvider code={this.state.code.trim()} scope={this.props.scope} mountStylesheet={false}>
+          <div className={styles.liveExampleWrapper}>
+
+            <div className={styles.editor}>
+              <LiveEditor className={styles.editorView} onChange={this.onCodeChange}/>
+            </div>
+
+            <div className={styles.preview}>
+              <LivePreview/>
+              <LiveError className={styles.error}/>
+            </div>
+          </div>
+        </LiveProvider>
+      </div>
+    );
+  }
+
+}

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -2,34 +2,47 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {LiveProvider, LiveEditor, LiveError, LivePreview} from 'react-live';
 import classnames from 'classnames';
+import {Collapse} from 'react-collapse';
 import styles from './index.scss';
 
 import ToggleSwitch from 'wix-style-react/ToggleSwitch';
 import EmptyTrash from 'wix-ui-icons-common/EmptyTrash';
+import Code from 'wix-ui-icons-common/Code';
 import TextButton from '../TextButton';
+
+const LiveCodeExamplesRow = props => (
+  <div className={styles.examplesContainer} {...props}/>
+);
 
 export default class LiveCodeExample extends Component {
 
   static propTypes = {
     initialCode: PropTypes.string,
     title: PropTypes.string,
-    scope: PropTypes.object
+    scope: PropTypes.object,
+    compact: PropTypes.bool
   };
 
+  static defaultProps = {
+    compact: false
+  };
+
+  static Row = LiveCodeExamplesRow;
+
   resetCode = () => {
-    // We'll need to update the state twice in order to cause react-live to
-    // update the code
     this.setState({
-      code: ''
-    }, () => {
-      this.setState({
-        code: this.props.initialCode
-      });
+      code: this.props.initialCode
     });
   };
 
+  onCodeChange = code => this.setState({code});
+
   onToggleRtl = isRtl => this.setState({isRtl});
   onToggleBackground = isDarkBackground => this.setState({isDarkBackground});
+
+  onToggleCode = () => this.setState(state => ({
+    isEditorOpened: !state.isEditorOpened
+  }));
 
   constructor(props) {
     super(props);
@@ -37,15 +50,21 @@ export default class LiveCodeExample extends Component {
     this.state = {
       code: props.initialCode,
       isRtl: false,
-      isDarkBackground: false
+      isDarkBackground: false,
+      isEditorOpened: !props.compact
     };
   }
 
   render() {
-    const {code, isRtl, isDarkBackground} = this.state;
+    const {compact} = this.props;
+    const {code, isRtl, isDarkBackground, isEditorOpened} = this.state;
 
     return (
-      <div className={styles.wrapper}>
+      <div
+        className={classnames(styles.wrapper, {
+          [styles.compact]: compact
+        })}
+      >
 
         <div className={styles.header}>
           <h2>{this.props.title}</h2>
@@ -72,15 +91,23 @@ export default class LiveCodeExample extends Component {
             />
           </div>
 
-          <TextButton onClick={this.resetCode} prefixIcon={<EmptyTrash/>}>Reset</TextButton>
+          {isEditorOpened && (
+            <TextButton onClick={this.resetCode} prefixIcon={<EmptyTrash/>}>Reset</TextButton>
+          )}
+
+          {compact && (
+            <TextButton onClick={this.onToggleCode} prefixIcon={<Code/>}>
+              {this.state.isEditorOpened ? 'Hide' : 'Show'} code
+            </TextButton>
+          )}
         </div>
 
         <LiveProvider code={code.trim()} scope={this.props.scope} mountStylesheet={false}>
           <div className={styles.liveExampleWrapper}>
 
-            <div className={styles.editor}>
+            <Collapse isOpened={isEditorOpened} className={styles.editor}>
               <LiveEditor className={styles.editorView} onChange={this.onCodeChange}/>
-            </div>
+            </Collapse>
 
             <div
               className={classnames({

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types';
 import {LiveProvider, LiveEditor, LiveError, LivePreview} from 'react-live';
 import classnames from 'classnames';
 import {Collapse} from 'react-collapse';
+import copy from 'copy-to-clipboard';
 import styles from './index.scss';
 
+import Notification from 'wix-style-react/Notification';
 import ToggleSwitch from 'wix-style-react/ToggleSwitch';
-import EmptyTrash from 'wix-ui-icons-common/EmptyTrash';
+import Revert from 'wix-ui-icons-common/Revert';
 import Code from 'wix-ui-icons-common/Code';
+import Document from 'wix-ui-icons-common/Document';
 import TextButton from '../TextButton';
 
 const LiveCodeExamplesRow = props => (
@@ -44,6 +47,11 @@ export default class LiveCodeExample extends Component {
     isEditorOpened: !state.isEditorOpened
   }));
 
+  onCopyClick = () => {
+    copy(this.state.code);
+    this.setState({showNotification: true});
+  };
+
   constructor(props) {
     super(props);
 
@@ -51,8 +59,15 @@ export default class LiveCodeExample extends Component {
       code: props.initialCode,
       isRtl: false,
       isDarkBackground: false,
-      isEditorOpened: !props.compact
+      isEditorOpened: !props.compact,
+      showNotification: false
     };
+  }
+
+  renderCopyButton() {
+    return (
+      <TextButton onClick={this.onCopyClick} prefixIcon={<Document/>}>Copy to clipboard</TextButton>
+    );
   }
 
   render() {
@@ -65,6 +80,22 @@ export default class LiveCodeExample extends Component {
           [styles.compact]: compact
         })}
       >
+
+        <Notification
+          onClose={() => this.setState({showNotification: false})}
+          show={this.state.showNotification}
+          size="small"
+          theme="standard"
+          timeout={3000}
+          type="sticky"
+          zIndex={10000}
+        >
+          <Notification.TextLabel>
+          Copied!
+          </Notification.TextLabel>
+
+          <Notification.CloseButton/>
+        </Notification>
 
         <div className={styles.header}>
           <h2>{this.props.title}</h2>
@@ -91,8 +122,12 @@ export default class LiveCodeExample extends Component {
             />
           </div>
 
+          {!compact && (
+            this.renderCopyButton()
+          )}
+
           {isEditorOpened && (
-            <TextButton onClick={this.resetCode} prefixIcon={<EmptyTrash/>}>Reset</TextButton>
+            <TextButton onClick={this.resetCode} prefixIcon={<Revert/>}>Reset</TextButton>
           )}
 
           {compact && (
@@ -105,7 +140,12 @@ export default class LiveCodeExample extends Component {
         <LiveProvider code={code.trim()} scope={this.props.scope} mountStylesheet={false}>
           <div className={styles.liveExampleWrapper}>
 
-            <Collapse isOpened={isEditorOpened} className={styles.editor}>
+            <Collapse
+              isOpened={isEditorOpened}
+              className={classnames(styles.editor, {
+                [styles.opened]: isEditorOpened
+              })}
+            >
               <LiveEditor className={styles.editorView} onChange={this.onCodeChange}/>
             </Collapse>
 
@@ -122,6 +162,10 @@ export default class LiveCodeExample extends Component {
             </div>
           </div>
         </LiveProvider>
+
+        {(isEditorOpened && compact) && (
+          this.renderCopyButton()
+        )}
       </div>
     );
   }

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -55,7 +55,6 @@
 
 .liveExampleWrapper {
   display: flex;
-  margin-bottom: 5px;
 
   // Stack on top when in compact mode
   .compact & {
@@ -63,6 +62,7 @@
     border-radius: 6px;
     overflow: hidden;
     box-shadow: 0px 0px 0px 4px #F0F4F7;
+    margin-bottom: 5px;
   }
 
   .editor,

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -19,6 +19,8 @@
     min-width: auto;
     max-width: 400px;
     margin-right: 20px;
+    border: 0;
+    overflow: unset;
   }
 }
 
@@ -30,6 +32,8 @@
 
   .compact & {
     height: 3em;
+    border: 0;
+    padding: 0;
   }
 
   .spacer {
@@ -51,10 +55,14 @@
 
 .liveExampleWrapper {
   display: flex;
+  margin-bottom: 5px;
 
   // Stack on top when in compact mode
   .compact & {
     flex-direction: column;
+    border-radius: 6px;
+    overflow: hidden;
+    box-shadow: 0px 0px 0px 4px #F0F4F7;
   }
 
   .editor,
@@ -66,6 +74,10 @@
     // Take all width in compact mode
     .compact & {
       width: 100%;
+
+      border-radius: 6px;
+      box-shadow: 0px 0px 0px 4px #F0F4F7;
+      overflow: hidden;
     }
   }
 
@@ -75,12 +87,16 @@
 
     .compact & {
       border-right: 0;
-      border-bottom: 1px solid #DFE5EB;
+
+      &.opened {
+        margin-bottom: 4px;
+      }
     }
 
     .editorView {
       padding: 20px;
       height: 100%;
+      margin: 0;
       overflow: auto;
       outline: 0;
       font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
@@ -95,7 +111,6 @@
       // https://github.com/PrismJS/prism-themes/blob/master/themes/prism-base16-ateliersulphurpool.light.css
       :global {
         pre[class*="language-"] {
-          padding: 1em;
           margin: .5em 0;
           overflow: auto;
         }

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -1,25 +1,35 @@
+@import '../mixins.scss';
+
 .wrapper {
   min-width: 894px;
   max-width: 1254px;
+
+  margin-bottom: 20px;
+  border: 1px solid #DFE5EB;
+  border-radius: 3px;
+  overflow: hidden;
 }
 
 .header {
   display: flex;
-  align-items: flex-end;
-  border-bottom: 1px solid #ccc;
-  margin-bottom: 1em;
+  align-items: center;
+  border-bottom: 1px solid #DFE5EB;
+  padding: 0 1em;
 
-  & .spacer {
+  .spacer {
     flex: 1;
+  }
+
+  .headerControl {
+    margin-right: 20px;
+    display: flex;
+    align-items: center;
+    line-height: 0;
   }
 }
 
 .liveExampleWrapper {
   display: flex;
-  margin-bottom: 20px;
-  border: 3px solid #DFE5EB;
-  border-radius: 6px;
-  overflow: hidden;
 
   .editor,
   .preview {
@@ -29,7 +39,7 @@
   }
 
   .editor {
-    border-right: 3px solid #DFE5EB;
+    border-right: 1px solid #DFE5EB;
 
     .editorView {
       padding: 20px;
@@ -153,11 +163,12 @@
   .preview {
     padding: 30px 20px;
     box-shadow: 0 0 10px 2px #e5ebf1 inset;
-    background: linear-gradient(45deg, #eff2f6 25%, transparent 25%, transparent 75%, #eff2f6 75%, #eff2f6 0), linear-gradient(45deg, #eff2f6 25%, transparent 5%, transparent 75%, #eff2f6 75%, #eff2f6 0), #fff;
-    background-position: 0 0, 10px 10px;
-    background-size: 20px 20px;
-    background-clip: border-box;
-    background-origin: padding-box;
+    @include checkerboard(20px, #eff2f6, #fff);
+
+    &.darkPreview {
+      @include checkerboard(20px, #5b7fa4, #486684);
+      box-shadow: 0 0 10px 2px #486684 inset;
+    }
 
     .error {
       position: absolute;

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -1,0 +1,173 @@
+.wrapper {
+  min-width: 894px;
+  max-width: 1254px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-end;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 1em;
+
+  & .spacer {
+    flex: 1;
+  }
+}
+
+.liveExampleWrapper {
+  display: flex;
+  margin-bottom: 20px;
+  border: 3px solid #DFE5EB;
+  border-radius: 6px;
+  overflow: hidden;
+
+  .editor,
+  .preview {
+    box-sizing: border-box;
+    width: 50%;
+    position: relative;
+  }
+
+  .editor {
+    border-right: 3px solid #DFE5EB;
+
+    .editorView {
+      padding: 20px;
+      min-height: 300px;
+      height: 100%;
+      overflow: auto;
+      outline: 0;
+      font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+
+      // Theme extracted from
+      // https://github.com/PrismJS/prism-themes/blob/master/themes/prism-base16-ateliersulphurpool.light.css
+      :global {
+        pre[class*="language-"] {
+          padding: 1em;
+          margin: .5em 0;
+          overflow: auto;
+        }
+
+        /* Inline code */
+        :not(pre) > code[class*="language-"] {
+          padding: .1em;
+          border-radius: .3em;
+        }
+
+        .token.comment,
+        .token.prolog,
+        .token.doctype,
+        .token.cdata {
+          color: #898ea4;
+        }
+
+        .token.punctuation {
+          color: #5e6687;
+        }
+
+        .token.namespace {
+          opacity: .7;
+        }
+
+        .token.operator,
+        .token.boolean,
+        .token.number {
+          color: #c76b29;
+        }
+
+        .token.property {
+          color: #c08b30;
+        }
+
+        .token.tag {
+          color: #3d8fd1;
+        }
+
+        .token.string {
+          color: #22a2c9;
+        }
+
+        .token.selector {
+          color: #6679cc;
+        }
+
+        .token.attr-name {
+          color: #c76b29;
+        }
+
+        .token.entity,
+        .token.url,
+        .language-css .token.string,
+        .style .token.string {
+          color: #22a2c9;
+        }
+
+        .token.attr-value,
+        .token.keyword,
+        .token.control,
+        .token.directive,
+        .token.unit {
+          color: #ac9739;
+        }
+
+        .token.statement,
+        .token.regex,
+        .token.atrule {
+          color: #22a2c9;
+        }
+
+        .token.placeholder,
+        .token.variable {
+          color: #3d8fd1;
+        }
+
+        .token.deleted {
+          text-decoration: line-through;
+        }
+
+        .token.inserted {
+          border-bottom: 1px dotted #202746;
+          text-decoration: none;
+        }
+
+        .token.italic {
+          font-style: italic;
+        }
+
+        .token.important,
+        .token.bold {
+          font-weight: bold;
+        }
+
+        .token.important {
+          color: #c94922;
+        }
+
+        .token.entity {
+          cursor: help;
+        }
+      }
+    }
+  }
+
+  .preview {
+    padding: 30px 20px;
+    box-shadow: 0 0 10px 2px #e5ebf1 inset;
+    background: linear-gradient(45deg, #eff2f6 25%, transparent 25%, transparent 75%, #eff2f6 75%, #eff2f6 0), linear-gradient(45deg, #eff2f6 25%, transparent 5%, transparent 75%, #eff2f6 75%, #eff2f6 0), #fff;
+    background-position: 0 0, 10px 10px;
+    background-size: 20px 20px;
+    background-clip: border-box;
+    background-origin: padding-box;
+
+    .error {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      background: #ff5555;
+      color: #ffffff;
+      padding: 10px;
+      white-space: pre;
+    }
+  }
+}

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -1,11 +1,5 @@
 @import '../mixins.scss';
 
-.examplesContainer {
-  display: flex;
-  max-width: 1254px;
-  align-items: baseline;
-}
-
 .wrapper {
   min-width: 894px;
   max-width: 1254px;
@@ -17,8 +11,7 @@
 
   &.compact {
     min-width: auto;
-    max-width: 400px;
-    margin-right: 20px;
+    width: 100%;
     border: 0;
     overflow: unset;
   }
@@ -229,11 +222,17 @@
       position: absolute;
       bottom: 0;
       left: 0;
-      width: 100%;
+      right: 0;
       background: #ff5555;
       color: #ffffff;
       padding: 10px;
       white-space: pre;
+
+      .compact & {
+        top: 0;
+        height: 100%;
+        overflow: auto;
+      }
     }
   }
 }

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -1,5 +1,11 @@
 @import '../mixins.scss';
 
+.examplesContainer {
+  display: flex;
+  max-width: 1254px;
+  align-items: baseline;
+}
+
 .wrapper {
   min-width: 894px;
   max-width: 1254px;
@@ -8,6 +14,12 @@
   border: 1px solid #DFE5EB;
   border-radius: 3px;
   overflow: hidden;
+
+  &.compact {
+    min-width: auto;
+    max-width: 400px;
+    margin-right: 20px;
+  }
 }
 
 .header {
@@ -15,6 +27,10 @@
   align-items: center;
   border-bottom: 1px solid #DFE5EB;
   padding: 0 1em;
+
+  .compact & {
+    height: 3em;
+  }
 
   .spacer {
     flex: 1;
@@ -25,29 +41,55 @@
     display: flex;
     align-items: center;
     line-height: 0;
+
+    // Hide toggles on compact mode
+    .compact & {
+      display: none;
+    }
   }
 }
 
 .liveExampleWrapper {
   display: flex;
 
+  // Stack on top when in compact mode
+  .compact & {
+    flex-direction: column;
+  }
+
   .editor,
   .preview {
     box-sizing: border-box;
     width: 50%;
     position: relative;
+
+    // Take all width in compact mode
+    .compact & {
+      width: 100%;
+    }
   }
 
   .editor {
     border-right: 1px solid #DFE5EB;
+    background-color: #F8FAFB;
+
+    .compact & {
+      border-right: 0;
+      border-bottom: 1px solid #DFE5EB;
+    }
 
     .editorView {
       padding: 20px;
-      min-height: 300px;
       height: 100%;
       overflow: auto;
       outline: 0;
       font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+
+      // Auto height when in compact mode
+      .compact & {
+        min-height: auto;
+        height: auto;
+      }
 
       // Theme extracted from
       // https://github.com/PrismJS/prism-themes/blob/master/themes/prism-base16-ateliersulphurpool.light.css
@@ -162,12 +204,10 @@
 
   .preview {
     padding: 30px 20px;
-    box-shadow: 0 0 10px 2px #e5ebf1 inset;
     @include checkerboard(20px, #eff2f6, #fff);
 
     &.darkPreview {
       @include checkerboard(20px, #5b7fa4, #486684);
-      box-shadow: 0 0 10px 2px #486684 inset;
     }
 
     .error {

--- a/packages/wix-storybook-utils/src/TextButton/index.js
+++ b/packages/wix-storybook-utils/src/TextButton/index.js
@@ -5,6 +5,7 @@ export default class TextButton extends Component {
 
   static propTypes = {
     onClick: PropTypes.func,
+    prefixIcon: PropTypes.node,
     children: PropTypes.node
   };
 
@@ -31,7 +32,9 @@ export default class TextButton extends Component {
       outline: 'none',
       border: 'none',
       background: 'none',
-      cursor: 'pointer'
+      cursor: 'pointer',
+      display: 'flex',
+      lineHeight: 2
     };
 
     return (
@@ -41,6 +44,16 @@ export default class TextButton extends Component {
         onMouseLeave={this.toggleHover}
         onClick={this.props.onClick}
       >
+        {this.props.prefixIcon ? (
+          <div
+            style={{
+              padding: '0 6px 0 0',
+              lineHeight: '0 !important'
+            }}
+          >
+            {this.props.prefixIcon}
+          </div>
+        ) : null}
         {this.props.children}
       </button>
     );

--- a/packages/wix-storybook-utils/src/TextButton/index.js
+++ b/packages/wix-storybook-utils/src/TextButton/index.js
@@ -34,7 +34,8 @@ export default class TextButton extends Component {
       background: 'none',
       cursor: 'pointer',
       display: 'flex',
-      lineHeight: 2
+      alignItems: 'center',
+      lineHeight: 0
     };
 
     return (

--- a/packages/wix-storybook-utils/src/mixins.scss
+++ b/packages/wix-storybook-utils/src/mixins.scss
@@ -1,0 +1,22 @@
+@mixin checkerboard($size, $color1, $color2) {
+  background:
+    linear-gradient(45deg,
+      $color1 25%,
+      transparent 25%,
+      transparent 75%,
+      $color1 75%,
+      $color1 0
+    ),
+    linear-gradient(45deg,
+      $color1 25%,
+      transparent 5%,
+      transparent 75%,
+      $color1 75%,
+      $color1 0
+    ),
+    $color2;
+  background-position: 0 0, ($size / 2) ($size / 2);
+  background-size: $size $size;
+  background-clip: border-box;
+  background-origin: padding-box;
+}

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import Component from './component';
 import CodeShowcase from '../src/CodeShowcase/';
+import LiveCodeExample from '../src/LiveCodeExample';
+
+// Taking the whole wsr library for the code example test
+import * as wsrScope from 'wix-style-react';
 
 const showcase = `<button className={button.one}>one</button>
 <button className={button.two}>two</button>
 <button className={button.three}>three</button>`;
 
-const ExampleShowcase = (
+const ExampleShowcase = () => (
   <CodeShowcase title="CodeShowcase" code={showcase}>
     <button style={{marginRight: '5px'}}>one</button>
     <button style={{marginRight: '5px'}}>two</button>
@@ -42,5 +46,66 @@ export default {
 
   hiddenProps: ['propNotVisibleInStorybook'],
 
-  examples: ExampleShowcase
+  examples: (
+    <div>
+      <ExampleShowcase/>
+
+      <LiveCodeExample
+        scope={wsrScope}
+        title="Live code example" initialCode={`
+/* This is just a big example to test the live editor */
+<div>
+  <Dropdown
+    placeholder="Select dominant hand"
+    options={[
+      {id: 0, value: 'Left'},
+      {id: 1, value: 'Right'},
+      {id: 2, value: 'Ambidextrous'}
+    ]}
+  />
+
+  <br/>
+
+  <Heading>This is a live preview!</Heading>
+  <Heading>This is a live preview!</Heading>
+  <Heading>This is a live preview!</Heading>
+
+  <br/>
+
+  <Card>
+    <Card.Header
+        title="Even Cards!"
+        suffix={
+          <Button
+            onClick={() => alert('Clicked!')}
+            height="small"
+            theme="fullblue"
+            children="New Image"
+            />
+        }
+        />
+
+      <Card.Content>
+        <EmptyState
+          title="You don't have any images yet"
+          subtitle="'member EmptyState?"
+          children={<TextLink>Add image</TextLink>}
+          />
+      </Card.Content>
+    </Card>
+
+  <br/>
+
+  <Tooltip content="Even tooltip works!">
+    <span>Hover me!</span>
+  </Tooltip>
+
+  <br/>
+  <br/>
+
+  <Button>Click me!</Button>
+</div>
+      `}/>
+    </div>
+  )
 };

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -70,7 +70,7 @@ export default {
 </div>
       `}/>
 
-      <LiveCodeExample.Row>
+      <div style={{maxWidth: 440}}>
         <LiveCodeExample
           compact
           title="Large size"
@@ -87,38 +87,7 @@ export default {
 </TextField>
           `}
         />
-        <LiveCodeExample
-          compact
-          title="Medium size"
-          scope={wsrScope}
-          initialCode={`
-<TextField>
-  <Label for="firstName">
-    Label
-  </Label>
-  <Input
-    placeholder="Place holder test goes here"
-  />
-</TextField>
-          `}
-        />
-        <LiveCodeExample
-          compact
-          title="Small size"
-          scope={wsrScope}
-          initialCode={`
-<TextField>
-  <Label for="firstName">
-    Label
-  </Label>
-  <Input
-    placeholder="Place holder test goes here"
-    size="small"
-  />
-</TextField>
-          `}
-        />
-      </LiveCodeExample.Row>
+      </div>
     </div>
   )
 };

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -3,12 +3,13 @@ import Component from './component';
 import CodeShowcase from '../src/CodeShowcase/';
 import LiveCodeExample from '../src/LiveCodeExample';
 
-// Taking the whole wsr library for the code example test
-import * as wsrScope from 'wix-style-react';
-
 const showcase = `<button className={button.one}>one</button>
 <button className={button.two}>two</button>
 <button className={button.three}>three</button>`;
+
+const exampleScope = {
+  Button: props => <button {...props}/>
+};
 
 const ExampleShowcase = () => (
   <CodeShowcase title="CodeShowcase" code={showcase}>
@@ -51,40 +52,24 @@ export default {
       <ExampleShowcase/>
 
       <LiveCodeExample
-        scope={wsrScope}
+        scope={exampleScope}
         title="Live code example" initialCode={`
-/* This is just a big example to test the live editor */
 <div>
-  <Dropdown
-    placeholder="Select dominant hand"
-    options={[
-      {id: 0, value: 'Left'},
-      {id: 1, value: 'Right'},
-      {id: 2, value: 'Ambidextrous'}
-    ]}
-  />
-
-  <br/>
-
-  <Heading>This is a live preview!</Heading>
+  <p>Look at me!</p>
+  <Button>I come from the scope!</Button>
 </div>
       `}/>
 
       <div style={{maxWidth: 440}}>
         <LiveCodeExample
           compact
-          title="Large size"
-          scope={wsrScope}
+          title="Compact mode"
+          scope={exampleScope}
           initialCode={`
-<TextField>
-  <Label for="firstName">
-    Label
-  </Label>
-  <Input
-    placeholder="Place holder test goes here"
-    size="large"
-  />
-</TextField>
+<div>
+  <p>Look at me!</p>
+  <Button>I come from the scope!</Button>
+</div>
           `}
         />
       </div>

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -51,7 +51,7 @@ export default {
       <ExampleShowcase/>
 
       <LiveCodeExample
-        scope={wsrScope}
+        scop={wsrScope}
         title="Live code example" initialCode={`
 /* This is just a big example to test the live editor */
 <div>
@@ -67,45 +67,58 @@ export default {
   <br/>
 
   <Heading>This is a live preview!</Heading>
-  <Heading>This is a live preview!</Heading>
-  <Heading>This is a live preview!</Heading>
-
-  <br/>
-
-  <Card>
-    <Card.Header
-        title="Even Cards!"
-        suffix={
-          <Button
-            onClick={() => alert('Clicked!')}
-            height="small"
-            theme="fullblue"
-            children="New Image"
-            />
-        }
-        />
-
-      <Card.Content>
-        <EmptyState
-          title="You don't have any images yet"
-          subtitle="'member EmptyState?"
-          children={<TextLink>Add image</TextLink>}
-          />
-      </Card.Content>
-    </Card>
-
-  <br/>
-
-  <Tooltip content="Even tooltip works!">
-    <span>Hover me!</span>
-  </Tooltip>
-
-  <br/>
-  <br/>
-
-  <Button>Click me!</Button>
 </div>
       `}/>
+
+      <LiveCodeExample.Row>
+        <LiveCodeExample
+          compact
+          title="Large size"
+          scope={wsrScope}
+          initialCode={`
+<TextField>
+  <Label for="firstName">
+    Label
+  </Label>
+  <Input
+    placeholder="Place holder test goes here"
+    size="large"
+  />
+</TextField>
+          `}
+        />
+        <LiveCodeExample
+          compact
+          title="Medium size"
+          scope={wsrScope}
+          initialCode={`
+<TextField>
+  <Label for="firstName">
+    Label
+  </Label>
+  <Input
+    placeholder="Place holder test goes here"
+  />
+</TextField>
+          `}
+        />
+        <LiveCodeExample
+          compact
+          title="Small size"
+          scope={wsrScope}
+          initialCode={`
+<TextField>
+  <Label for="firstName">
+    Label
+  </Label>
+  <Input
+    placeholder="Place holder test goes here"
+    size="small"
+  />
+</TextField>
+          `}
+        />
+      </LiveCodeExample.Row>
     </div>
   )
 };

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -51,7 +51,7 @@ export default {
       <ExampleShowcase/>
 
       <LiveCodeExample
-        scop={wsrScope}
+        scope={wsrScope}
         title="Live code example" initialCode={`
 /* This is just a big example to test the live editor */
 <div>


### PR DESCRIPTION
This PR adds a new component to `wix-storybook-utils`: `<LiveCodeExample/>`. It uses [`react-live`](https://github.com/FormidableLabs/react-live) for the most parts.

![screen shot 2018-10-25 at 15 46 33](https://user-images.githubusercontent.com/11786506/47501064-3068a780-d86d-11e8-9516-a853c11b8ea0.png)

### Usage

```jsx
// You'll need to pass a `scope` to the component. Basically its
// just an object containing all the globals (in our case: our component).
import * as wsrScope from 'wix-style-react';

<LiveCodeExample
	scope={wsrScopr}
	title="Dropdown live example"
	initialCode={`
<Dropdown
	placeholder="Select dominant hand"
	options={[
		{id: 0, value: 'Left'},
		{id: 1, value: 'Right'},
		{id: 2, value: 'Ambidextrous'}
	]}
/>
	`}
/>
```

When using this component in a library, say WSR, you'd want to create a wrapper component that sets the scope for you. For example:

```jsx
// ./stories/components/LiveCodeExample
import LiveCodeExample from 'wix-storybook-utils/LiveCodeExample';
import * as scope from '../../';
export default props => (
	<LiveCodeExample scope={scope} {...props} />
);
```

### Ideas

#### Syntax highlighting

I noticed we don't have a syntax highlighting in out stories (maybe it's broken, or maybe its on purpose?). Since both `react-live` and the `<CodeBlock/>` uses `prism.js`, they can share the same highlighting theme. Currently the theme is scoped to the live editor only, but I think its a really hood idea that we'll have it in both of them.

#### RTL and dark background toggles

Do you think should add these toggles, like in the playground?