### PR TITLE
Wix storybook utils/yoshi3

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -85,22 +85,20 @@
     "react-dom": "^16.3.1",
     "react-test-renderer": "^16.3.1",
     "ts-jest": "^23.10.4",
-    "tslint-config-prettier": "^1.15.0",
-    "tslint-react": "^3.6.0",
     "typescript": "^3.1.3",
     "wix-ui-test-utils": "^1.0.120",
-    "yoshi": "^2.13.0"
+    "yoshi": "^3.17.0"
   },
   "babel": {
     "plugins": [
       "transform-runtime"
     ],
     "presets": [
-      "wix"
+      "yoshi"
     ]
   },
   "eslintConfig": {
-    "extends": "wix/react",
+    "extends": "yoshi",
     "env": {
       "jest": true
     },

--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -79,6 +79,7 @@
     "eslint-config-wix": "latest",
     "identity-obj-proxy": "^3.0.0",
     "import-path": "latest",
+    "node-sass": "^4.9.4",
     "prop-types": "^15.6.0",
     "raf": "^3.4.0",
     "react": "^16.3.1",

--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -85,6 +85,8 @@
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-test-renderer": "^16.3.1",
+    "resolve-url-loader": "^3.0.0",
+    "sass-loader": "^7.1.0",
     "ts-jest": "^23.10.4",
     "typescript": "^3.1.3",
     "wix-ui-test-utils": "^1.0.120",

--- a/packages/wix-storybook-utils/src/AutoDocs/component-resolver.js
+++ b/packages/wix-storybook-utils/src/AutoDocs/component-resolver.js
@@ -44,13 +44,12 @@ const isComponentDefinition = (path, types) =>
 const resolveHOC = (path, types) => {
   const node = path.node;
 
-  if (types.CallExpression.check(node) && !isReactCreateClassCall(path)) {
-    if (node.arguments.length) {
-      return resolveHOC(
-        path.get('arguments', node.arguments.length - 1),
-        types,
-      );
-    }
+  if (
+    types.CallExpression.check(node) &&
+    !isReactCreateClassCall(path) &&
+    node.arguments.length
+  ) {
+    return resolveHOC(path.get('arguments', node.arguments.length - 1), types);
   }
 
   return path;
@@ -82,11 +81,11 @@ export default (ast, recast) => {
 
   const exportDeclaration = path => {
     const definitions = resolveExportDeclaration(path, types).reduce(
-      (acc, definition) => {
-        if (isComponentDefinition(definition, types)) {
-          acc.push(definition);
+      (acc, def) => {
+        if (isComponentDefinition(def, types)) {
+          acc.push(def);
         } else {
-          const resolved = resolveToValue(resolveHOC(definition, types));
+          const resolved = resolveToValue(resolveHOC(def, types));
           if (isComponentDefinition(resolved, types)) {
             acc.push(resolved);
           }

--- a/packages/wix-storybook-utils/src/AutoDocs/component-resolver.js
+++ b/packages/wix-storybook-utils/src/AutoDocs/component-resolver.js
@@ -1,4 +1,4 @@
-import {utils} from 'react-docgen';
+import { utils } from 'react-docgen';
 
 const {
   isExportsOrModuleAssignment,
@@ -7,7 +7,7 @@ const {
   isStatelessComponent,
   normalizeClassDefinition,
   resolveExportDeclaration,
-  resolveToValue
+  resolveToValue,
 } = utils;
 
 const ERROR_MULTIPLE_DEFINITIONS =
@@ -16,7 +16,10 @@ const ERROR_MULTIPLE_DEFINITIONS =
 const isReactComponentExtendedClass = (path, types) => {
   const node = path.node;
 
-  if (!types.ClassDeclaration.check(node) && !types.ClassExpression.check(node)) {
+  if (
+    !types.ClassDeclaration.check(node) &&
+    !types.ClassExpression.check(node)
+  ) {
     return false;
   }
 
@@ -24,7 +27,11 @@ const isReactComponentExtendedClass = (path, types) => {
     return false;
   }
 
-  console.warn(`<AutoDocs/> Warning: ${node.id.name} extends ${node.superClass.name} instead of React.Component. Auto generated documentation may be incomplete!`);
+  console.warn(
+    `<AutoDocs/> Warning: ${node.id.name} extends ${
+      node.superClass.name
+    } instead of React.Component. Auto generated documentation may be incomplete!`,
+  );
   return true;
 };
 
@@ -39,7 +46,10 @@ const resolveHOC = (path, types) => {
 
   if (types.CallExpression.check(node) && !isReactCreateClassCall(path)) {
     if (node.arguments.length) {
-      return resolveHOC(path.get('arguments', node.arguments.length - 1), types);
+      return resolveHOC(
+        path.get('arguments', node.arguments.length - 1),
+        types,
+      );
     }
   }
 
@@ -53,7 +63,10 @@ const resolveDefinition = (definition, types) => {
     if (types.ObjectExpression.check(resolvedPath.node)) {
       return resolvedPath;
     }
-  } else if (isReactComponentClass(definition) || isReactComponentExtendedClass(definition, types)) {
+  } else if (
+    isReactComponentClass(definition) ||
+    isReactComponentExtendedClass(definition, types)
+  ) {
     normalizeClassDefinition(definition);
     return definition;
   } else if (isStatelessComponent(definition)) {
@@ -68,8 +81,8 @@ export default (ast, recast) => {
   let definition;
 
   const exportDeclaration = path => {
-    const definitions = resolveExportDeclaration(path, types)
-      .reduce((acc, definition) => {
+    const definitions = resolveExportDeclaration(path, types).reduce(
+      (acc, definition) => {
         if (isComponentDefinition(definition, types)) {
           acc.push(definition);
         } else {
@@ -80,7 +93,9 @@ export default (ast, recast) => {
         }
 
         return acc;
-      }, []);
+      },
+      [],
+    );
 
     if (definitions.length === 0) {
       return false;
@@ -141,7 +156,7 @@ export default (ast, recast) => {
       definition = resolveDefinition(path, types);
 
       return false;
-    }
+    },
   });
 
   return definition;

--- a/packages/wix-storybook-utils/src/AutoDocs/index.js
+++ b/packages/wix-storybook-utils/src/AutoDocs/index.js
@@ -7,9 +7,7 @@ import parser from './parser';
 const shouldHideForE2E = global.self === global.top;
 
 const prepareParsedProps = props => {
-  const asList = Object
-    .keys(props)
-    .map(key => ({...props[key], name: key}));
+  const asList = Object.keys(props).map(key => ({ ...props[key], name: key }));
 
   const required = asList.filter(prop => prop.required);
   const notRequired = asList.filter(prop => !prop.required);
@@ -18,45 +16,64 @@ const prepareParsedProps = props => {
   return required.concat(notRequired);
 };
 
-const wrap = name => children =>
-  <span>{name} [{children}]</span>;
+const wrap = name => children => (
+  <span>
+    {name} [{children}]
+  </span>
+);
 
-const failSafe = type => () =>
+const failSafe = type => () => (
   <span>
     Sorry, unable to parse this propType:
     <pre>{JSON.stringify(type, null, 2)}</pre>
-  </span>;
+  </span>
+);
 
 const renderPropType = (type = {}) => {
   const typeHandlers = {
     custom: () => wrap('custom')(),
 
-    enum: value => wrap('oneOf')(value.map((v, i, allValues) =>
-      <span key={i}><code>{v.value}</code>{allValues[i + 1] && ', '}</span>)),
+    enum: value =>
+      wrap('oneOf')(
+        value.map((v, i, allValues) => (
+          <span key={i}>
+            <code>{v.value}</code>
+            {allValues[i + 1] && ', '}
+          </span>
+        )),
+      ),
 
-    union: value => wrap('oneOfType')(value.map((v, i, allValues) =>
-      <span key={i}>
-        {renderPropType(v)}
-        {allValues[i + 1] && ', '}
-      </span>
-    )),
+    union: value =>
+      wrap('oneOfType')(
+        value.map((v, i, allValues) => (
+          <span key={i}>
+            {renderPropType(v)}
+            {allValues[i + 1] && ', '}
+          </span>
+        )),
+      ),
 
-    shape: value => wrap('shape')(
-      <ul>
-        { Object
-          .keys(value)
-          .map(key => ({...value[key], key}))
-          .map((v, i) =>
-            <li key={i}>
-              {v.key}:&nbsp;
-              {renderPropType(v)}
-              {v.required && <small><strong>&nbsp;required</strong></small>}
-            </li>)
-        }
-      </ul>
-    ),
+    shape: value =>
+      wrap('shape')(
+        <ul>
+          {Object.keys(value)
+            .map(key => ({ ...value[key], key }))
+            .map((v, i) => (
+              <li key={i}>
+                {v.key}
+                :&nbsp;
+                {renderPropType(v)}
+                {v.required && (
+                  <small>
+                    <strong>&nbsp;required</strong>
+                  </small>
+                )}
+              </li>
+            ))}
+        </ul>,
+      ),
 
-    arrayOf: value => wrap('arrayOf')(renderPropType(value))
+    arrayOf: value => wrap('arrayOf')(renderPropType(value)),
   };
 
   if (type.value) {
@@ -66,95 +83,107 @@ const renderPropType = (type = {}) => {
   return <span>{type.name}</span>;
 };
 
-const AutoDocs = ({source = '', parsedSource, showTitle}) => {
-  const {
-    description,
-    displayName,
-    props,
-    composes = [],
-    methods = []
-  } = parsedSource || parser(source);
+const AutoDocs = ({ source = '', parsedSource, showTitle }) => {
+  const { description, displayName, props, composes = [], methods = [] } =
+    parsedSource || parser(source);
 
-  const propRow = (prop, index) =>
+  const propRow = (prop, index) => (
     <tr key={index}>
       <td>{prop.name || '-'}</td>
       <td>{renderPropType(prop.type)}</td>
-      <td>{prop.defaultValue && prop.defaultValue.value && <Markdown source={`\`${prop.defaultValue.value}\``}/>}</td>
-      <td>{prop.required && 'Required' }</td>
-      <td>{prop.description && <Markdown source={prop.description}/>}</td>
-    </tr>;
+      <td>
+        {prop.defaultValue &&
+          prop.defaultValue.value && (
+            <Markdown source={`\`${prop.defaultValue.value}\``} />
+          )}
+      </td>
+      <td>{prop.required && 'Required'}</td>
+      <td>{prop.description && <Markdown source={prop.description} />}</td>
+    </tr>
+  );
 
   const methodsToMarkdown = methods =>
     methods
-      .filter(({name}) => !name.startsWith('_'))
-      .map(method =>
-        `* __${method.name}(${method.params.map(({name}) => name).join(', ')})__: ${method.docblock || ''}`
+      .filter(({ name }) => !name.startsWith('_'))
+      .map(
+        method =>
+          `* __${method.name}(${method.params
+            .map(({ name }) => name)
+            .join(', ')})__: ${method.docblock || ''}`,
       )
       .join('\n');
 
-  return !shouldHideForE2E && (
-    <div className="markdown-body">
-      { showTitle && displayName &&
-        <div>
-          <h1>
-            { displayName && <code>{`<${displayName}/>`}</code> }
-          </h1>
-        </div>
-      }
+  return (
+    !shouldHideForE2E && (
+      <div className="markdown-body">
+        {showTitle &&
+          displayName && (
+            <div>
+              <h1>{displayName && <code>{`<${displayName}/>`}</code>}</h1>
+            </div>
+          )}
 
-      { !displayName && <blockquote>This component has no <code>displayName</code></blockquote> }
+        {!displayName && (
+          <blockquote>
+            This component has no <code>displayName</code>
+          </blockquote>
+        )}
 
-      { description && <Markdown source={description}/> }
+        {description && <Markdown source={description} />}
 
-      <h2>Available <code>props</code></h2>
+        <h2>
+          Available <code>props</code>
+        </h2>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Default Value</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          { prepareParsedProps(props).map(propRow) }
-
-          { !parsedSource && composes.length > 0 &&
+        <table>
+          <thead>
             <tr>
-              <td colSpan={5}>
-                Also includes props from:
-
-                <ul>
-                  {composes.map((path, i) =>
-                    <li key={i}>
-                      {path}
-                    </li>
-                  )}
-                </ul>
-              </td>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Default Value</th>
+              <th>Required</th>
+              <th>Description</th>
             </tr>
-          }
-        </tbody>
-      </table>
+          </thead>
 
-      { methods.filter(({name}) => !name.startsWith('_')).length > 0 && <h2>Available <code>methods</code></h2> }
-      { methods.length > 0 && <Markdown source={methodsToMarkdown(methods)}/> }
-    </div>
+          <tbody>
+            {prepareParsedProps(props).map(propRow)}
+
+            {!parsedSource &&
+              composes.length > 0 && (
+                <tr>
+                  <td colSpan={5}>
+                    Also includes props from:
+                    <ul>
+                      {composes.map((path, i) => (
+                        <li key={i}>{path}</li>
+                      ))}
+                    </ul>
+                  </td>
+                </tr>
+              )}
+          </tbody>
+        </table>
+
+        {methods.filter(({ name }) => !name.startsWith('_')).length > 0 && (
+          <h2>
+            Available <code>methods</code>
+          </h2>
+        )}
+        {methods.length > 0 && <Markdown source={methodsToMarkdown(methods)} />}
+      </div>
+    )
   );
 };
 
 AutoDocs.propTypes = {
   source: PropTypes.string,
   parsedSource: PropTypes.object,
-  showTitle: PropTypes.bool
+  showTitle: PropTypes.bool,
 };
 
 AutoDocs.defaultProps = {
-  showTitle: true
+  showTitle: true,
 };
 
 export default AutoDocs;
-

--- a/packages/wix-storybook-utils/src/AutoDocs/index.js
+++ b/packages/wix-storybook-utils/src/AutoDocs/index.js
@@ -83,6 +83,17 @@ const renderPropType = (type = {}) => {
   return <span>{type.name}</span>;
 };
 
+const methodsToMarkdown = methods =>
+  methods
+    .filter(({ name }) => !name.startsWith('_'))
+    .map(
+      method =>
+        `* __${method.name}(${method.params
+          .map(({ name }) => name)
+          .join(', ')})__: ${method.docblock || ''}`,
+    )
+    .join('\n');
+
 const AutoDocs = ({ source = '', parsedSource, showTitle }) => {
   const { description, displayName, props, composes = [], methods = [] } =
     parsedSource || parser(source);
@@ -101,17 +112,6 @@ const AutoDocs = ({ source = '', parsedSource, showTitle }) => {
       <td>{prop.description && <Markdown source={prop.description} />}</td>
     </tr>
   );
-
-  const methodsToMarkdown = methods =>
-    methods
-      .filter(({ name }) => !name.startsWith('_'))
-      .map(
-        method =>
-          `* __${method.name}(${method.params
-            .map(({ name }) => name)
-            .join(', ')})__: ${method.docblock || ''}`,
-      )
-      .join('\n');
 
   return (
     !shouldHideForE2E && (

--- a/packages/wix-storybook-utils/src/AutoDocs/parser.js
+++ b/packages/wix-storybook-utils/src/AutoDocs/parser.js
@@ -1,6 +1,5 @@
-import {parse} from 'react-docgen';
+import { parse } from 'react-docgen';
 
 import ComponentResolver from './component-resolver';
 
-export default (source = '') =>
-  parse(source, ComponentResolver);
+export default (source = '') => parse(source, ComponentResolver);

--- a/packages/wix-storybook-utils/src/AutoExample/categorize-props.js
+++ b/packages/wix-storybook-utils/src/AutoExample/categorize-props.js
@@ -1,39 +1,32 @@
 const falsy = () => false;
 
 const categorizeProps = (props = {}, categories = {}) => {
-  const sortedCategories = Object
-    .entries(categories)
-    .sort((
-      [, {order: aOrder = -1}],
-      [, {order: bOrder = -1}]
-    ) =>
-      aOrder - bOrder
-    );
+  const sortedCategories = Object.entries(categories).sort(
+    ([, { order: aOrder = -1 }], [, { order: bOrder = -1 }]) => aOrder - bOrder,
+  );
 
-  return Object
-    .entries(props)
-    .reduce(
-      (result, [propName, prop]) => {
-        const [categoryName] =
-          sortedCategories
-            .find(([, {matcher = falsy}]) => matcher(propName, prop)) || ['primary'];
+  return Object.entries(props).reduce(
+    (result, [propName, prop]) => {
+      const [categoryName] = sortedCategories.find(([, { matcher = falsy }]) =>
+        matcher(propName, prop),
+      ) || ['primary'];
 
-        const category = result[categoryName] || categories[categoryName] || {};
+      const category = result[categoryName] || categories[categoryName] || {};
 
-        return {
-          ...result,
-          [categoryName]: {
-            ...category,
-            props: {
-              ...(category.props || {}),
-              [propName]: prop
-            }
-          }
-        };
-      },
+      return {
+        ...result,
+        [categoryName]: {
+          ...category,
+          props: {
+            ...(category.props || {}),
+            [propName]: prop,
+          },
+        },
+      };
+    },
 
-      {}
-    );
+    {},
+  );
 };
 
 export default categorizeProps;

--- a/packages/wix-storybook-utils/src/AutoExample/categorize-props.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/categorize-props.test.js
@@ -13,9 +13,11 @@ describe('categorizeProps', () => {
     it('should return props under `primary` property', () => {
       const props = {
         one: 'hello',
-        two: 'world'
+        two: 'world',
       };
-      expect(categorizeProps(props)).toEqual({primary: expect.objectContaining({props})});
+      expect(categorizeProps(props)).toEqual({
+        primary: expect.objectContaining({ props }),
+      });
     });
   });
 
@@ -25,90 +27,90 @@ describe('categorizeProps', () => {
         onClick: 'hello click',
         onBlur: 'hello blur',
         ariaRequired: 'hello required',
-        something: 'else'
+        something: 'else',
       };
       const categories = {
-        accessibility: {matcher: name => name.startsWith('aria')},
-        events: {matcher: name => name.startsWith('on')}
+        accessibility: { matcher: name => name.startsWith('aria') },
+        events: { matcher: name => name.startsWith('on') },
       };
 
       expect(categorizeProps(props, categories)).toEqual({
         accessibility: expect.objectContaining({
           props: {
-            ariaRequired: 'hello required'
-          }
+            ariaRequired: 'hello required',
+          },
         }),
         events: expect.objectContaining({
           props: {
             onClick: 'hello click',
-            onBlur: 'hello blur'
-          }
+            onBlur: 'hello blur',
+          },
         }),
         primary: expect.objectContaining({
           props: {
-            something: 'else'
-          }
-        })
+            something: 'else',
+          },
+        }),
       });
     });
 
     it('should return object including only existing categories', () => {
       const props = {
         // 1. this do not include any aria nor event properties
-        something: 'else'
+        something: 'else',
       };
 
       const categories = {
-        accessibility: {matcher: name => name.startsWith('aria')},
-        events: {matcher: name => name.startsWith('on')}
+        accessibility: { matcher: name => name.startsWith('aria') },
+        events: { matcher: name => name.startsWith('on') },
       };
 
       expect(categorizeProps(props, categories)).toEqual({
         // 2. this should not include events nor accessibility properties
         primary: {
-          props: {something: 'else'}
-        }
+          props: { something: 'else' },
+        },
       });
     });
 
     it('should add props property and keep original category definition structure', () => {
       const props = {
-        hello: 'world'
+        hello: 'world',
       };
 
       const categories = {
         whatever: {
           matcher: () => true,
           hello: 'here too',
-          i: 'should remain'
-        }
+          i: 'should remain',
+        },
       };
 
       expect(categorizeProps(props, categories)).toEqual({
         whatever: {
           ...categories.whatever,
-          props: {hello: 'world'}
-        }
+          props: { hello: 'world' },
+        },
       });
     });
 
     it('should categorize props in given order', () => {
       const props = {
         hello: 'is it me',
-        you: 'are looking for'
+        you: 'are looking for',
       };
 
       const matcher = () => true;
 
       const categories = {
-        first: {order: 1, matcher},
-        realFirst: {order: 0, matcher}
+        first: { order: 1, matcher },
+        realFirst: { order: 0, matcher },
       };
 
       expect(categorizeProps(props, categories)).toEqual({
         realFirst: expect.objectContaining({
-          props: {hello: 'is it me', you: 'are looking for'}
-        })
+          props: { hello: 'is it me', you: 'are looking for' },
+        }),
       });
     });
   });

--- a/packages/wix-storybook-utils/src/AutoExample/components/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/index.js
@@ -72,9 +72,9 @@ Toggle.propTypes = {
   onChange: PropTypes.func,
 };
 
-const Input = ({ value, onChange, defaultValue, ...props }) => (
+const Input = ({ value: inputValue, onChange, defaultValue, ...props }) => (
   <UIInput
-    value={value}
+    value={inputValue}
     onChange={({ target: { value } }) => onChange(value)}
     placeholder={defaultValue}
     {...props}

--- a/packages/wix-storybook-utils/src/AutoExample/components/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import {Cell} from '../../ui/Layout';
+import { Cell } from '../../ui/Layout';
 import UIInput from '../../ui/input';
 import ToggleSwitch from '../../ui/toggle-switch';
 import Heading from '../../ui/heading';
@@ -18,7 +18,7 @@ const Preview = ({
   isRtl,
   onToggleRtl,
   isDarkBackground,
-  onToggleBackground
+  onToggleBackground,
 }) => (
   <Cell span={6}>
     <div className={styles.title}>
@@ -27,7 +27,7 @@ const Preview = ({
       <div className={styles.previewControls}>
         <div className={styles.previewControl}>
           Imitate RTL:&nbsp;
-          <ToggleSwitch size="small" checked={isRtl} onChange={onToggleRtl}/>
+          <ToggleSwitch size="small" checked={isRtl} onChange={onToggleRtl} />
         </div>
 
         <div className={styles.previewControl}>
@@ -45,9 +45,9 @@ const Preview = ({
       {...{
         className: classnames(styles.preview, {
           rtl: isRtl,
-          [styles.darkPreview]: isDarkBackground
+          [styles.darkPreview]: isDarkBackground,
         }),
-        ...(isRtl ? {dir: 'rtl'} : {})
+        ...(isRtl ? { dir: 'rtl' } : {}),
       }}
     >
       {children}
@@ -60,22 +60,22 @@ Preview.propTypes = {
   isRtl: PropTypes.bool,
   isDarkBackground: PropTypes.bool,
   onToggleRtl: PropTypes.func,
-  onToggleBackground: PropTypes.func
+  onToggleBackground: PropTypes.func,
 };
 
-const Toggle = ({value, onChange}) => (
-  <ToggleSwitch checked={value} onChange={onChange}/>
+const Toggle = ({ value, onChange }) => (
+  <ToggleSwitch checked={value} onChange={onChange} />
 );
 
 Toggle.propTypes = {
   value: PropTypes.bool,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
 };
 
-const Input = ({value, onChange, defaultValue, ...props}) => (
+const Input = ({ value, onChange, defaultValue, ...props }) => (
   <UIInput
     value={value}
-    onChange={({target: {value}}) => onChange(value)}
+    onChange={({ target: { value } }) => onChange(value)}
     placeholder={defaultValue}
     {...props}
   />
@@ -84,21 +84,21 @@ const Input = ({value, onChange, defaultValue, ...props}) => (
 Input.propTypes = {
   value: PropTypes.string,
   defaultValue: PropTypes.string,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
 };
 
-const Code = ({component}) => (
+const Code = ({ component }) => (
   <Cell>
     <div className={styles.title}>
       <Heading>Code</Heading>
     </div>
 
-    <ComponentSource component={component}/>
+    <ComponentSource component={component} />
   </Cell>
 );
 
 Code.propTypes = {
-  component: PropTypes.node.isRequired
+  component: PropTypes.node.isRequired,
 };
 
-export {Option, Preview, Toggle, Input, List, Code};
+export { Option, Preview, Toggle, Input, List, Code };

--- a/packages/wix-storybook-utils/src/AutoExample/components/list.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/list.js
@@ -20,7 +20,7 @@ export default class List extends React.Component {
     defaultValue: PropTypes.any,
     values: PropTypes.arrayOf(PropTypes.any),
     onChange: PropTypes.func,
-    isRequired: PropTypes.bool
+    isRequired: PropTypes.bool,
   };
 
   constructor(props) {
@@ -34,11 +34,11 @@ export default class List extends React.Component {
       currentValue,
       currentFilter:
         props.defaultValue &&
-        [props.defaultValue, props.defaultValue.type].some(isFunction) ?
-          currentValue.value :
-          props.defaultValue || '',
+        [props.defaultValue, props.defaultValue.type].some(isFunction)
+          ? currentValue.value
+          : props.defaultValue || '',
       isFiltering: false,
-      options
+      options,
     };
   }
 
@@ -53,48 +53,48 @@ export default class List extends React.Component {
         // displaying that component, we save it in `realValue` and
         // show `value` as some string representation of component instead
         value: option.label || (option.type && option.type.name) || '' + option,
-        realValue: isUndefined(option.value) ? option : option.value
+        realValue: isUndefined(option.value) ? option : option.value,
       };
     });
 
   getFilteredOptions = () =>
-    this.state.isFiltering ?
-      this.state.options.filter(
-        ({value}) =>
-          this.state.currentFilter.length ?
-            value.toLowerCase().includes(this.state.currentFilter) :
-            true
-      ) :
-      this.state.options;
+    this.state.isFiltering
+      ? this.state.options.filter(
+          ({ value }) =>
+            this.state.currentFilter.length
+              ? value.toLowerCase().includes(this.state.currentFilter)
+              : true,
+        )
+      : this.state.options;
 
   clearValue = () =>
-    this.setState({currentValue: {}, currentFilter: ''}, () =>
-      this.props.onChange(NO_VALUE_TYPE)
+    this.setState({ currentValue: {}, currentFilter: '' }, () =>
+      this.props.onChange(NO_VALUE_TYPE),
     );
 
   clearIcon = (
     <span
       onClick={this.clearValue}
-      style={{color: '#3899ec', cursor: 'pointer', marginLeft: '-20px'}}
-      children={<CloseIcon size="7px"/>}
+      style={{ color: '#3899ec', cursor: 'pointer', marginLeft: '-20px' }}
+      children={<CloseIcon size="7px" />}
     />
   );
 
   clearButton = (
-    <div style={{padding: '1em 0'}}>
-      <Button children="Clear" onClick={this.clearValue}/>
+    <div style={{ padding: '1em 0' }}>
+      <Button children="Clear" onClick={this.clearValue} />
     </div>
   );
 
   getSelectedOption = () => {
     const selectedOption =
       this.state.options.find(
-        option => option.id === this.state.currentValue.id
+        option => option.id === this.state.currentValue.id,
       ) || {};
     return selectedOption;
   };
 
-  onOptionChange = ({id}) => {
+  onOptionChange = ({ id }) => {
     const currentValue =
       this.state.options.find(option => option.id === id) || {};
 
@@ -102,14 +102,14 @@ export default class List extends React.Component {
       {
         currentValue,
         currentFilter: currentValue.value,
-        isFiltering: false
+        isFiltering: false,
       },
-      () => this.props.onChange(currentValue.realValue)
+      () => this.props.onChange(currentValue.realValue),
     );
   };
 
   onFilterChange = currentFilter =>
-    this.setState({currentFilter, isFiltering: true});
+    this.setState({ currentFilter, isFiltering: true });
 
   dropdown() {
     return (
@@ -132,7 +132,7 @@ export default class List extends React.Component {
       <div>
         <RadioGroup
           value={this.state.currentValue.id}
-          onChange={id => this.onOptionChange({id})}
+          onChange={id => this.onOptionChange({ id })}
           radios={this.state.options}
         />
 

--- a/packages/wix-storybook-utils/src/AutoExample/components/option.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/option.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Layout, Cell} from '../../ui/Layout';
+import { Layout, Cell } from '../../ui/Layout';
 
 import Markdown from '../../Markdown';
 import styles from './styles.scss';
@@ -12,19 +12,19 @@ const Option = ({
   onChange,
   defaultValue,
   isRequired,
-  dataHook
+  dataHook,
 }) =>
   children ? (
     <Layout dataHook={dataHook} className={styles.option}>
       <Cell span={5}>
-        <Markdown source={`\`${label}${isRequired ? '*' : ''}\``}/>
+        <Markdown source={`\`${label}${isRequired ? '*' : ''}\``} />
       </Cell>
 
       <Cell span={7}>
         {React.cloneElement(children, {
           value: children.type === 'div' ? value.toString() : value,
           defaultValue,
-          onChange
+          onChange,
         })}
       </Cell>
     </Layout>
@@ -37,7 +37,7 @@ Option.propTypes = {
   children: PropTypes.node,
   onChange: PropTypes.func,
   isRequired: PropTypes.bool,
-  dataHook: PropTypes.string
+  dataHook: PropTypes.string,
 };
 
 export default Option;

--- a/packages/wix-storybook-utils/src/AutoExample/components/section-collapse/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/section-collapse/index.js
@@ -10,22 +10,22 @@ export default class PropsCollapse extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     isOpen: PropTypes.bool.isRequired,
-    children: PropTypes.node.isRequired
+    children: PropTypes.node.isRequired,
   };
 
   static defaultProps = {
-    isOpen: false
+    isOpen: false,
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      isOpen: props.isOpen
+      isOpen: props.isOpen,
     };
   }
 
-  toggleCollapse = () => this.setState(({isOpen}) => ({isOpen: !isOpen}));
+  toggleCollapse = () => this.setState(({ isOpen }) => ({ isOpen: !isOpen }));
 
   getNumChildren = () => Object.keys(this.props.children).length;
 

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -268,7 +268,7 @@ export default class extends Component {
           ...this.props.exampleProps,
           ...this.preparedComponentProps,
         })
-          .filter(name => !['on', 'data'].some(i => name.startsWith(i)))
+          .filter(n => !['on', 'data'].some(i => n.startsWith(i)))
           .some(propName => propName === name),
     },
 

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -1,12 +1,12 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import styles from './styles.scss';
 import NO_VALUE_TYPE from './no-value-type';
 import categorizeProps from './categorize-props';
 
-import {Option, Preview, Code, Toggle, Input, List} from './components';
-import {Layout, Cell} from '../ui/Layout';
+import { Option, Preview, Code, Toggle, Input, List } from './components';
+import { Layout, Cell } from '../ui/Layout';
 import SectionCollapse from './components/section-collapse';
 
 import matchFuncProp from './utils/match-func-prop';
@@ -82,7 +82,7 @@ export default class extends Component {
     isInteractive: PropTypes.bool,
 
     /** currently only `false` possible. later same property shall be used for configuring code example */
-    codeExample: PropTypes.bool
+    codeExample: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -92,7 +92,7 @@ export default class extends Component {
     parsedSource: {},
     exampleProps: {},
     isInteractive: true,
-    codeExample: true
+    codeExample: true,
   };
 
   _initialPropsState = {};
@@ -103,64 +103,66 @@ export default class extends Component {
 
     this.parsedComponent = props.parsedSource;
     this.preparedComponentProps = this.prepareComponentProps(
-      this.props.componentProps
+      this.props.componentProps,
     );
 
     this.state = {
       propsState: {
         ...(this.props.component.defaultProps || {}),
-        ...this.preparedComponentProps
+        ...this.preparedComponentProps,
       },
       funcValues: {},
       funcAnimate: {},
       isRtl: false,
-      isDarkBackground: false
+      isDarkBackground: false,
     };
 
     this._initialPropsState = this.state.propsState;
 
     this._categorizedProps = Object.entries(
       categorizeProps(
-        {...this.preparedComponentProps, ...this.parsedComponent.props},
-        this.propsCategories
-      )
+        { ...this.preparedComponentProps, ...this.parsedComponent.props },
+        this.propsCategories,
+      ),
     )
       .map(([, category]) => category)
-      .sort(({order: aOrder = -1}, {order: bOrder = -1}) => aOrder - bOrder);
+      .sort(
+        ({ order: aOrder = -1 }, { order: bOrder = -1 }) => aOrder - bOrder,
+      );
   }
 
-  resetState = () => this.setState({propsState: this._initialPropsState});
+  resetState = () => this.setState({ propsState: this._initialPropsState });
 
   componentWillReceiveProps(nextProps) {
     this.setState({
       propsState: {
         ...this.state.propsState,
-        ...this.prepareComponentProps(nextProps.componentProps)
-      }
+        ...this.prepareComponentProps(nextProps.componentProps),
+      },
     });
   }
 
   prepareComponentProps = props =>
-    typeof props === 'function' ?
-      props(
-        // setState
-        componentProps =>
-          this.setState({
-            propsState: {...this.state.propsState, ...componentProps}
-          }),
+    typeof props === 'function'
+      ? props(
+          // setState
+          componentProps =>
+            this.setState({
+              propsState: { ...this.state.propsState, ...componentProps },
+            }),
 
-        // getState
-        () => this.state.propsState || {}
-      ) :
-      props;
+          // getState
+          () => this.state.propsState || {},
+        )
+      : props;
 
   setProp = (key, value) => {
     if (value === NO_VALUE_TYPE) {
       // eslint-disable-next-line no-unused-vars
-      const {[key]: deletedKey, ...propsState} = this.state.propsState;
-      this.setState({propsState});
+      const { [key]: deletedKey, ...propsState } = this.state.propsState;
+      this.setState({ propsState });
     } else {
-      this.setState({propsState: {...this.state.propsState, [key]: value}});
+      this.setState({ propsState: { ...this.state.propsState, [key]: value } });
     }
   };
 
@@ -168,7 +170,7 @@ export default class extends Component {
     {
       types: ['func', /event/, /\) => void$/],
 
-      controller: ({propKey}) => {
+      controller: ({ propKey }) => {
         let classNames = styles.example;
 
         if (this.state.funcAnimate[propKey]) {
@@ -176,9 +178,9 @@ export default class extends Component {
           setTimeout(
             () =>
               this.setState({
-                funcAnimate: {...this.state.funcAnimate, [propKey]: false}
+                funcAnimate: { ...this.state.funcAnimate, [propKey]: false },
               }),
-            2000
+            2000,
           );
         }
 
@@ -189,19 +191,19 @@ export default class extends Component {
             </div>
           );
         }
-      }
+      },
     },
 
     {
       types: ['bool', 'Boolean'],
-      controller: () => <Toggle/>
+      controller: () => <Toggle />,
     },
 
     {
       types: ['enum'],
-      controller: ({type}) => (
-        <List values={type.value.map(({value}) => stripQuotes(value))}/>
-      )
+      controller: ({ type }) => (
+        <List values={type.value.map(({ value }) => stripQuotes(value))} />
+      ),
     },
 
     {
@@ -212,29 +214,29 @@ export default class extends Component {
         'arrayOf',
         'union',
         'node',
-        'ReactNode'
+        'ReactNode',
       ],
-      controller: () => <Input/>
-    }
+      controller: () => <Input />,
+    },
   ];
 
   getPropControlComponent = (propKey, type = {}) => {
     if (!matchFuncProp(type.name) && this.props.exampleProps[propKey]) {
-      return <List values={this.props.exampleProps[propKey]}/>;
+      return <List values={this.props.exampleProps[propKey]} />;
     }
 
-    const propControllerCandidate = this.propControllers.find(({types}) =>
-      types.some(t => ensureRegexp(t).test(type.name))
+    const propControllerCandidate = this.propControllers.find(({ types }) =>
+      types.some(t => ensureRegexp(t).test(type.name)),
     );
 
     return propControllerCandidate && propControllerCandidate.controller ? (
-      propControllerCandidate.controller({propKey, type})
+      propControllerCandidate.controller({ propKey, type })
     ) : (
-      <Input/>
+      <Input />
     );
   };
 
-  renderPropControllers = ({props, allProps}) => {
+  renderPropControllers = ({ props, allProps }) => {
     return Object.entries(props).map(([key, prop]) => (
       <Option
         key={key}
@@ -242,12 +244,12 @@ export default class extends Component {
           label: key,
           value: allProps[key],
           defaultValue:
-            typeof this.props.componentProps === 'function' ?
-              undefined :
-              this.props.componentProps[key],
+            typeof this.props.componentProps === 'function'
+              ? undefined
+              : this.props.componentProps[key],
           isRequired: prop.required || false,
           onChange: value => this.setProp(key, value),
-          children: this.getPropControlComponent(key, prop.type)
+          children: this.getPropControlComponent(key, prop.type),
         }}
       />
     ));
@@ -264,43 +266,43 @@ export default class extends Component {
         // with `data`, including data-hook or dataHook)
         Object.keys({
           ...this.props.exampleProps,
-          ...this.preparedComponentProps
+          ...this.preparedComponentProps,
         })
           .filter(name => !['on', 'data'].some(i => name.startsWith(i)))
-          .some(propName => propName === name)
+          .some(propName => propName === name),
     },
 
     events: {
       title: 'Callback Props',
       order: 1,
-      matcher: name => name.toLowerCase().startsWith('on')
+      matcher: name => name.toLowerCase().startsWith('on'),
     },
 
     html: {
       title: 'HTML Props',
       order: 3,
-      matcher: name => HTMLPropsList.some(i => name === i)
+      matcher: name => HTMLPropsList.some(i => name === i),
     },
 
     accessibility: {
       title: 'Accessibility Props',
       order: 4,
-      matcher: name => name.toLowerCase().startsWith('aria')
+      matcher: name => name.toLowerCase().startsWith('aria'),
     },
 
     other: {
       // miscellaneous props are everything that doesn't fit in other categories
       title: 'Misc. Props',
       order: 5,
-      matcher: () => true
-    }
+      matcher: () => true,
+    },
   };
 
   render() {
     const functionExampleProps = Object.keys(this.props.exampleProps).filter(
       prop =>
         this.parsedComponent.props[prop] &&
-        matchFuncProp(this.parsedComponent.props[prop].type.name)
+        matchFuncProp(this.parsedComponent.props[prop].type.name),
     );
 
     const componentProps = {
@@ -313,13 +315,13 @@ export default class extends Component {
           this.setState({
             funcValues: {
               ...this.state.funcValues,
-              [prop]: this.props.exampleProps[prop](...rest)
+              [prop]: this.props.exampleProps[prop](...rest),
             },
-            funcAnimate: {...this.state.funcAnimate, [prop]: true}
+            funcAnimate: { ...this.state.funcAnimate, [prop]: true },
           });
         };
         return acc;
-      }, {})
+      }, {}),
     };
 
     const codeProps = {
@@ -327,7 +329,7 @@ export default class extends Component {
       ...functionExampleProps.reduce((acc, key) => {
         acc[key] = this.props.exampleProps[key];
         return acc;
-      }, {})
+      }, {}),
     };
 
     if (!this.props.isInteractive) {
@@ -338,33 +340,33 @@ export default class extends Component {
       <Layout dataHook="auto-example">
         <Cell span={6}>
           {this._categorizedProps.reduce(
-            (components, {title, isOpen, props}, i) => {
+            (components, { title, isOpen, props }, i) => {
               const renderablePropControllers = this.renderPropControllers({
                 props,
-                allProps: componentProps // TODO: ideally this should not be here
-              }).filter(({props: {children}}) => children);
+                allProps: componentProps, // TODO: ideally this should not be here
+              }).filter(({ props: { children } }) => children);
 
-              return renderablePropControllers.length ?
-                components.concat(
-                  React.createElement(SectionCollapse, {
-                    key: title,
-                    title,
-                    isOpen: isOpen || i === 0,
-                    children: renderablePropControllers
-                  })
-                ) :
-                components;
+              return renderablePropControllers.length
+                ? components.concat(
+                    React.createElement(SectionCollapse, {
+                      key: title,
+                      title,
+                      isOpen: isOpen || i === 0,
+                      children: renderablePropControllers,
+                    }),
+                  )
+                : components;
             },
-            []
+            [],
           )}
         </Cell>
 
         <Preview
           isRtl={this.state.isRtl}
           isDarkBackground={this.state.isDarkBackground}
-          onToggleRtl={isRtl => this.setState({isRtl})}
+          onToggleRtl={isRtl => this.setState({ isRtl })}
           onToggleBackground={isDarkBackground =>
-            this.setState({isDarkBackground})
+            this.setState({ isDarkBackground })
           }
           children={React.createElement(this.props.component, componentProps)}
         />

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -20,10 +20,9 @@ describe('AutoExample', () => {
           functionProp: () => '',
         },
       });
-      const [prop1, prop2] = testkit.get.options();
-
-      expect(prop1.props.label).toBe('stringProp');
-      expect(prop2.props.label).toBe('functionProp');
+      const options = testkit.get.options();
+      expect(options.at(0).prop('label')).toBe('stringProp');
+      expect(options.at(1).prop('label')).toBe('functionProp');
     });
 
     it('should categorize aria props', () => {

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -9,16 +9,16 @@ describe('AutoExample', () => {
         parsedSource: {
           displayName: 'TestComponent',
           props: {
-            stringProp: {type: {name: 'string'}},
-            functionProp: {type: {name: 'func'}}
-          }
+            stringProp: { type: { name: 'string' } },
+            functionProp: { type: { name: 'func' } },
+          },
         },
         componentProps: {
-          stringProp: ''
+          stringProp: '',
         },
         exampleProps: {
-          functionProp: () => ''
-        }
+          functionProp: () => '',
+        },
       });
       const [prop1, prop2] = testkit.get.options();
 
@@ -32,15 +32,15 @@ describe('AutoExample', () => {
         parsedSource: {
           displayName: 'TestComponent',
           props: {
-            'aria-label': {type: {name: 'string'}},
-            'Aria-required': {type: {name: 'bool'}},
-            ariaDisabled: {type: {name: 'bool'}},
-            'anything-else': {type: {name: 'string'}}
-          }
+            'aria-label': { type: { name: 'string' } },
+            'Aria-required': { type: { name: 'bool' } },
+            ariaDisabled: { type: { name: 'bool' } },
+            'anything-else': { type: { name: 'string' } },
+          },
         },
         componentProps: {
-          'anything-else': 'test'
-        }
+          'anything-else': 'test',
+        },
       });
 
       // expeting only 1 because others should be collapsed
@@ -55,12 +55,12 @@ describe('AutoExample', () => {
         parsedSource: {
           displayName: 'TestComponent',
           props: {
-            functionProp: {type: {name: 'func'}}
-          }
+            functionProp: { type: { name: 'func' } },
+          },
         },
         exampleProps: {
-          functionProp: () => {}
-        }
+          functionProp: () => {},
+        },
       });
 
       const option = testkit.get.options().props();
@@ -74,13 +74,13 @@ describe('AutoExample', () => {
           displayName: 'TestComponent',
           props: {
             someProp: {
-              type: {name: 'unknown type name, something really obscure'}
-            }
-          }
+              type: { name: 'unknown type name, something really obscure' },
+            },
+          },
         },
         exampleProps: {
-          someProp: [1, 2, 3, 4, 5]
-        }
+          someProp: [1, 2, 3, 4, 5],
+        },
       });
 
       const option = testkit.get.options().props();
@@ -92,7 +92,7 @@ describe('AutoExample', () => {
     it('should not render when `false`', () => {
       const testkit = new Testkit(AutoExample);
       testkit.when.created({
-        codeExample: false
+        codeExample: false,
       });
       expect(testkit.get.codeBlock().length).toEqual(0);
     });

--- a/packages/wix-storybook-utils/src/AutoExample/no-value-type.js
+++ b/packages/wix-storybook-utils/src/AutoExample/no-value-type.js
@@ -1,8 +1,8 @@
 /**
-  * this is used to mark a prop for removal.
-  *
-  * i cannot use null nor undefined, nor false, nor 0 or anything alike since
-  * all of these are valid values
-  */
+ * this is used to mark a prop for removal.
+ *
+ * i cannot use null nor undefined, nor false, nor 0 or anything alike since
+ * all of these are valid values
+ */
 
 export default '@@NO-VALUE-TYPE@@';

--- a/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
+++ b/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
@@ -15,7 +15,9 @@ module.exports = {
         {
           rule: value =>
             typeof value === 'string' && value.match(/^function|\(\)\s?=>/),
+          /* tslint:disable */
           parser: value => eval(`(${value})`), // eslint-disable-line no-eval
+          /* tslint:enable */
         },
         {
           rule: value => Array.isArray(value),
@@ -36,10 +38,10 @@ module.exports = {
         },
       ];
 
-      const args = Object.keys(componentProps).reduce((props, key) => {
-        const { parser } = parsers.find(({ rule }) => rule(props[key]));
-        props[key] = parser(props[key]);
-        return props;
+      const args = Object.keys(componentProps).reduce((allProps, key) => {
+        const { parser } = parsers.find(({ rule }) => rule(allProps[key]));
+        props[key] = parser(allProps[key]);
+        return allProps;
       }, componentProps);
 
       // this is possible because:

--- a/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
+++ b/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
@@ -10,45 +10,42 @@ module.exports = {
       const parsers = [
         {
           rule: value => value.toString() === '[object Object]',
-          parser: value => value
+          parser: value => value,
         },
         {
-          rule: value => typeof value === 'string' && value.match(/^function|\(\)\s?=>/),
-          parser: value => eval(`(${value})`) // eslint-disable-line no-eval
+          rule: value =>
+            typeof value === 'string' && value.match(/^function|\(\)\s?=>/),
+          parser: value => eval(`(${value})`), // eslint-disable-line no-eval
         },
         {
           rule: value => Array.isArray(value),
-          parser: value => value
+          parser: value => value,
         },
         {
           rule: value => typeof value === 'string' && !isNaN(Date.parse(value)),
-          parser: value => new Date(value)
+          parser: value => new Date(value),
         },
         {
           rule: value => typeof value === 'string',
-          parser: value => value
+          parser: value => value,
         },
-        { // default
+        {
+          // default
           rule: () => true,
-          parser: value => JSON.parse(value)
-        }
+          parser: value => JSON.parse(value),
+        },
       ];
 
-      const args = Object
-        .keys(componentProps)
-        .reduce(
-          (props, key) => {
-            const {parser} = parsers.find(({rule}) => rule(props[key]));
-            props[key] = parser(props[key]);
-            return props;
-          },
-          componentProps
-        );
+      const args = Object.keys(componentProps).reduce((props, key) => {
+        const { parser } = parsers.find(({ rule }) => rule(props[key]));
+        props[key] = parser(props[key]);
+        return props;
+      }, componentProps);
 
       // this is possible because:
       // <AutoExample ref={ref => window.autoexample = ref}/>
       window.autoexample.setState({
-        propsState: Object.assign({}, window.autoexample.state.propsState, args)
+        propsState: { ...window.autoexample.state.propsState, ...args },
       });
     };
 
@@ -59,5 +56,5 @@ module.exports = {
   },
   remount: () => {
     return browser.executeScript('window.story.remount()');
-  }
+  },
 };

--- a/packages/wix-storybook-utils/src/AutoExample/testkit.js
+++ b/packages/wix-storybook-utils/src/AutoExample/testkit.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 
-import {Option, Code} from './components';
+import { Option, Code } from './components';
 
 export default class AutoExampleTestkit {
   constructor(AutoExample) {
@@ -11,13 +11,11 @@ export default class AutoExampleTestkit {
   component;
 
   when = {
-    created: props =>
-      this.component = mount(<this.AutoExample {...props}/>)
-  }
+    created: props => (this.component = mount(<this.AutoExample {...props} />)),
+  };
 
   get = {
     options: () => this.component.find(Option),
-    codeBlock: () => this.component.find(Code)
-  }
+    codeBlock: () => this.component.find(Code),
+  };
 }
-

--- a/packages/wix-storybook-utils/src/AutoExample/utils/ensure-regexp.js
+++ b/packages/wix-storybook-utils/src/AutoExample/utils/ensure-regexp.js
@@ -1,2 +1,1 @@
-export default a =>
-  a instanceof RegExp ? a : new RegExp(a);
+export default a => (a instanceof RegExp ? a : new RegExp(a));

--- a/packages/wix-storybook-utils/src/AutoExample/utils/match-func-prop.js
+++ b/packages/wix-storybook-utils/src/AutoExample/utils/match-func-prop.js
@@ -1,6 +1,2 @@
 export default (string = '') =>
-  [
-    /^func/i,
-    /event/,
-    /\) => void$/
-  ].some(needle => string.match(needle));
+  [/^func/i, /event/, /\) => void$/].some(needle => string.match(needle));

--- a/packages/wix-storybook-utils/src/AutoExample/utils/omit.js
+++ b/packages/wix-storybook-utils/src/AutoExample/utils/omit.js
@@ -1,9 +1,6 @@
 export default object => predicate =>
-  Object
-    .entries(object)
-    .reduce(
-      (result, [key, value]) =>
-        predicate(key, value) ? result : {...result, [key]: value},
-      {}
-    );
-
+  Object.entries(object).reduce(
+    (result, [key, value]) =>
+      predicate(key, value) ? result : { ...result, [key]: value },
+    {},
+  );

--- a/packages/wix-storybook-utils/src/AutoTestKit/DriverParser.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/DriverParser.js
@@ -18,7 +18,10 @@ class DriverParser {
   }
 
   parse() {
-    const topParentScope = new GlobalScope(this.recastedDriver.program.body, this.files);
+    const topParentScope = new GlobalScope(
+      this.recastedDriver.program.body,
+      this.files,
+    );
 
     // We only case about what this file exports..
     //TODO: Parse non-default exports
@@ -29,7 +32,7 @@ class DriverParser {
     if (!declaration) {
       throw new Error('There is no declaration');
     }
-    const {type} = declaration;
+    const { type } = declaration;
     let returnValue = null;
     switch (type) {
       case 'ArrowFunctionExpression':
@@ -41,7 +44,10 @@ class DriverParser {
       case 'Identifier':
         {
           const returnData = scope.getIdentifierValue(declaration.name);
-          returnValue = this._parseDeclaration(returnData.scope, returnData.identifierValue);
+          returnValue = this._parseDeclaration(
+            returnData.scope,
+            returnData.identifierValue,
+          );
         }
         break;
       case 'UnaryExpression':
@@ -74,7 +80,9 @@ class DriverParser {
     };
 
     return comments.reduce((description, comment) => {
-      return isValidComment(comment) ? description + parseCommentValue(comment.value) : description;
+      return isValidComment(comment)
+        ? description + parseCommentValue(comment.value)
+        : description;
     }, '');
   }
 
@@ -86,20 +94,27 @@ class DriverParser {
       type: 'function',
       name: 'Anonymous',
       description: declaration.description,
-      params: arrParams
+      params: arrParams,
     };
     if (functionReturnValue) {
-      returnValue.returns = this._parseDeclaration(functionScope, functionReturnValue);
+      returnValue.returns = this._parseDeclaration(
+        functionScope,
+        functionReturnValue,
+      );
     }
     return returnValue;
   }
 
   _parseObjectExpression(scope, declaration) {
-    const {properties} = declaration;
+    const { properties } = declaration;
     const returnObject = {};
 
     properties.forEach(property => {
-      const {key: {name}, value, comments} = property;
+      const {
+        key: { name },
+        value,
+        comments,
+      } = property;
       returnObject[name] = this._parseDeclaration(scope, value, comments);
     });
 

--- a/packages/wix-storybook-utils/src/AutoTestKit/FunctionScope.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/FunctionScope.js
@@ -2,8 +2,8 @@ const Scope = require('./Scope');
 
 class FunctionScope extends Scope {
   constructor(functionScope, parentScope) {
-    const {body, params} = functionScope;
-    const {type: bodyType} = body;
+    const { body, params } = functionScope;
+    const { type: bodyType } = body;
     let blockScope = [];
     switch (bodyType) {
       case 'BlockStatement':
@@ -43,7 +43,7 @@ class FunctionScope extends Scope {
     this.params.forEach(param => {
       const paramDescriptor = {};
       params.push(paramDescriptor);
-      const {type} = param;
+      const { type } = param;
 
       switch (type) {
         case 'ObjectPattern':
@@ -64,16 +64,19 @@ class FunctionScope extends Scope {
   }
 
   getReturnValue() {
-    const {type} = this.body;
+    const { type } = this.body;
     let returnValue = null;
     switch (type) {
       case 'ObjectExpression':
         returnValue = this.body;
         break;
-      case 'BlockStatement': {
-        const returnStatement = this.body.body.find(statement => statement.type === 'ReturnStatement');
-        returnValue = returnStatement && returnStatement.argument;
-      }
+      case 'BlockStatement':
+        {
+          const returnStatement = this.body.body.find(
+            statement => statement.type === 'ReturnStatement',
+          );
+          returnValue = returnStatement && returnStatement.argument;
+        }
         break;
       case 'CallExpression':
       case 'MemberExpression':
@@ -94,7 +97,8 @@ class FunctionScope extends Scope {
     return returnValue;
   }
 
-  _getIdentifierValueFromParams(name) { // eslint-disable-line no-unused-vars
+  _getIdentifierValueFromParams(name) {
+    // eslint-disable-line no-unused-vars
     /*
       TODO: Currently this method always returns 'undefined'. This is because we can never know the value of the param (maybe we can in the future when we use TypeScript)
 
@@ -103,13 +107,12 @@ class FunctionScope extends Scope {
     const params = this.params;
     const value = undefined;
     (params || []).forEach(param => {
-      const {type} = param;
+      const { type } = param;
       switch (type) {
         case 'ObjectPattern':
           break;
         // TODO: Get the param with the name
         default:
-          break;
       }
     });
 
@@ -117,7 +120,10 @@ class FunctionScope extends Scope {
   }
 
   _getIdentifierValueFromCurrentScope(name) {
-    return this._getIdentifierValueFromParams(name) || super._getIdentifierValueFromCurrentScope(name);
+    return (
+      this._getIdentifierValueFromParams(name) ||
+      super._getIdentifierValueFromCurrentScope(name)
+    );
   }
 }
 

--- a/packages/wix-storybook-utils/src/AutoTestKit/GlobalScope.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/GlobalScope.js
@@ -8,19 +8,23 @@ class GlobalScope extends Scope {
   }
 
   _getIdentifierValueFromImport(name, declaration) {
-    if (declaration.specifiers.some(specifier => specifier.local.name === name)) {
+    if (
+      declaration.specifiers.some(specifier => specifier.local.name === name)
+    ) {
       const fileContents = this.files[declaration.source.value];
       const recastedContent = parse(fileContents);
       // We return a new scope because we return a new file contents which has its own scope
       return {
-        identifierValue: this._getDefaultExportStatement(recastedContent.program.body).declaration,
-        scope: new GlobalScope(recastedContent.program.body, this.files)
+        identifierValue: this._getDefaultExportStatement(
+          recastedContent.program.body,
+        ).declaration,
+        scope: new GlobalScope(recastedContent.program.body, this.files),
       };
     }
   }
 
   _getDefaultExportStatement(scope) {
-    return scope.find(({type}) => type === 'ExportDefaultDeclaration');
+    return scope.find(({ type }) => type === 'ExportDefaultDeclaration');
   }
 
   getDefaultExportStatement() {

--- a/packages/wix-storybook-utils/src/AutoTestKit/Scope.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/Scope.js
@@ -12,7 +12,10 @@ class Scope {
     if (Array.isArray(allDeclarations) && allDeclarations.length) {
       for (let index = 0; index < allDeclarations.length; index++) {
         const declaration = allDeclarations[index];
-        identifierValue = this._getIdentifierValueFromDeclaration(name, declaration);
+        identifierValue = this._getIdentifierValueFromDeclaration(
+          name,
+          declaration,
+        );
         if (identifierValue) {
           break;
         }
@@ -22,24 +25,32 @@ class Scope {
   }
 
   getIdentifierValue(name) {
-    return this._getIdentifierValueFromCurrentScope(name) || (this.parentScope && this.parentScope.getIdentifierValue(name));
+    return (
+      this._getIdentifierValueFromCurrentScope(name) ||
+      (this.parentScope && this.parentScope.getIdentifierValue(name))
+    );
   }
 
   _getIdentifierFromDeclarator(declarationName, declarator) {
-    const {id: {name}} = declarator;
+    const {
+      id: { name },
+    } = declarator;
     return declarationName === name && declarator;
   }
 
   _getIdentifierValueFromDeclaration(name, declaration) {
-    const {type, declarations} = declaration;
+    const { type, declarations } = declaration;
     let identifierValue = null;
     switch (type) {
       case 'VariableDeclaration':
         for (let index = 0; index < declarations.length; index++) {
           const declarator = declarations[index];
-          const identifier = this._getIdentifierFromDeclarator(name, declarator);
+          const identifier = this._getIdentifierFromDeclarator(
+            name,
+            declarator,
+          );
           if (identifier) {
-            identifierValue = {identifierValue: identifier.init, scope: this};
+            identifierValue = { identifierValue: identifier.init, scope: this };
             break;
           }
         }

--- a/packages/wix-storybook-utils/src/AutoTestKit/Scope.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/Scope.js
@@ -10,8 +10,7 @@ class Scope {
       return value.type.endsWith('Declaration');
     });
     if (Array.isArray(allDeclarations) && allDeclarations.length) {
-      for (let index = 0; index < allDeclarations.length; index++) {
-        const declaration = allDeclarations[index];
+      for (const declaration of allDeclarations) {
         identifierValue = this._getIdentifierValueFromDeclaration(
           name,
           declaration,
@@ -43,8 +42,7 @@ class Scope {
     let identifierValue = null;
     switch (type) {
       case 'VariableDeclaration':
-        for (let index = 0; index < declarations.length; index++) {
-          const declarator = declarations[index];
+        for (const declarator of declarations) {
           const identifier = this._getIdentifierFromDeclarator(
             name,
             declarator,

--- a/packages/wix-storybook-utils/src/AutoTestKit/index.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/index.js
@@ -1,9 +1,9 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 export default class AutoTestKit extends Component {
   static propTypes = {
-    source: PropTypes.object.isRequired
+    source: PropTypes.object.isRequired,
   };
 
   getMethodRow = methodName => {
@@ -17,15 +17,18 @@ export default class AutoTestKit extends Component {
         <td data-hook="description">{method.description}</td>
       </tr>
     );
-  }
+  };
 
   getParams = params => {
     if (params.length) {
-      return params.map((param, i) => `${param.name} (${param.type})${i === params.length - 1 ? '' : '\n'}`);
+      return params.map(
+        (param, i) =>
+          `${param.name} (${param.type})${i === params.length - 1 ? '' : '\n'}`,
+      );
     } else {
       return '---';
     }
-  }
+  };
 
   render() {
     const source = this.props.source;
@@ -44,9 +47,7 @@ export default class AutoTestKit extends Component {
             </tr>
           </thead>
 
-          <tbody>
-            { Object.keys(source.returns).map(this.getMethodRow) }
-          </tbody>
+          <tbody>{Object.keys(source.returns).map(this.getMethodRow)}</tbody>
         </table>
       </div>
     );

--- a/packages/wix-storybook-utils/src/AutoTestKit/index.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/index.js
@@ -25,9 +25,9 @@ export default class AutoTestKit extends Component {
         (param, i) =>
           `${param.name} (${param.type})${i === params.length - 1 ? '' : '\n'}`,
       );
-    } else {
-      return '---';
     }
+
+    return '---';
   };
 
   render() {

--- a/packages/wix-storybook-utils/src/AutoTestKit/index.spec.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/index.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import fs from 'fs';
 import path from 'path';
-import {DriverParser} from './DriverParser';
+import { DriverParser } from './DriverParser';
 import BadgeDriverJson from './Badge.driver.json';
 
 import AutoTestKit from './';
@@ -12,16 +12,20 @@ const fakeTestKitsPaths = {
   Input: 'mock-testkits/Input.driver.txt',
   DropdownLayout: 'mock-testkits/DropdownLayout.driver.txt',
   Badge: 'mock-testkits/Badge.driver.txt',
-  TextLink: 'mock-testkits/textLink.driver.txt'
+  TextLink: 'mock-testkits/textLink.driver.txt',
 };
 
 const getFakeTestKitFile = fileName =>
   fs.readFileSync(path.resolve(path.join(__dirname, fileName)), 'utf8');
 
 const getFiles = () => ({
-  '../InputWithOptions/InputWithOptions.driver': getFakeTestKitFile(fakeTestKitsPaths.InputWithOptions),
+  '../InputWithOptions/InputWithOptions.driver': getFakeTestKitFile(
+    fakeTestKitsPaths.InputWithOptions,
+  ),
   './Input.driver': getFakeTestKitFile(fakeTestKitsPaths.Input),
-  '../DropdownLayout/DropdownLayout.driver': getFakeTestKitFile(fakeTestKitsPaths.DropdownLayout)
+  '../DropdownLayout/DropdownLayout.driver': getFakeTestKitFile(
+    fakeTestKitsPaths.DropdownLayout,
+  ),
 });
 
 const parseTestKit = testKit => {
@@ -29,17 +33,16 @@ const parseTestKit = testKit => {
   const files = {
     entry: testKit,
     ...getFiles,
-    [testKit]: entryTestKitFile
+    [testKit]: entryTestKitFile,
   };
   return new DriverParser(files).parse();
 };
 
 const render = testKit => {
-  return mount(<AutoTestKit source={parseTestKit(testKit)}/>);
+  return mount(<AutoTestKit source={parseTestKit(testKit)} />);
 };
 
-const byHook = (wrapper, hook) =>
-  wrapper.find(`[data-hook="${hook}"]`);
+const byHook = (wrapper, hook) => wrapper.find(`[data-hook="${hook}"]`);
 
 const createDriver = wrapper => {
   return {
@@ -48,19 +51,20 @@ const createDriver = wrapper => {
       const method = byHook(wrapper, 'method').at(index);
       return {
         getName: () => byHook(method, 'name').text(),
-        getDescription: () => byHook(method, 'description').text()
+        getDescription: () => byHook(method, 'description').text(),
       };
-    }
+    },
   };
 };
 
 describe('AutoTestKit', () => {
-
   describe('Badge testKit', () => {
     it('should have seven methods', () => {
       const driver = createDriver(render(fakeTestKitsPaths.Badge));
       expect(driver.getMethodsCount()).toEqual(7);
-      expect(driver.getMethodAt(0).getDescription()).toEqual(' Something  Something ');
+      expect(driver.getMethodAt(0).getDescription()).toEqual(
+        ' Something  Something ',
+      );
     });
   });
 
@@ -78,5 +82,3 @@ describe('AutoTestKit', () => {
     });
   });
 });
-
-

--- a/packages/wix-storybook-utils/src/AutoTestKit/run-with-node.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/run-with-node.js
@@ -25,10 +25,11 @@ const getFileContent = filePath => {
       const programBody = parse(fileContents).program.body;
       const promises = [];
       programBody.forEach(declaration => {
-        if (declaration.type === 'ImportDeclaration') {
-          if (declaration.source.value[0] === '.') {
-            promises.push(getFileContent(declaration.source.value));
-          }
+        if (
+          declaration.type === 'ImportDeclaration' &&
+          declaration.source.value[0] === '.'
+        ) {
+          promises.push(getFileContent(declaration.source.value));
         }
       });
       return Promise.all(promises);

--- a/packages/wix-storybook-utils/src/AutoTestKit/run-with-node.js
+++ b/packages/wix-storybook-utils/src/AutoTestKit/run-with-node.js
@@ -9,7 +9,7 @@ const readFile = filePath => {
   });
 };
 
-const files = {entry: './mock-testkits/Badge.driver'};
+const files = { entry: './mock-testkits/Badge.driver' };
 
 const getFileContent = filePath => {
   if (filePath.includes('scss')) {
@@ -19,8 +19,8 @@ const getFileContent = filePath => {
   const fileName = temp[temp.length - 1];
 
   console.log(fileName);
-  return readFile(path.resolve(`./mock-testkits/${fileName}.txt`))
-    .then(fileContents => {
+  return readFile(path.resolve(`./mock-testkits/${fileName}.txt`)).then(
+    fileContents => {
       files[filePath] = fileContents;
       const programBody = parse(fileContents).program.body;
       const promises = [];
@@ -32,9 +32,9 @@ const getFileContent = filePath => {
         }
       });
       return Promise.all(promises);
-    });
+    },
+  );
 };
-
 
 getFileContent(files.entry).then(() => {
   const parser = new SuperParse(files);

--- a/packages/wix-storybook-utils/src/CodeBlock/index.js
+++ b/packages/wix-storybook-utils/src/CodeBlock/index.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import copy from 'copy-to-clipboard';
 
@@ -12,26 +12,26 @@ export default class CodeBlock extends Component {
   static propTypes = {
     source: PropTypes.string,
     type: PropTypes.string,
-    dataHook: PropTypes.string
+    dataHook: PropTypes.string,
   };
 
   static defaultProps = {
-    type: 'js'
+    type: 'js',
   };
 
   state = {
-    showNotification: false
+    showNotification: false,
   };
 
   onCopyClick = () => {
     copy(this.props.source);
-    this.setState({showNotification: true}, () =>
-      setTimeout(() => this.setState({showNotification: false}), 3000)
+    this.setState({ showNotification: true }, () =>
+      setTimeout(() => this.setState({ showNotification: false }), 3000),
     );
   };
 
   render() {
-    const {source, type, dataHook} = this.props;
+    const { source, type, dataHook } = this.props;
 
     return (
       <div data-hook={dataHook}>
@@ -39,7 +39,7 @@ export default class CodeBlock extends Component {
 
         {this.state.showNotification && 'Copied!'}
 
-        <Markdown source={toCodeBlock(source, type)}/>
+        <Markdown source={toCodeBlock(source, type)} />
       </div>
     );
   }

--- a/packages/wix-storybook-utils/src/CodeExample/index.js
+++ b/packages/wix-storybook-utils/src/CodeExample/index.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Collapse from 'react-collapse';
 import styles from './styles.scss';
@@ -7,24 +7,23 @@ import CodeBlock from '../CodeBlock';
 import TextButton from '../TextButton';
 
 export default class CodeExample extends Component {
-
   static propTypes = {
     code: PropTypes.string,
     codeType: CodeBlock.propTypes.type,
     children: PropTypes.node,
     title: PropTypes.string,
-    autoExpand: PropTypes.bool
+    autoExpand: PropTypes.bool,
   };
 
   static defaultProps = {
-    codeType: CodeBlock.defaultProps.type
+    codeType: CodeBlock.defaultProps.type,
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      isOpened: !!props.autoExpand
+      isOpened: !!props.autoExpand,
     };
 
     this.toggleCode = this.toggleCode.bind(this);
@@ -32,29 +31,26 @@ export default class CodeExample extends Component {
 
   toggleCode() {
     this.setState({
-      isOpened: !this.state.isOpened
+      isOpened: !this.state.isOpened,
     });
   }
 
   render() {
     return (
       <div>
-        <div className={styles.panelControl} style={{display: 'flex'}}>
+        <div className={styles.panelControl} style={{ display: 'flex' }}>
           <h2>{this.props.title}</h2>
-          <div style={{margin: '22px 24px 0'}}>
+          <div style={{ margin: '22px 24px 0' }}>
             <TextButton onClick={this.toggleCode}>
               {this.state.isOpened ? 'Hide' : 'Show'} code
             </TextButton>
           </div>
         </div>
         <Collapse isOpened={this.state.isOpened}>
-          <CodeBlock source={this.props.code} type={this.props.codeType}/>
+          <CodeBlock source={this.props.code} type={this.props.codeType} />
         </Collapse>
-        <div>
-          {this.props.children}
-        </div>
+        <div>{this.props.children}</div>
       </div>
     );
   }
-
 }

--- a/packages/wix-storybook-utils/src/CodeShowcase/components/List.js
+++ b/packages/wix-storybook-utils/src/CodeShowcase/components/List.js
@@ -1,33 +1,33 @@
 import React from 'react';
 import styleclass from '../CodeShowcase.st.css';
-import {node, bool} from 'prop-types';
+import { node, bool } from 'prop-types';
 
 const spacing = {
   marginRight: '8px',
   marginBottom: '8px',
   marginTop: '8px',
-  display: 'flex'
+  display: 'flex',
 };
 
-const List = ({children, inverted}) => (
-  <div {...styleclass('demoItems', {inverted})}>
-    {Array.isArray(children) ?
-      children.map((child, index) => (
-        <div key={index} style={spacing}>
-          {child}
-        </div>
-      )) :
-      children}
+const List = ({ children, inverted }) => (
+  <div {...styleclass('demoItems', { inverted })}>
+    {Array.isArray(children)
+      ? children.map((child, index) => (
+          <div key={index} style={spacing}>
+            {child}
+          </div>
+        ))
+      : children}
   </div>
 );
 
 List.propTypes = {
   children: node,
-  inverted: bool
+  inverted: bool,
 };
 
 List.defaultProps = {
-  inverted: false
+  inverted: false,
 };
 
 export default List;

--- a/packages/wix-storybook-utils/src/CodeShowcase/index.js
+++ b/packages/wix-storybook-utils/src/CodeShowcase/index.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import {string, node, bool, object, oneOfType} from 'prop-types';
+import { string, node, bool, object, oneOfType } from 'prop-types';
 import SyntaxHighlighter, {
-  registerLanguage
+  registerLanguage,
 } from 'react-syntax-highlighter/prism-light';
 import jsx from 'react-syntax-highlighter/languages/prism/jsx';
 import vs from 'react-syntax-highlighter/styles/prism/vs';
 
 import styleclass from './CodeShowcase.st.css';
 import List from './components/List';
-import {iconShow} from './components/Show';
-import {iconHide} from './components/Hide';
+import { iconShow } from './components/Show';
+import { iconHide } from './components/Hide';
 
 registerLanguage('jsx', jsx);
 
@@ -17,19 +17,19 @@ const customHighlighterStyle = {
   padding: '16px 0',
   border: 'none',
   fontFamily: `"HelveticaNeueW01-45Ligh","sans-serif"`,
-  fontSize: '1.2em'
+  fontSize: '1.2em',
 };
 
 class CodeShowcase extends React.Component {
   constructor() {
     super();
     this.state = {
-      show: false
+      show: false,
     };
   }
 
   toggleCodeShow = () => {
-    this.setState({show: !this.state.show});
+    this.setState({ show: !this.state.show });
   };
 
   render() {
@@ -41,11 +41,11 @@ class CodeShowcase extends React.Component {
       inverted,
       theme,
       style,
-      children
+      children,
     } = this.props;
-    const {show} = this.state;
+    const { show } = this.state;
     return (
-      <div style={style} {...styleclass('root', {}, {className: theme})}>
+      <div style={style} {...styleclass('root', {}, { className: theme })}>
         <section className={styleclass.demo}>
           <List inverted={inverted}>{children}</List>
         </section>
@@ -66,7 +66,7 @@ class CodeShowcase extends React.Component {
             customStyle={customHighlighterStyle}
             language="jsx"
             codeTagProps={{
-              style: {fontFamily: `monospace`}
+              style: { fontFamily: `monospace` },
             }}
             style={vs}
           >
@@ -87,13 +87,13 @@ CodeShowcase.propTypes = {
   link: string,
   theme: string,
   style: object,
-  className: string
+  className: string,
 };
 
 CodeShowcase.defaultProps = {
   title: 'Example',
   inverted: false,
-  code: ''
+  code: '',
 };
 
 export default CodeShowcase;

--- a/packages/wix-storybook-utils/src/ComponentSource/function-to-string.js
+++ b/packages/wix-storybook-utils/src/ComponentSource/function-to-string.js
@@ -6,12 +6,12 @@ const namedTypes = recast.types.namedTypes;
 const ensureShorthandProperties = ast =>
   recast.visit(ast, {
     visitProperty(path) {
-      const {key, value} = path.node;
+      const { key, value } = path.node;
       if (key.test === value.test) {
         path.node.shorthand = true;
       }
       this.traverse(path);
-    }
+    },
   });
 
 const functionToString = prop => {
@@ -26,18 +26,18 @@ const functionToString = prop => {
     return prop;
   }
 
-  const {params, body} = program.expression;
+  const { params, body } = program.expression;
 
   const arrowFuncExpr = builders.arrowFunctionExpression(
     params,
     ensureShorthandProperties(
-      body.body.length === 1 && namedTypes.ReturnStatement.check(body.body[0]) ?
-        body.body[0].argument :
-        body
-    )
+      body.body.length === 1 && namedTypes.ReturnStatement.check(body.body[0])
+        ? body.body[0].argument
+        : body,
+    ),
   );
 
-  const result = recast.prettyPrint(arrowFuncExpr, {tabWidth: 2}).code;
+  const result = recast.prettyPrint(arrowFuncExpr, { tabWidth: 2 }).code;
 
   return result.replace(/;$/, '');
 };

--- a/packages/wix-storybook-utils/src/ComponentSource/function-to-string.test.js
+++ b/packages/wix-storybook-utils/src/ComponentSource/function-to-string.test.js
@@ -37,7 +37,7 @@ describe('functionToString', () => {
       function prop(value) {
         /* eslint-disable */
         return setState({
-          value: value
+          value,
         });
         /* eslint-enable */
       }
@@ -49,12 +49,9 @@ describe('functionToString', () => {
   });
 
   describe('given non function argument', () => {
-    [
-      0, 10, false, String('hello'), [], null, NaN, Infinity
-    ].map(assert =>
+    [0, 10, false, String('hello'), [], null, NaN, Infinity].map(assert =>
       it(`which is ${assert} should return ${assert}`, () =>
-        expect(functionToString(assert)).toEqual(assert)
-      )
+        expect(functionToString(assert)).toEqual(assert)),
     );
   });
 });

--- a/packages/wix-storybook-utils/src/ComponentSource/index.js
+++ b/packages/wix-storybook-utils/src/ComponentSource/index.js
@@ -7,30 +7,25 @@ import removeHOC from './remove-hoc';
 import functionToString from './function-to-string';
 
 const componentToJSX = component =>
-  reactElementToJSXString(
-    component,
-    {
-      displayName: element =>
-        element.type.displayName ?
-          removeHOC(element.type.displayName) :
-          element.type.name || element.type,
-      showDefaultProps: false,
-      showFunctions: false,
-      functionValue: functionToString
-    }
-  );
+  reactElementToJSXString(component, {
+    displayName: element =>
+      element.type.displayName
+        ? removeHOC(element.type.displayName)
+        : element.type.name || element.type,
+    showDefaultProps: false,
+    showFunctions: false,
+    functionValue: functionToString,
+  });
 
 /**
-  * given react component, render a source example
-  */
-const ComponentSource = ({component}) =>
-  <CodeBlock
-    dataHook="metadata-codeblock"
-    source={componentToJSX(component)}
-  />;
+ * given react component, render a source example
+ */
+const ComponentSource = ({ component }) => (
+  <CodeBlock dataHook="metadata-codeblock" source={componentToJSX(component)} />
+);
 
 ComponentSource.propTypes = {
-  component: PropTypes.node.isRequired
+  component: PropTypes.node.isRequired,
 };
 
 export default ComponentSource;

--- a/packages/wix-storybook-utils/src/ComponentSource/remove-hoc.test.js
+++ b/packages/wix-storybook-utils/src/ComponentSource/remove-hoc.test.js
@@ -12,13 +12,11 @@ describe('removeHOC() given', () => {
     ['hello(world)', 'world'],
     ['Hel+lo(world)', 'world'],
     ['hello(w o r l d)', 'w o r l d'],
-    ['(hello)', 'hello']
+    ['(hello)', 'hello'],
   ];
 
   assertsAndExpectations.map(([assert, expectation]) =>
-    it(
-      `"${assert}" should return "${expectation}"`,
-      () => expect(removeHOC(assert)).toEqual(expectation)
-    )
+    it(`"${assert}" should return "${expectation}"`, () =>
+      expect(removeHOC(assert)).toEqual(expectation)),
   );
 });

--- a/packages/wix-storybook-utils/src/InteractiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/InteractiveCodeExample/index.js
@@ -1,25 +1,24 @@
-import React, {cloneElement, Component, Children} from 'react';
+import React, { cloneElement, Component, Children } from 'react';
 import PropTypes from 'prop-types';
 
 import CodeExample from '../CodeExample';
 
 export default class InteractiveCodeExample extends Component {
-
   static propTypes = {
     children: PropTypes.node,
     title: PropTypes.string,
-    autoExpand: PropTypes.bool
-  }
+    autoExpand: PropTypes.bool,
+  };
 
   static defaultProps = {
-    autoExpand: true
-  }
+    autoExpand: true,
+  };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      code: ''
+      code: '',
     };
 
     this.onCodeChange = this.onCodeChange.bind(this);
@@ -27,13 +26,13 @@ export default class InteractiveCodeExample extends Component {
 
   onCodeChange(code) {
     if (code !== this.state.code) {
-      this.setState({code});
+      this.setState({ code });
     }
   }
 
   render() {
-    const childrenWithOnChange = Children.map(this.props.children,
-      child => cloneElement(child, {onChange: this.onCodeChange})
+    const childrenWithOnChange = Children.map(this.props.children, child =>
+      cloneElement(child, { onChange: this.onCodeChange }),
     );
 
     return (
@@ -47,5 +46,4 @@ export default class InteractiveCodeExample extends Component {
       </CodeExample>
     );
   }
-
 }

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -1,8 +1,8 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {LiveProvider, LiveEditor, LiveError, LivePreview} from 'react-live';
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
 import classnames from 'classnames';
-import {Collapse} from 'react-collapse';
+import { Collapse } from 'react-collapse';
 import copy from 'copy-to-clipboard';
 import styles from './index.scss';
 
@@ -17,33 +17,33 @@ export default class LiveCodeExample extends Component {
     initialCode: PropTypes.string,
     title: PropTypes.string,
     scope: PropTypes.object,
-    compact: PropTypes.bool
+    compact: PropTypes.bool,
   };
 
   static defaultProps = {
-    compact: false
+    compact: false,
   };
 
   resetCode = () => {
     this.setState({
-      code: this.props.initialCode
+      code: this.props.initialCode,
     });
   };
 
-  onCodeChange = code => this.setState({code});
+  onCodeChange = code => this.setState({ code });
 
-  onToggleRtl = isRtl => this.setState({isRtl});
-  onToggleBackground = isDarkBackground => this.setState({isDarkBackground});
+  onToggleRtl = isRtl => this.setState({ isRtl });
+  onToggleBackground = isDarkBackground => this.setState({ isDarkBackground });
 
   onToggleCode = () =>
     this.setState(state => ({
-      isEditorOpened: !state.isEditorOpened
+      isEditorOpened: !state.isEditorOpened,
     }));
 
   onCopyClick = () => {
     copy(this.state.code);
-    this.setState({showNotification: true}, () =>
-      setTimeout(() => this.setState({showNotification: false}), 3000)
+    this.setState({ showNotification: true }, () =>
+      setTimeout(() => this.setState({ showNotification: false }), 3000),
     );
   };
 
@@ -55,32 +55,32 @@ export default class LiveCodeExample extends Component {
       isRtl: false,
       isDarkBackground: false,
       isEditorOpened: !props.compact,
-      showNotification: false
+      showNotification: false,
     };
   }
 
   renderCopyButton() {
     return (
-      <TextButton onClick={this.onCopyClick} prefixIcon={<Document/>}>
+      <TextButton onClick={this.onCopyClick} prefixIcon={<Document />}>
         {this.state.showNotification ? 'Copied!' : 'Copy to clipboard'}
       </TextButton>
     );
   }
 
   render() {
-    const {compact} = this.props;
-    const {code, isRtl, isDarkBackground, isEditorOpened} = this.state;
+    const { compact } = this.props;
+    const { code, isRtl, isDarkBackground, isEditorOpened } = this.state;
 
     return (
       <div
         className={classnames(styles.wrapper, {
-          [styles.compact]: compact
+          [styles.compact]: compact,
         })}
       >
         <div className={styles.header}>
           <h2>{this.props.title}</h2>
 
-          <div className={styles.spacer}/>
+          <div className={styles.spacer} />
 
           <div className={styles.headerControl}>
             Imitate RTL:&nbsp;
@@ -103,13 +103,13 @@ export default class LiveCodeExample extends Component {
           {!compact && this.renderCopyButton()}
 
           {isEditorOpened && (
-            <TextButton onClick={this.resetCode} prefixIcon={<Revert/>}>
+            <TextButton onClick={this.resetCode} prefixIcon={<Revert />}>
               Reset
             </TextButton>
           )}
 
           {compact && (
-            <TextButton onClick={this.onToggleCode} prefixIcon={<Code/>}>
+            <TextButton onClick={this.onToggleCode} prefixIcon={<Code />}>
               {this.state.isEditorOpened ? 'Hide' : 'Show'} code
             </TextButton>
           )}
@@ -124,7 +124,7 @@ export default class LiveCodeExample extends Component {
             <Collapse
               isOpened={isEditorOpened}
               className={classnames(styles.editor, {
-                [styles.opened]: isEditorOpened
+                [styles.opened]: isEditorOpened,
               })}
             >
               <LiveEditor
@@ -136,12 +136,12 @@ export default class LiveCodeExample extends Component {
             <div
               className={classnames(styles.preview, {
                 rtl: isRtl,
-                [styles.darkPreview]: isDarkBackground
+                [styles.darkPreview]: isDarkBackground,
               })}
               dir={isRtl ? 'rtl' : ''}
             >
-              <LivePreview/>
-              <LiveError className={styles.error}/>
+              <LivePreview />
+              <LiveError className={styles.error} />
             </div>
           </div>
         </LiveProvider>

--- a/packages/wix-storybook-utils/src/Markdown/index.js
+++ b/packages/wix-storybook-utils/src/Markdown/index.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Remarkable from 'react-remarkable';
 import hljs from 'highlight.js/lib/highlight.js';
@@ -6,12 +6,12 @@ import './style.scss';
 
 hljs.registerLanguage(
   'javascript',
-  require('highlight.js/lib/languages/javascript.js')
+  require('highlight.js/lib/languages/javascript.js'),
 );
 
 hljs.registerLanguage(
   'typescript',
-  require('highlight.js/lib/languages/typescript.js')
+  require('highlight.js/lib/languages/typescript.js'),
 );
 
 hljs.registerLanguage('css', require('highlight.js/lib/languages/css.js'));
@@ -24,18 +24,18 @@ hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash.js'));
 
 hljs.registerLanguage(
   'markdown',
-  require('highlight.js/lib/languages/markdown.js')
+  require('highlight.js/lib/languages/markdown.js'),
 );
 
 hljs.registerLanguage(
   'django',
-  require('highlight.js/lib/languages/django.js')
+  require('highlight.js/lib/languages/django.js'),
 );
 
 export default class Markdown extends Component {
   static propTypes = {
     source: PropTypes.string,
-    className: PropTypes.string
+    className: PropTypes.string,
   };
 
   render() {
@@ -46,12 +46,12 @@ export default class Markdown extends Component {
       linkTarget: '_parent',
       highlight(code, lang) {
         return hljs.highlight(lang, code).value;
-      }
+      },
     };
-    const {source, className} = this.props;
+    const { source, className } = this.props;
     return !shouldHideForE2E ? (
       <div className={className || 'markdown-body'}>
-        <Remarkable source={source} options={options}/>
+        <Remarkable source={source} options={options} />
       </div>
     ) : null;
   }

--- a/packages/wix-storybook-utils/src/Story/RemountHoc.js
+++ b/packages/wix-storybook-utils/src/Story/RemountHoc.js
@@ -3,18 +3,20 @@ import PropTypes from 'prop-types';
 
 export default class extends React.Component {
   state = {
-    visible: true
+    visible: true,
+  };
+  static propTypes = {
+    children: PropTypes.node,
+  };
+  componentDidMount() {
+    window.story = this;
   }
-   static propTypes = {
-     children: PropTypes.node
-   }
-   componentDidMount() {
-     window.story = this;
-   }
   remount = () =>
     new Promise(resolve =>
-      this.setState({visible: false}, () =>
-        this.setState({visible: true}, resolve)))
+      this.setState({ visible: false }, () =>
+        this.setState({ visible: true }, resolve),
+      ),
+    );
   render() {
     return this.state.visible ? this.props.children : null;
   }

--- a/packages/wix-storybook-utils/src/Story/index.js
+++ b/packages/wix-storybook-utils/src/Story/index.js
@@ -19,39 +19,39 @@ export default ({
   codeExample,
   hiddenProps,
   _config,
-  _metadata
+  _metadata,
 }) =>
-  _config
-    .storiesOf(category, module)
-    .add(
-      storyName || _metadata.displayName,
-      () =>
-        isE2E ?
-          <div>
-            <Remount>
-              <AutoExample
-                isInteractive={false}
-                ref={ref => global.autoexample = ref}
-                component={component}
-                componentProps={componentProps}
-                parsedSource={_metadata}
-              />
-            </Remount>
-            {queryString.parse(window.location.search).withExamples !== undefined && examples}
-          </div> :
-
-          <StoryPage
-            {...{
-              component,
-              componentProps,
-              exampleProps,
-              exampleImport,
-              displayName,
-              examples,
-              codeExample,
-              hiddenProps,
-              metadata: _metadata,
-              config: _config
-            }}
-          />
-    );
+  _config.storiesOf(category, module).add(
+    storyName || _metadata.displayName,
+    () =>
+      isE2E ? (
+        <div>
+          <Remount>
+            <AutoExample
+              isInteractive={false}
+              ref={ref => (global.autoexample = ref)}
+              component={component}
+              componentProps={componentProps}
+              parsedSource={_metadata}
+            />
+          </Remount>
+          {queryString.parse(window.location.search).withExamples !==
+            undefined && examples}
+        </div>
+      ) : (
+        <StoryPage
+          {...{
+            component,
+            componentProps,
+            exampleProps,
+            exampleImport,
+            displayName,
+            examples,
+            codeExample,
+            hiddenProps,
+            metadata: _metadata,
+            config: _config,
+          }}
+        />
+      ),
+  );

--- a/packages/wix-storybook-utils/src/StoryPage/index.test.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/index.test.tsx
@@ -14,7 +14,7 @@ describe('StoryPage', () => {
   describe('given `exampleImport`', () => {
     it('should render it', () => {
       const exampleImport = 'hello there';
-      testkit.when.created({exampleImport});
+      testkit.when.created({ exampleImport });
       expect(testkit.get.import()).toMatch(exampleImport);
     });
   });
@@ -23,9 +23,9 @@ describe('StoryPage', () => {
     it('should format and render it in story', () => {
       const config = {
         importFormat: "hey %moduleName, what's your name, %moduleName?",
-        moduleName: 'dork'
+        moduleName: 'dork',
       };
-      testkit.when.created({config});
+      testkit.when.created({ config });
       expect(testkit.get.import()).toMatch("hey dork, what's your name, dork?");
     });
 
@@ -34,11 +34,11 @@ describe('StoryPage', () => {
         importFormat: 'good %daytime, %person, where is my %thing at?',
         daytime: 'evening',
         person: 'Homer',
-        thing: 'money'
+        thing: 'money',
       };
-      testkit.when.created({config});
+      testkit.when.created({ config });
       expect(testkit.get.import()).toMatch(
-        'good evening, Homer, where is my money at?'
+        'good evening, Homer, where is my money at?',
       );
     });
 
@@ -47,16 +47,16 @@ describe('StoryPage', () => {
         config: {
           importFormat:
             "import {%componentName} from '%moduleName/%componentName';",
-          moduleName: 'wix-ui-core'
+          moduleName: 'wix-ui-core',
         },
         metadata: {
           displayName: 'BesterestestComponent',
-          props: {}
-        }
+          props: {},
+        },
       };
       testkit.when.created(props);
       expect(testkit.get.import()).toMatch(
-        "import {BesterestestComponent} from 'wix-ui-core/BesterestestComponent';"
+        "import {BesterestestComponent} from 'wix-ui-core/BesterestestComponent';",
       );
     });
   });
@@ -65,10 +65,10 @@ describe('StoryPage', () => {
     it('should show it instead of using one from `metadata`', () => {
       const props = {
         metadata: {
-          props: {}
+          props: {},
         },
         config: {},
-        displayName: 'well hello there'
+        displayName: 'well hello there',
       };
 
       testkit.when.created(props);
@@ -83,11 +83,11 @@ describe('StoryPage', () => {
       testkit.when.created({
         metadata: {
           props: {
-            hiddenProp: {type: {name: 'string'}},
-            visibleProp: {type: {name: 'string'}}
-          }
+            hiddenProp: { type: { name: 'string' } },
+            visibleProp: { type: { name: 'string' } },
+          },
         },
-        hiddenProps: ['hiddenProp']
+        hiddenProps: ['hiddenProp'],
       });
 
       expect(testkit.get.autoExample().find(Option).length).toEqual(1);
@@ -96,7 +96,7 @@ describe('StoryPage', () => {
 
   describe('code example', () => {
     it('should show displayName without HOC', () => {
-      const component = ({children}) => <div>{children}</div>; // eslint-disable-line react/prop-types
+      const component = ({ children }) => <div>{children}</div>; // eslint-disable-line react/prop-types
       component.displayName = 'someHOC(componentName)';
 
       const IShouldBeTheName = () => null;
@@ -108,11 +108,11 @@ describe('StoryPage', () => {
             <div>
               <IShouldBeTheName />
             </div>
-          )
+          ),
         },
         exampleProps: {
-          children: []
-        }
+          children: [],
+        },
       };
 
       testkit.when.created(props);
@@ -128,7 +128,7 @@ describe('StoryPage', () => {
     it('should not be rendered given `codeExample: false`', () => {
       testkit.when.created({
         component: () => '',
-        codeExample: false
+        codeExample: false,
       });
 
       expect(testkit.get.codeBlock().length).toEqual(0);

--- a/packages/wix-storybook-utils/src/StoryPage/index.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/index.tsx
@@ -13,24 +13,24 @@ const tabs = metadata => [
   'Usage',
   'API',
   ...(metadata.readmeTestkit ? ['Testkit'] : []),
-  ...(metadata.readmeAccessibility ? ['Accessibility'] : [])
+  ...(metadata.readmeAccessibility ? ['Accessibility'] : []),
 ];
 
-type ImportString = {
+interface ImportString {
   metadata: Metadata;
   config: Config;
   exampleImport: string;
-};
+}
 
 const importString: (ImportString) => string = ({
   metadata,
   config,
-  exampleImport
+  exampleImport,
 }: ImportString) =>
   [
     {
       when: () => exampleImport,
-      make: () => exampleImport
+      make: () => exampleImport,
     },
     {
       when: () => config.importFormat,
@@ -39,8 +39,8 @@ const importString: (ImportString) => string = ({
           .replace(/%componentName/g, metadata.displayName)
           .replace(
             new RegExp('%(' + Object.keys(config).join('|') + ')', 'g'),
-            (match, configKey) => config[configKey] || ''
-          )
+            (match, configKey) => config[configKey] || '',
+          ),
     },
     {
       // default
@@ -48,10 +48,10 @@ const importString: (ImportString) => string = ({
       make: () =>
         `import ${metadata.displayName} from '${config.moduleName}/${
           metadata.displayName
-        }';`
-    }
+        }';`,
+    },
   ]
-    .filter(({when}) => when())[0]
+    .filter(({ when }) => when())[0]
     .make();
 
 interface SectionProps {
@@ -61,7 +61,7 @@ interface SectionProps {
 
 const Section: React.StatelessComponent<SectionProps> = ({
   title,
-  children
+  children,
 }: SectionProps) => (
   <div>
     {/* tslint: disable */}
@@ -100,13 +100,13 @@ const StoryPage: React.StatelessComponent<StoryPageProps> = ({
   exampleProps,
   exampleImport,
   examples,
-  codeExample
+  codeExample,
 }: StoryPageProps) => {
   const visibleDisplayName = displayName || metadata.displayName;
   const visibleMetadata = {
     ...metadata,
     displayName: visibleDisplayName,
-    props: omit(metadata.props)(prop => hiddenProps.includes(prop))
+    props: omit(metadata.props)(prop => hiddenProps.includes(prop)),
   };
 
   return (
@@ -134,7 +134,7 @@ const StoryPage: React.StatelessComponent<StoryPageProps> = ({
           source={importString({
             config,
             metadata: visibleMetadata,
-            exampleImport
+            exampleImport,
           })}
         />
 
@@ -164,9 +164,9 @@ StoryPage.defaultProps = {
   config: {
     importFormat: '',
     moduleName: '',
-    repoBaseURL: ''
+    repoBaseURL: '',
   },
-  hiddenProps: []
+  hiddenProps: [],
 };
 
 export default StoryPage;

--- a/packages/wix-storybook-utils/src/StoryPage/testkit.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/testkit.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 
 import Markdown from '../Markdown';
 import AutoExample from '../AutoExample';
@@ -11,20 +11,20 @@ export default class {
   defaultProps = {
     metadata: {
       displayName: 'componentName',
-      props: {}
+      props: {},
     },
     config: {},
-    component: () => <div/>,
+    component: () => <div />,
     componentProps: {},
     exampleProps: {},
-    examples: null
+    examples: null,
   };
 
   when = {
     created: props =>
       (this.component = mount(
-        <StoryPage {...{...this.defaultProps, ...props}}/>
-      ))
+        <StoryPage {...{ ...this.defaultProps, ...props }} />,
+      )),
   };
 
   get = {
@@ -40,6 +40,6 @@ export default class {
     codeBlock: () =>
       this.component.find('[dataHook="metadata-codeblock"]').find(Markdown),
 
-    autoExample: () => this.component.find(AutoExample)
+    autoExample: () => this.component.find(AutoExample),
   };
 }

--- a/packages/wix-storybook-utils/src/TabbedView/index.js
+++ b/packages/wix-storybook-utils/src/TabbedView/index.js
@@ -1,27 +1,27 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Tabs from '../ui/Tabs';
 
-const createTab = id => ({title: id, id});
+const createTab = id => ({ title: id, id });
 
 export default class TabbedView extends Component {
   static propTypes = {
     tabs: PropTypes.arrayOf(PropTypes.string),
     children: PropTypes.oneOfType([
       PropTypes.node,
-      PropTypes.arrayOf(PropTypes.node)
-    ])
+      PropTypes.arrayOf(PropTypes.node),
+    ]),
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      activeTabId: props.tabs[0]
+      activeTabId: props.tabs[0],
     };
   }
 
-  onTabClick = tab => this.setState({activeTabId: tab.id});
+  onTabClick = tab => this.setState({ activeTabId: tab.id });
 
   render() {
     const shouldHideForE2E = global.self === global.top;
@@ -39,7 +39,7 @@ export default class TabbedView extends Component {
         {React.Children.map(
           this.props.children,
           (child, index) =>
-            this.state.activeTabId === this.props.tabs[index] ? child : null
+            this.state.activeTabId === this.props.tabs[index] ? child : null,
         )}
       </div>
     );

--- a/packages/wix-storybook-utils/src/TextButton/index.js
+++ b/packages/wix-storybook-utils/src/TextButton/index.js
@@ -1,19 +1,18 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styles from './styles.scss';
 
 export default class TextButton extends Component {
-
   static propTypes = {
     onClick: PropTypes.func,
     prefixIcon: PropTypes.node,
-    children: PropTypes.node
+    children: PropTypes.node,
   };
 
   constructor(props) {
     super(props);
     this.state = {
-      isHover: false
+      isHover: false,
     };
 
     this.toggleHover = this.toggleHover.bind(this);
@@ -21,7 +20,7 @@ export default class TextButton extends Component {
 
   toggleHover() {
     this.setState({
-      isHover: !this.state.isHover
+      isHover: !this.state.isHover,
     });
   }
 
@@ -33,7 +32,7 @@ export default class TextButton extends Component {
       outline: 'none',
       border: 'none',
       background: 'none',
-      cursor: 'pointer'
+      cursor: 'pointer',
     };
 
     return (
@@ -45,9 +44,7 @@ export default class TextButton extends Component {
         onClick={this.props.onClick}
       >
         {this.props.prefixIcon ? (
-          <div className={styles.prefix}>
-            {this.props.prefixIcon}
-          </div>
+          <div className={styles.prefix}>{this.props.prefixIcon}</div>
         ) : null}
         {this.props.children}
       </button>

--- a/packages/wix-storybook-utils/src/loader/index.js
+++ b/packages/wix-storybook-utils/src/loader/index.js
@@ -6,18 +6,14 @@ const gatherAll = require('react-autodocs-utils/src/gather-all');
 const metadataMerger = require('react-autodocs-utils/src/metadata-merger');
 const prepareStory = require('react-autodocs-utils/src/prepare-story'); // TODO: should be part of wix-storybook-utils
 
-
-module.exports = function (source) {
+module.exports = function(source) {
   const callback = this.async();
-  const {storyConfig} = loaderUtils.getOptions(this);
+  const { storyConfig } = loaderUtils.getOptions(this);
 
   // 1. find component path
   pathFinder(source)
-
     // 2. get component metadata
-    .then(componentPath =>
-      gatherAll(path.join(this.context, componentPath))
-    )
+    .then(componentPath => gatherAll(path.join(this.context, componentPath)))
 
     // 3. merge component metadata with storybook config
     .then(metadataMerger(source))

--- a/packages/wix-storybook-utils/src/ui/Layout/Cell/index.js
+++ b/packages/wix-storybook-utils/src/ui/Layout/Cell/index.js
@@ -4,12 +4,12 @@ import classname from 'classnames';
 
 import styles from './styles.scss';
 
-const Cell = ({span, children, vertical}) => (
+const Cell = ({ span, children, vertical }) => (
   <div
     style={{
-      gridColumn: `span ${span}`
+      gridColumn: `span ${span}`,
     }}
-    className={classname(styles.root, {[styles.vertical]: vertical})}
+    className={classname(styles.root, { [styles.vertical]: vertical })}
     children={children}
   />
 );
@@ -24,11 +24,11 @@ Cell.propTypes = {
   span: PropTypes.number,
 
   /** whether to align children vertically to the middle */
-  vertical: PropTypes.bool
+  vertical: PropTypes.bool,
 };
 
 Cell.defaultProps = {
-  span: 12
+  span: 12,
 };
 
 export default Cell;

--- a/packages/wix-storybook-utils/src/ui/Layout/Cell/index.spec.js
+++ b/packages/wix-storybook-utils/src/ui/Layout/Cell/index.spec.js
@@ -1,7 +1,7 @@
 /* global expect describe it */
 
 import React from 'react';
-import {shallow} from 'enzyme';
+import { shallow } from 'enzyme';
 
 import styles from './styles.scss';
 import Cell from './';
@@ -9,14 +9,14 @@ import Cell from './';
 describe('Cell', () => {
   describe('`span` prop', () => {
     it('should be set in `gridColumn` style', () => {
-      const cell = shallow(<Cell span={4}/>);
+      const cell = shallow(<Cell span={4} />);
       expect(cell.prop('style').gridColumn).toEqual('span 4');
     });
   });
 
   describe('`vertical`', () => {
     it('should set correct classname', () => {
-      const cell = shallow(<Cell vertical/>);
+      const cell = shallow(<Cell vertical />);
       expect(cell.prop('className')).toMatch(styles.vertical);
     });
   });

--- a/packages/wix-storybook-utils/src/ui/Layout/Layout/index.js
+++ b/packages/wix-storybook-utils/src/ui/Layout/Layout/index.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 import styles from './styles.scss';
 
-const Layout = ({children, gap, cols, dataHook, className}) => (
+const Layout = ({ children, gap, cols, dataHook, className }) => (
   <div
     style={{
       gridGap: gap,
-      gridTemplateColumns: cols ? `repeat(${cols}, 1fr)` : undefined
+      gridTemplateColumns: cols ? `repeat(${cols}, 1fr)` : undefined,
     }}
     className={`${styles.root} ${className}`}
     children={children}
@@ -28,11 +28,11 @@ Layout.propTypes = {
   cols: PropTypes.number,
 
   dataHook: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 Layout.defaultProps = {
-  gap: '30px'
+  gap: '30px',
 };
 
 export default Layout;

--- a/packages/wix-storybook-utils/src/ui/Layout/Layout/index.spec.js
+++ b/packages/wix-storybook-utils/src/ui/Layout/Layout/index.spec.js
@@ -1,26 +1,28 @@
 /* global expect describe it */
 
 import React from 'react';
-import {shallow} from 'enzyme';
+import { shallow } from 'enzyme';
 
 import Layout from './';
 
 describe('Layout', () => {
   describe('`gap` prop', () => {
     it('should set `gridGap` style', () => {
-      const layout = shallow(<Layout gap="30px 20px"/>);
+      const layout = shallow(<Layout gap="30px 20px" />);
       expect(layout.prop('style').gridGap).toEqual('30px 20px');
     });
   });
 
   describe('`cols` prop', () => {
     it('should set `gridTemplateColumns` style', () => {
-      const layout = shallow(<Layout cols={5}/>);
-      expect(layout.prop('style').gridTemplateColumns).toEqual('repeat(5, 1fr)');
+      const layout = shallow(<Layout cols={5} />);
+      expect(layout.prop('style').gridTemplateColumns).toEqual(
+        'repeat(5, 1fr)',
+      );
     });
 
     it('should not set `gridTemplateColumns` inline style by default', () => {
-      const layout = shallow(<Layout/>);
+      const layout = shallow(<Layout />);
       expect(layout.prop('style').gridTemplateColumns).toBeUndefined();
     });
   });

--- a/packages/wix-storybook-utils/src/ui/Layout/index.js
+++ b/packages/wix-storybook-utils/src/ui/Layout/index.js
@@ -1,4 +1,4 @@
 import Layout from './Layout';
 import Cell from './Cell';
 
-export {Layout, Cell};
+export { Layout, Cell };

--- a/packages/wix-storybook-utils/src/ui/Tabs/core/SideContent/index.js
+++ b/packages/wix-storybook-utils/src/ui/Tabs/core/SideContent/index.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 import styles from '../../Tabs.scss';
 
-
-const SideContent = ({content}) => content ? <div className={styles.sideContent}>{content}</div> : null;
+const SideContent = ({ content }) =>
+  content ? <div className={styles.sideContent}>{content}</div> : null;
 
 SideContent.propTypes = {
-  content: PropTypes.node
+  content: PropTypes.node,
 };
 
 export default SideContent;

--- a/packages/wix-storybook-utils/src/ui/Tabs/core/TabItem/index.js
+++ b/packages/wix-storybook-utils/src/ui/Tabs/core/TabItem/index.js
@@ -8,13 +8,13 @@ import styles from '../../styles.scss';
 
 class TabItem extends React.Component {
   render() {
-    const {item, onItemClick, isActive, dynamicProperties} = this.props;
+    const { item, onItemClick, isActive, dynamicProperties } = this.props;
 
     const containerProps = {
       key: item.id,
       onClick: () => onItemClick(item),
-      className: classNames(styles.tab, {[styles.active]: isActive}),
-      ...pick(this.props, dynamicProperties)
+      className: classNames(styles.tab, { [styles.active]: isActive }),
+      ...pick(this.props, dynamicProperties),
     };
 
     return <li {...containerProps}>{item.title}</li>;
@@ -28,7 +28,7 @@ TabItem.propTypes = {
   onItemClick: TabPropTypes.onClick,
   type: TabPropTypes.type,
   width: TabPropTypes.width,
-  dynamicProperties: PropTypes.array
+  dynamicProperties: PropTypes.array,
 };
 
 export default TabItem;

--- a/packages/wix-storybook-utils/src/ui/Tabs/core/TabItems/index.js
+++ b/packages/wix-storybook-utils/src/ui/Tabs/core/TabItems/index.js
@@ -9,7 +9,7 @@ import styles from '../../styles.scss';
 
 class TabItems extends React.Component {
   renderItem(item) {
-    const {activeId, type, width, onClick, itemMaxWidth} = this.props;
+    const { activeId, type, width, onClick, itemMaxWidth } = this.props;
     return (
       <TabItem
         key={item.id}
@@ -25,14 +25,14 @@ class TabItems extends React.Component {
   }
 
   render() {
-    const {items, type, dataHook} = this.props;
+    const { items, type, dataHook } = this.props;
     const className = classNames(styles.itemsContainer, styles[type]);
 
     return (
       <ul
         className={className}
         data-hook={dataHook}
-        style={{minWidth: this.props.minWidth}}
+        style={{ minWidth: this.props.minWidth }}
       >
         {items.map(item => this.renderItem(item))}
       </ul>
@@ -48,7 +48,7 @@ TabItems.propTypes = {
   minWidth: TabPropTypes.width,
   type: TabPropTypes.type,
   width: TabPropTypes.width,
-  onClick: TabPropTypes.onClick
+  onClick: TabPropTypes.onClick,
 };
 
 export default withItemMaxWidth(TabItems);

--- a/packages/wix-storybook-utils/src/ui/Tabs/core/constants/tab-prop-types.js
+++ b/packages/wix-storybook-utils/src/ui/Tabs/core/constants/tab-prop-types.js
@@ -2,10 +2,16 @@ import PropTypes from 'prop-types';
 
 import TabTypes from './tab-types';
 
+const stringOrNumber = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number,
+]);
 
-const stringOrNumber = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
-
-export const item = PropTypes.shape({id: stringOrNumber, title: PropTypes.node, dataHook: PropTypes.string});
+export const item = PropTypes.shape({
+  id: stringOrNumber,
+  title: PropTypes.node,
+  dataHook: PropTypes.string,
+});
 
 export const items = PropTypes.arrayOf(item);
 

--- a/packages/wix-storybook-utils/src/ui/Tabs/core/utils.js
+++ b/packages/wix-storybook-utils/src/ui/Tabs/core/utils.js
@@ -1,1 +1,2 @@
-export const getWidth = element => element ? element.getBoundingClientRect().width : 0;
+export const getWidth = element =>
+  element ? element.getBoundingClientRect().width : 0;

--- a/packages/wix-storybook-utils/src/ui/Tabs/core/withItemMaxWidth/index.js
+++ b/packages/wix-storybook-utils/src/ui/Tabs/core/withItemMaxWidth/index.js
@@ -1,11 +1,9 @@
 import React from 'react';
 
 import * as TabPropTypes from '../constants/tab-prop-types';
-import {getWidth} from '../utils';
-
+import { getWidth } from '../utils';
 
 const withMaxWidth = WrappedComponent => {
-
   const getMaxWidth = (items, containerWidth) => {
     const COMPACT_SIDE_MARGIN = 18;
     const marginsBetweenItems = COMPACT_SIDE_MARGIN * 2 * (items.length - 1);
@@ -13,13 +11,12 @@ const withMaxWidth = WrappedComponent => {
   };
 
   class Wrapper extends React.Component {
-
     state = {
-      itemMaxWidth: undefined
+      itemMaxWidth: undefined,
     };
 
     initMaxWidth(itemsContainer) {
-      const {type, items} = this.props;
+      const { type, items } = this.props;
 
       if (!itemsContainer || type !== 'compactSide') {
         return;
@@ -27,23 +24,25 @@ const withMaxWidth = WrappedComponent => {
 
       const itemMaxWidth = getMaxWidth(items, getWidth(itemsContainer));
       if (this.state.itemMaxWidth !== itemMaxWidth) {
-        this.setState({itemMaxWidth});
+        this.setState({ itemMaxWidth });
       }
     }
 
     render() {
       return (
-        <div ref={el => this.initMaxWidth(el)} style={{width: '100%'}}>
-          <WrappedComponent {...this.props} itemMaxWidth={this.state.itemMaxWidth}/>
+        <div ref={el => this.initMaxWidth(el)} style={{ width: '100%' }}>
+          <WrappedComponent
+            {...this.props}
+            itemMaxWidth={this.state.itemMaxWidth}
+          />
         </div>
       );
     }
-
   }
 
   Wrapper.propTypes = {
     type: TabPropTypes.type,
-    items: TabPropTypes.items.isRequired
+    items: TabPropTypes.items.isRequired,
   };
 
   return Wrapper;

--- a/packages/wix-storybook-utils/src/ui/Tabs/core/withTooltip/index.js
+++ b/packages/wix-storybook-utils/src/ui/Tabs/core/withTooltip/index.js
@@ -2,21 +2,18 @@ import React from 'react';
 
 import Tooltip from '../../../Tooltip';
 import * as TabPropTypes from '../constants/tab-prop-types';
-import {getWidth} from '../utils';
-
+import { getWidth } from '../utils';
 
 const withTooltip = WrappedComponent => {
-
   const VERTICAL_PADDING = 18;
 
   class Wrapper extends React.Component {
-
     state = {
-      hasTooltip: false
+      hasTooltip: false,
     };
 
     initHasTooltip(content) {
-      const {type} = this.props;
+      const { type } = this.props;
 
       if (!content || type !== 'compactSide') {
         return;
@@ -24,26 +21,36 @@ const withTooltip = WrappedComponent => {
 
       const hasTooltip = getWidth(content) > getWidth(content.parentElement);
       if (this.state.hasTooltip !== hasTooltip) {
-        this.setState({hasTooltip});
+        this.setState({ hasTooltip });
       }
     }
 
     withTooltipProperties(component, key) {
-      const tooltipProperties = ['onMouseEnter', 'onMouseLeave', 'onFocus', 'onBlur'];
-      return React.cloneElement(component, {[key]: tooltipProperties});
+      const tooltipProperties = [
+        'onMouseEnter',
+        'onMouseLeave',
+        'onFocus',
+        'onBlur',
+      ];
+      return React.cloneElement(component, { [key]: tooltipProperties });
     }
 
     withTooltip(component) {
-      const {id, title} = this.props.item;
+      const { id, title } = this.props.item;
       return (
-        <Tooltip key={id} content={title} moveBy={{y: VERTICAL_PADDING}}>
+        <Tooltip key={id} content={title} moveBy={{ y: VERTICAL_PADDING }}>
           {this.withTooltipProperties(component, 'dynamicProperties')}
         </Tooltip>
       );
     }
 
     renderWrappedComponent() {
-      return <WrappedComponent {...this.props} initHasTooltip={el => this.initHasTooltip(el)}/>;
+      return (
+        <WrappedComponent
+          {...this.props}
+          initHasTooltip={el => this.initHasTooltip(el)}
+        />
+      );
     }
 
     render() {
@@ -54,7 +61,7 @@ const withTooltip = WrappedComponent => {
 
   Wrapper.propTypes = {
     type: TabPropTypes.type,
-    item: TabPropTypes.item.isRequired
+    item: TabPropTypes.item.isRequired,
   };
 
   return Wrapper;

--- a/packages/wix-storybook-utils/src/ui/Tabs/index.js
+++ b/packages/wix-storybook-utils/src/ui/Tabs/index.js
@@ -6,14 +6,14 @@ import styles from './styles.scss';
 
 const Tabs = props => (
   <div className={styles.container}>
-    <TabItems {...props}/>
+    <TabItems {...props} />
   </div>
 );
 
 Tabs.propTypes = {
   activeId: PropTypes.string,
   items: PropTypes.array,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 export default Tabs;

--- a/packages/wix-storybook-utils/src/ui/button.js
+++ b/packages/wix-storybook-utils/src/ui/button.js
@@ -1,4 +1,4 @@
-import {createElement} from 'react';
+import { createElement } from 'react';
 
 import styles from './styles.scss';
 
@@ -6,5 +6,5 @@ export default props =>
   createElement('button', {
     type: 'button',
     className: styles.button,
-    ...props
+    ...props,
   });

--- a/packages/wix-storybook-utils/src/ui/dropdown.js
+++ b/packages/wix-storybook-utils/src/ui/dropdown.js
@@ -15,7 +15,7 @@ const Dropdown = ({
   onSelect,
   onChange,
   placeholder,
-  onClear
+  onClear,
 }) => (
   <Downshift
     onChange={onSelect}
@@ -32,7 +32,7 @@ const Dropdown = ({
       highlightedIndex,
       selectedItem,
       openMenu,
-      clearSelection
+      clearSelection,
     }) => (
       <div className={styles.dropdown}>
         <Input
@@ -41,12 +41,12 @@ const Dropdown = ({
             placeholder,
             onChange: e => onChange(e.target.value),
             onClick: openMenu,
-            className: styles.dropdownInput
+            className: styles.dropdownInput,
           })}
         />
 
         <div className={styles.dropdownIcons}>
-          <DropDownArrowIcon size="10px" onClick={openMenu}/>
+          <DropDownArrowIcon size="10px" onClick={openMenu} />
 
           {onClear &&
             inputValue && (
@@ -72,8 +72,8 @@ const Dropdown = ({
                     [styles.dropdownMenuItemSelected]:
                       selectedItem && selectedItem.id === option.id,
                     [styles.dropdownMenuItemHighlighted]:
-                      highlightedIndex === index
-                  })
+                      highlightedIndex === index,
+                  }),
                 })}
               >
                 {option.value}
@@ -92,7 +92,7 @@ Dropdown.propTypes = {
   onSelect: PropTypes.func,
   onChange: PropTypes.func,
   onClear: PropTypes.func,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
 };
 
 export default Dropdown;

--- a/packages/wix-storybook-utils/src/ui/heading.js
+++ b/packages/wix-storybook-utils/src/ui/heading.js
@@ -1,9 +1,9 @@
-import {createElement} from 'react';
+import { createElement } from 'react';
 
 import styles from './styles.scss';
 
 export default props =>
   createElement('h2', {
     className: styles.heading,
-    ...props
+    ...props,
   });

--- a/packages/wix-storybook-utils/src/ui/input.js
+++ b/packages/wix-storybook-utils/src/ui/input.js
@@ -1,4 +1,4 @@
-import {createElement} from 'react';
+import { createElement } from 'react';
 import classnames from 'classnames';
 
 import styles from './styles.scss';
@@ -6,5 +6,5 @@ import styles from './styles.scss';
 export default props =>
   createElement('input', {
     ...props,
-    className: classnames(styles.input, props.className)
+    className: classnames(styles.input, props.className),
   });

--- a/packages/wix-storybook-utils/src/ui/radio-group.js
+++ b/packages/wix-storybook-utils/src/ui/radio-group.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 
 import styles from './styles.scss';
 
-const RadioGroup = ({value, radios, onChange}) => (
+const RadioGroup = ({ value, radios, onChange }) => (
   <div className={styles.radioGroup}>
     {radios.map(radio => (
       <label key={radio.id} className={styles.radio}>
@@ -15,7 +15,7 @@ const RadioGroup = ({value, radios, onChange}) => (
         />
         <div
           className={classnames(styles.radioBubble, {
-            [styles.radioBubbleChecked]: value === radio.id
+            [styles.radioBubbleChecked]: value === radio.id,
           })}
         />
         <div>{radio.value}</div>
@@ -27,7 +27,7 @@ const RadioGroup = ({value, radios, onChange}) => (
 RadioGroup.propTypes = {
   value: PropTypes.any,
   radios: PropTypes.arrayOf(PropTypes.any),
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
 };
 
 export default RadioGroup;

--- a/packages/wix-storybook-utils/src/ui/toggle-switch.js
+++ b/packages/wix-storybook-utils/src/ui/toggle-switch.js
@@ -1,33 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import {ToggleOff, ToggleOn} from 'wix-ui-icons-common/system';
+import { ToggleOff, ToggleOn } from 'wix-ui-icons-common/system';
 
 import styles from './styles.scss';
 
-const ToggleSwitch = ({checked, size, onChange}) => (
+const ToggleSwitch = ({ checked, size, onChange }) => (
   <div
     className={classnames(styles.toggleSwitch, {
       [styles.toggleSwitchChecked]: checked,
-      [styles.toggleSwitchSmall]: size === 'small'
+      [styles.toggleSwitchSmall]: size === 'small',
     })}
     onClick={() => onChange(!checked)}
   >
-    <div className={styles.toggleSwitchTrack}/>
+    <div className={styles.toggleSwitchTrack} />
     <div className={styles.toggleSwitchKnob}>
-      {checked ? <ToggleOn/> : <ToggleOff/>}
+      {checked ? <ToggleOn /> : <ToggleOff />}
     </div>
   </div>
 );
 
 ToggleSwitch.defaultProps = {
-  size: 'normal'
+  size: 'normal',
 };
 
 ToggleSwitch.propTypes = {
   checked: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'normal']),
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
 };
 
 export default ToggleSwitch;

--- a/packages/wix-storybook-utils/tsconfig.json
+++ b/packages/wix-storybook-utils/tsconfig.json
@@ -16,7 +16,6 @@
   "include": [
     "./src/**/*.ts",
     "./src/**/*.js",
-    "./src/**/*.tsx",
-    "./src/typings/*.d.ts"
+    "./src/**/*.tsx"
   ]
 }

--- a/packages/wix-storybook-utils/tslint.json
+++ b/packages/wix-storybook-utils/tslint.json
@@ -1,9 +1,5 @@
 {
-  "extends": [
-    "tslint-config-wix",
-    "tslint-react",
-    "tslint-config-prettier"
-  ],
+  "extends": "tslint-config-yoshi",
   "rules": {
     "comma-dangle": ["error", "never"],
     "jsx-no-multiline-js": false,


### PR DESCRIPTION
since we're aiming to do more work on wix-storybook-utils which will
include refactorings as well as new features (some storypage redesign,
autotestkit and similar) i figure it should support typescript (with
`allowJs` to not require updating everything for now) and yoshi 3

this PR upgrades to yoshi 3:

* prettier changes
* tslint changes
* node-sass, sass-loader & resolve-url-loader (for until i get rid of sass)

should have no behavioural changes but i'll keep an eye on it