### PR TITLE
wix-storybook-utils: Fix error overflow in compact mode

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -87,7 +87,7 @@ export default class LiveCodeExample extends Component {
             <ToggleSwitch
               size="small"
               checked={isRtl}
-              onChange={e => this.onToggleRtl(e.target.checked)}
+              onChange={this.onToggleRtl}
             />
           </div>
 
@@ -96,7 +96,7 @@ export default class LiveCodeExample extends Component {
             <ToggleSwitch
               size="small"
               checked={isDarkBackground}
-              onChange={e => this.onToggleBackground(e.target.checked)}
+              onChange={this.onToggleBackground}
             />
           </div>
 

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -222,6 +222,7 @@
 
 .error {
   position: absolute;
+  top: 0;
   bottom: 0;
   left: 0;
   right: 0;
@@ -231,7 +232,6 @@
   white-space: pre;
 
   .compact & {
-    top: 0;
     overflow: auto;
     border-radius: 6px;
   }

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -232,7 +232,7 @@
 
   .compact & {
     top: 0;
-    height: 100%;
     overflow: auto;
+    border-radius: 6px;
   }
 }


### PR DESCRIPTION
As a result of https://github.com/wix/wix-ui/pull/835, the error message styles got messed up.

The error overflows the preview container (notice how the its not got `border-radius`):

![screen shot 2018-10-31 at 13 36 46](https://user-images.githubusercontent.com/11786506/47785708-300b5900-dd12-11e8-84f4-ace8dcf33954.png)
---
![screen shot 2018-10-31 at 13 36 38](https://user-images.githubusercontent.com/11786506/47785765-56c98f80-dd12-11e8-8e32-6c92a787f1e0.png)

This PR fixes that issue.