### PR TITLE
Stricted stylable import path

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -24,7 +24,7 @@
     "url": "git+https://github.com/wix/wix-ui.git"
   },
   "scripts": {
-    "build": "yoshi build && npm run generate-stylable-index && npm run transpile-mixins && npm run import-path && build-storybook",
+    "build": "yoshi build && npm run generate-stylable-components && npm run transpile-mixins && npm run import-path && build-storybook",
     "pr-postbuild": "npm install teamcity-surge-autorelease@^1.0.0 --no-save && teamcity-surge-autorelease",
     "test": "npm run test:unit && npm run test:e2e && npm run sanity && npm run a11y",
     "posttest": "npm run lint",
@@ -42,7 +42,7 @@
     "storybook": "start-storybook -p 6006",
     "import-path": "node scripts/import-path.js && node scripts/create-drivers-export.js",
     "transpile-mixins": "babel src/mixins -d dist/src/mixins",
-    "generate-stylable-index": "stc --srcDir=\"./dist/src\" --diagnostics --indexFile=index.st.css",
+    "generate-stylable-components": "stc --srcDir=\"./dist/src/components\" --diagnostics --indexFile=index.st.css",
     "test:browser": "wix-ui-mocha-runner"
   },
   "dependencies": {


### PR DESCRIPTION
This PR fixes issue when we can't create multiple file names with the same name. I have only narrow down the folder which we need to expose. Which is `components`. Although we have open question if we should expose theme st.css files too.

Previously we exposed `Focusable.st.css` file, but from `wix-ui-backoffice` I see that these are imported from `dist/src/hocs` anyway so we don't need to target those.

Tested dependencies:
 [x] wix-ui-backoffice
 [x] wix-ui-adi