### PR TITLE
fix(AutoExampleDriver): use correct reference

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
+++ b/packages/wix-storybook-utils/src/AutoExample/protractor.driver.js
@@ -40,7 +40,7 @@ module.exports = {
 
       const args = Object.keys(componentProps).reduce((allProps, key) => {
         const { parser } = parsers.find(({ rule }) => rule(allProps[key]));
-        props[key] = parser(allProps[key]);
+        allProps[key] = parser(allProps[key]);
         return allProps;
       }, componentProps);
 


### PR DESCRIPTION
this one was missed when fixing shadowed name tslint error