### PR TITLE
wix-storybook-utils: add all relevant styles and show in storybook

### DIFF
--- a/packages/wix-storybook-utils/.storybook/config.js
+++ b/packages/wix-storybook-utils/.storybook/config.js
@@ -2,6 +2,7 @@ import {configure, storiesOf} from '@storybook/react';
 import {setOptions} from '@storybook/addon-options';
 
 function loadStories() {
+  require('../stories/all');
   require('../stories/index.story.js');
   require('./stories.scss');
 }

--- a/packages/wix-storybook-utils/.storybook/stories.scss
+++ b/packages/wix-storybook-utils/.storybook/stories.scss
@@ -2,10 +2,3 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-
-body {
-  font-family: "HelveticaNeueW01-45Ligh", "HelveticaNeueW02-45Ligh", "HelveticaNeueW10-45Ligh", "Helvetica Neue", "Helvetica", "Arial", "\30E1\30A4\30EA\30AA", "meiryo", "\30D2\30E9\30AE\30CE\89D2\30B4 pro w3", "hiragino kaku gothic pro";
-  color: #222;
-  line-height: 1.2;
-  font-size: 13px;
-}

--- a/packages/wix-storybook-utils/src/AutoExample/components/section-collapse/styles.scss
+++ b/packages/wix-storybook-utils/src/AutoExample/components/section-collapse/styles.scss
@@ -1,4 +1,7 @@
+@import '../../../common.scss';
+
 .head {
+  @extend .commonText;
   display: flex;
   align-items: center;
   padding: 1em 0;

--- a/packages/wix-storybook-utils/src/AutoExample/components/styles.scss
+++ b/packages/wix-storybook-utils/src/AutoExample/components/styles.scss
@@ -1,4 +1,5 @@
 @import '../../mixins.scss';
+@import '../../common.scss';
 
 .wrapper {
   box-sizing: border-box;
@@ -35,6 +36,7 @@
 }
 
 .previewControl {
+  @extend .commonText;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/packages/wix-storybook-utils/src/CodeExample/index.js
+++ b/packages/wix-storybook-utils/src/CodeExample/index.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Collapse from 'react-collapse';
+import styles from './styles.scss';
 
 import CodeBlock from '../CodeBlock';
 import TextButton from '../TextButton';
@@ -38,7 +39,7 @@ export default class CodeExample extends Component {
   render() {
     return (
       <div>
-        <div style={{display: 'flex'}}>
+        <div className={styles.panelControl} style={{display: 'flex'}}>
           <h2>{this.props.title}</h2>
           <div style={{margin: '22px 24px 0'}}>
             <TextButton onClick={this.toggleCode}>

--- a/packages/wix-storybook-utils/src/CodeExample/styles.scss
+++ b/packages/wix-storybook-utils/src/CodeExample/styles.scss
@@ -1,0 +1,5 @@
+@import "../common.scss";
+
+.panel-control {
+  @extend .commonText;
+}

--- a/packages/wix-storybook-utils/src/InteractiveCodeExample/style.scss
+++ b/packages/wix-storybook-utils/src/InteractiveCodeExample/style.scss
@@ -1,7 +1,0 @@
-.example {
-  margin-bottom: 20px;
-}
-
-.input, .output {
-  margin-bottom: 20px;
-}

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -1,4 +1,5 @@
 @import '../mixins.scss';
+@import '../common.scss';
 
 .wrapper {
   min-width: 894px;
@@ -18,6 +19,7 @@
 }
 
 .header {
+  @extend .commonText;
   display: flex;
   align-items: center;
   border-bottom: 1px solid #DFE5EB;

--- a/packages/wix-storybook-utils/src/TextButton/index.js
+++ b/packages/wix-storybook-utils/src/TextButton/index.js
@@ -33,10 +33,7 @@ export default class TextButton extends Component {
       outline: 'none',
       border: 'none',
       background: 'none',
-      cursor: 'pointer',
-      display: 'flex',
-      alignItems: 'center',
-      lineHeight: 0
+      cursor: 'pointer'
     };
 
     return (
@@ -48,12 +45,7 @@ export default class TextButton extends Component {
         onClick={this.props.onClick}
       >
         {this.props.prefixIcon ? (
-          <div
-            style={{
-              padding: '0 6px 0 0',
-              lineHeight: '0 !important'
-            }}
-          >
+          <div className={styles.prefix}>
             {this.props.prefixIcon}
           </div>
         ) : null}

--- a/packages/wix-storybook-utils/src/TextButton/index.js
+++ b/packages/wix-storybook-utils/src/TextButton/index.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import styles from './styles.scss';
 
 export default class TextButton extends Component {
 
@@ -40,6 +41,7 @@ export default class TextButton extends Component {
 
     return (
       <button
+        className={styles.root}
         style={style}
         onMouseEnter={this.toggleHover}
         onMouseLeave={this.toggleHover}

--- a/packages/wix-storybook-utils/src/TextButton/styles.scss
+++ b/packages/wix-storybook-utils/src/TextButton/styles.scss
@@ -1,0 +1,5 @@
+@import "../common.scss";
+
+.root {
+  @extend .commonText;
+}

--- a/packages/wix-storybook-utils/src/TextButton/styles.scss
+++ b/packages/wix-storybook-utils/src/TextButton/styles.scss
@@ -3,3 +3,10 @@
 .root {
   @extend .commonText;
 }
+
+.prefix {
+  padding: 0 6px 0 0;
+  line-height: 0 !important;
+  display: inline-block;
+  vertical-align: middle;
+}

--- a/packages/wix-storybook-utils/src/common.scss
+++ b/packages/wix-storybook-utils/src/common.scss
@@ -1,0 +1,6 @@
+.commonText {
+  font-family: "HelveticaNeueW01-45Ligh", "HelveticaNeueW02-45Ligh", "HelveticaNeueW10-45Ligh", "Helvetica Neue", "Helvetica", "Arial", "\30E1\30A4\30EA\30AA", "meiryo", "\30D2\30E9\30AE\30CE\89D2\30B4 pro w3", "hiragino kaku gothic pro", serif;
+  color: #222;
+  line-height: 1.2;
+  font-size: 13px;
+}

--- a/packages/wix-storybook-utils/stories/all.js
+++ b/packages/wix-storybook-utils/stories/all.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import Markdown from '../src/Markdown';
+import InteractiveCodeExample from '../src/InteractiveCodeExample';
+import TabbedView from '../src/TabbedView';
+import CodeExample from '../src/CodeExample';
+import TextButton from '../src/TextButton';
+
+import markdown from './examples/markdown.md';
+import SomeComponentExample from './examples/Example';
+import SomeComponentExampleRaw from '!raw-loader!./examples/Example';
+
+storiesOf('Components', module)
+  .add('<CodeExample/>', () => (
+    <div>
+      Cool way to render components and see their code
+      <CodeExample title={'some code example'} code={SomeComponentExampleRaw}>
+        <SomeComponentExample/>
+      </CodeExample>
+    </div>
+  ))
+  .add('<TabbedView/>', () => (
+    <div>
+      Display data in multiple tabs
+      <TabbedView tabs={['A', 'B']}>
+        <div>
+          First Tab
+        </div>
+        <div>
+          Second Tab
+        </div>
+      </TabbedView>
+    </div>
+  ))
+  .add('<TextButton/>', () => (
+    <div>
+      a clickable textual button
+      <TextButton onClick={() => alert('yes, it is clickable')}>This is a clickable button</TextButton>
+    </div>
+  ))
+  .add('<Markdown/>', () => (
+    <div>
+      A great way to display Markdown files
+      <Markdown source={markdown}/>
+    </div>
+  ))
+  .add('<InteractiveCodeExample/> ', () => (
+    <div>
+      This component should display a component with some code above it
+      <br/>
+      It is relatively old and should be removed sometime
+      <InteractiveCodeExample title="Customize some section">
+        <SomeComponentExample/>
+      </InteractiveCodeExample>
+    </div>
+  ));

--- a/packages/wix-storybook-utils/stories/all.js
+++ b/packages/wix-storybook-utils/stories/all.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import Markdown from '../src/Markdown';
@@ -23,19 +24,17 @@ storiesOf('Components', module)
     <div>
       Display data in multiple tabs
       <TabbedView tabs={['A', 'B']}>
-        <div>
-          First Tab
-        </div>
-        <div>
-          Second Tab
-        </div>
+        <div>First Tab</div>
+        <div>Second Tab</div>
       </TabbedView>
     </div>
   ))
   .add('<TextButton/>', () => (
     <div>
       a clickable textual button
-      <TextButton onClick={() => alert('yes, it is clickable')}>This is a clickable button</TextButton>
+      <TextButton onClick={() => alert('yes, it is clickable')}>
+        This is a clickable button
+      </TextButton>
     </div>
   ))
   .add('<Markdown/>', () => (

--- a/packages/wix-storybook-utils/stories/examples/Example.js
+++ b/packages/wix-storybook-utils/stories/examples/Example.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default class SomeComponent extends React.Component {
+  render() {
+    return (
+      <div style={{background: 'lightyellow', display: 'inline-block'}}>some example component</div>
+    );
+  }
+}

--- a/packages/wix-storybook-utils/stories/examples/markdown.md
+++ b/packages/wix-storybook-utils/stories/examples/markdown.md
@@ -1,0 +1,1 @@
+# Some Markdown

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Component from './component';
-import CodeShowcase from '../src/CodeShowcase/';
+import CodeShowcase from '../src/CodeShowcase';
 import LiveCodeExample from '../src/LiveCodeExample';
 
 const showcase = `<button className={button.one}>one</button>


### PR DESCRIPTION
Following [this bug](https://github.com/wix/wix-style-react/issues/2375) and [this PR](https://github.com/wix/wix-style-react/pull/2377) I wanted to make sure all styles are applied correctly on the components.

On the way, I added a story per component, to verify it works