### PR TITLE
wix-storybook-utils - Add componentWrapper config

### DIFF
--- a/packages/wix-storybook-utils/docs/usage.md
+++ b/packages/wix-storybook-utils/docs/usage.md
@@ -351,3 +351,20 @@ export default {
   }
   ```
 </details>
+
+---
+
+<details>
+
+  <summary>`componentWrapper` - `func`</summary>
+
+  A render function for the component (in the Preview). Typicaly this function can wrap the component in something usefull like a theme className if needed.
+  Signature: ({component}) => JSXElement
+
+  ```js
+  export default {
+    componentWrapper: ({component})=> <div className="theme">{component}</div>
+  }
+  ```
+
+</details>

--- a/packages/wix-storybook-utils/src/AutoExample/components/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { Cell } from '../../ui/Layout';
+import {Cell} from '../../ui/Layout';
 import UIInput from '../../ui/input';
 import ToggleSwitch from '../../ui/toggle-switch';
 import Heading from '../../ui/heading';
@@ -19,41 +19,48 @@ const Preview = ({
   onToggleRtl,
   isDarkBackground,
   onToggleBackground,
-}) => (
-  <Cell span={6}>
-    <div className={styles.title}>
-      <Heading>Preview</Heading>
+  className
+}) => {
+  const wrapperProps = {
+    className: classnames(styles.preview, className, {
+      rtl: isRtl,
+      [styles.darkPreview]: isDarkBackground,
+    }),
+    ...(isRtl ? {dir: 'rtl'} : {}),
+  }
 
-      <div className={styles.previewControls}>
-        <div className={styles.previewControl}>
-          Imitate RTL:&nbsp;
+  return (
+
+    <Cell span={6}>
+      <div className={styles.title}>
+        <Heading>Preview</Heading>
+
+        <div className={styles.previewControls}>
+          <div className={styles.previewControl}>
+            Imitate RTL:&nbsp;
           <ToggleSwitch size="small" checked={isRtl} onChange={onToggleRtl} />
-        </div>
+          </div>
 
-        <div className={styles.previewControl}>
-          Dark Background:&nbsp;
+          <div className={styles.previewControl}>
+            Dark Background:&nbsp;
           <ToggleSwitch
-            size="small"
-            checked={isDarkBackground}
-            onChange={onToggleBackground}
-          />
+              size="small"
+              checked={isDarkBackground}
+              onChange={onToggleBackground}
+            />
+          </div>
         </div>
       </div>
-    </div>
 
-    <div
-      {...{
-        className: classnames(styles.preview, {
-          rtl: isRtl,
-          [styles.darkPreview]: isDarkBackground,
-        }),
-        ...(isRtl ? { dir: 'rtl' } : {}),
-      }}
-    >
-      {children}
-    </div>
-  </Cell>
-);
+      <div
+        {...wrapperProps}
+      >
+        {children}
+      </div>
+    </Cell>
+  )
+}
+
 
 Preview.propTypes = {
   children: PropTypes.node,
@@ -63,7 +70,7 @@ Preview.propTypes = {
   onToggleBackground: PropTypes.func,
 };
 
-const Toggle = ({ value, onChange }) => (
+const Toggle = ({value, onChange}) => (
   <ToggleSwitch checked={value} onChange={onChange} />
 );
 
@@ -72,10 +79,10 @@ Toggle.propTypes = {
   onChange: PropTypes.func,
 };
 
-const Input = ({ value: inputValue, onChange, defaultValue, ...props }) => (
+const Input = ({value: inputValue, onChange, defaultValue, ...props}) => (
   <UIInput
     value={inputValue}
-    onChange={({ target: { value } }) => onChange(value)}
+    onChange={({target: {value}}) => onChange(value)}
     placeholder={defaultValue}
     {...props}
   />
@@ -87,7 +94,7 @@ Input.propTypes = {
   onChange: PropTypes.func,
 };
 
-const Code = ({ component }) => (
+const Code = ({component}) => (
   <Cell>
     <div className={styles.title}>
       <Heading>Code</Heading>
@@ -101,4 +108,4 @@ Code.propTypes = {
   component: PropTypes.node.isRequired,
 };
 
-export { Option, Preview, Toggle, Input, List, Code };
+export {Option, Preview, Toggle, Input, List, Code};

--- a/packages/wix-storybook-utils/src/AutoExample/components/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/index.js
@@ -19,42 +19,41 @@ const Preview = ({
   onToggleRtl,
   isDarkBackground,
   onToggleBackground,
-  className,
-}) => {
-  const wrapperProps = {
-    className: classnames(styles.preview, className, {
-      rtl: isRtl,
-      [styles.darkPreview]: isDarkBackground,
-    }),
-    ...(isRtl ? { dir: 'rtl' } : {}),
-  };
+}) => (
+  <Cell span={6}>
+    <div className={styles.title}>
+      <Heading>Preview</Heading>
 
-  return (
-    <Cell span={6}>
-      <div className={styles.title}>
-        <Heading>Preview</Heading>
+      <div className={styles.previewControls}>
+        <div className={styles.previewControl}>
+          Imitate RTL:&nbsp;
+          <ToggleSwitch size="small" checked={isRtl} onChange={onToggleRtl} />
+        </div>
 
-        <div className={styles.previewControls}>
-          <div className={styles.previewControl}>
-            Imitate RTL:&nbsp;
-            <ToggleSwitch size="small" checked={isRtl} onChange={onToggleRtl} />
-          </div>
-
-          <div className={styles.previewControl}>
-            Dark Background:&nbsp;
-            <ToggleSwitch
-              size="small"
-              checked={isDarkBackground}
-              onChange={onToggleBackground}
-            />
-          </div>
+        <div className={styles.previewControl}>
+          Dark Background:&nbsp;
+          <ToggleSwitch
+            size="small"
+            checked={isDarkBackground}
+            onChange={onToggleBackground}
+          />
         </div>
       </div>
+    </div>
 
-      <div {...wrapperProps}>{children}</div>
-    </Cell>
-  );
-};
+    <div
+      {...{
+        className: classnames(styles.preview, {
+          rtl: isRtl,
+          [styles.darkPreview]: isDarkBackground,
+        }),
+        ...(isRtl ? { dir: 'rtl' } : {}),
+      }}
+    >
+      {children}
+    </div>
+  </Cell>
+);
 
 Preview.propTypes = {
   children: PropTypes.node,

--- a/packages/wix-storybook-utils/src/AutoExample/components/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import {Cell} from '../../ui/Layout';
+import { Cell } from '../../ui/Layout';
 import UIInput from '../../ui/input';
 import ToggleSwitch from '../../ui/toggle-switch';
 import Heading from '../../ui/heading';
@@ -19,18 +19,17 @@ const Preview = ({
   onToggleRtl,
   isDarkBackground,
   onToggleBackground,
-  className
+  className,
 }) => {
   const wrapperProps = {
     className: classnames(styles.preview, className, {
       rtl: isRtl,
       [styles.darkPreview]: isDarkBackground,
     }),
-    ...(isRtl ? {dir: 'rtl'} : {}),
-  }
+    ...(isRtl ? { dir: 'rtl' } : {}),
+  };
 
   return (
-
     <Cell span={6}>
       <div className={styles.title}>
         <Heading>Preview</Heading>
@@ -38,12 +37,12 @@ const Preview = ({
         <div className={styles.previewControls}>
           <div className={styles.previewControl}>
             Imitate RTL:&nbsp;
-          <ToggleSwitch size="small" checked={isRtl} onChange={onToggleRtl} />
+            <ToggleSwitch size="small" checked={isRtl} onChange={onToggleRtl} />
           </div>
 
           <div className={styles.previewControl}>
             Dark Background:&nbsp;
-          <ToggleSwitch
+            <ToggleSwitch
               size="small"
               checked={isDarkBackground}
               onChange={onToggleBackground}
@@ -52,15 +51,10 @@ const Preview = ({
         </div>
       </div>
 
-      <div
-        {...wrapperProps}
-      >
-        {children}
-      </div>
+      <div {...wrapperProps}>{children}</div>
     </Cell>
-  )
-}
-
+  );
+};
 
 Preview.propTypes = {
   children: PropTypes.node,
@@ -70,7 +64,7 @@ Preview.propTypes = {
   onToggleBackground: PropTypes.func,
 };
 
-const Toggle = ({value, onChange}) => (
+const Toggle = ({ value, onChange }) => (
   <ToggleSwitch checked={value} onChange={onChange} />
 );
 
@@ -79,10 +73,10 @@ Toggle.propTypes = {
   onChange: PropTypes.func,
 };
 
-const Input = ({value: inputValue, onChange, defaultValue, ...props}) => (
+const Input = ({ value: inputValue, onChange, defaultValue, ...props }) => (
   <UIInput
     value={inputValue}
-    onChange={({target: {value}}) => onChange(value)}
+    onChange={({ target: { value } }) => onChange(value)}
     placeholder={defaultValue}
     {...props}
   />
@@ -94,7 +88,7 @@ Input.propTypes = {
   onChange: PropTypes.func,
 };
 
-const Code = ({component}) => (
+const Code = ({ component }) => (
   <Cell>
     <div className={styles.title}>
       <Heading>Code</Heading>
@@ -108,4 +102,4 @@ Code.propTypes = {
   component: PropTypes.node.isRequired,
 };
 
-export {Option, Preview, Toggle, Input, List, Code};
+export { Option, Preview, Toggle, Input, List, Code };

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -301,7 +301,6 @@ export default class extends Component {
     },
   };
 
-
   render() {
     const functionExampleProps = Object.keys(this.props.exampleProps).filter(
       prop =>
@@ -340,11 +339,13 @@ export default class extends Component {
       return React.createElement(this.props.component, componentProps);
     }
     const component = React.createElement(this.props.component, componentProps);
-    
-    const componentWrapper = this.props.componentWrapper? 
-    React.cloneElement(this.props.componentWrapper({ component }), {'data-hook': 'wrapper'}): 
-    undefined;
-    
+
+    const componentWrapper = this.props.componentWrapper
+      ? React.cloneElement(this.props.componentWrapper({ component }), {
+          'data-hook': 'wrapper',
+        })
+      : undefined;
+
     return (
       <Layout dataHook="auto-example">
         <Cell span={6}>

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -1,12 +1,12 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
 import styles from './styles.scss';
 import NO_VALUE_TYPE from './no-value-type';
 import categorizeProps from './categorize-props';
 
-import { Option, Preview, Code, Toggle, Input, List } from './components';
-import { Layout, Cell } from '../ui/Layout';
+import {Option, Preview, Code, Toggle, Input, List} from './components';
+import {Layout, Cell} from '../ui/Layout';
 import SectionCollapse from './components/section-collapse';
 
 import matchFuncProp from './utils/match-func-prop';
@@ -76,6 +76,9 @@ export default class extends Component {
      * ```
      */
     componentProps: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+
+    /** A render function for the component (in the Preview). Typicaly this function can wrap the component in something usefull like a className which is needed. ({component}) => JSXElement */
+    componentWrapper: PropTypes.func,
     exampleProps: PropTypes.object,
 
     /** when true, display only component preview without interactive props nor code example */
@@ -121,17 +124,17 @@ export default class extends Component {
 
     this._categorizedProps = Object.entries(
       categorizeProps(
-        { ...this.preparedComponentProps, ...this.parsedComponent.props },
+        {...this.preparedComponentProps, ...this.parsedComponent.props},
         this.propsCategories,
       ),
     )
       .map(([, category]) => category)
       .sort(
-        ({ order: aOrder = -1 }, { order: bOrder = -1 }) => aOrder - bOrder,
+        ({order: aOrder = -1}, {order: bOrder = -1}) => aOrder - bOrder,
       );
   }
 
-  resetState = () => this.setState({ propsState: this._initialPropsState });
+  resetState = () => this.setState({propsState: this._initialPropsState});
 
   componentWillReceiveProps(nextProps) {
     this.setState({
@@ -145,24 +148,24 @@ export default class extends Component {
   prepareComponentProps = props =>
     typeof props === 'function'
       ? props(
-          // setState
-          componentProps =>
-            this.setState({
-              propsState: { ...this.state.propsState, ...componentProps },
-            }),
+        // setState
+        componentProps =>
+          this.setState({
+            propsState: {...this.state.propsState, ...componentProps},
+          }),
 
-          // getState
-          () => this.state.propsState || {},
-        )
+        // getState
+        () => this.state.propsState || {},
+      )
       : props;
 
   setProp = (key, value) => {
     if (value === NO_VALUE_TYPE) {
       // eslint-disable-next-line no-unused-vars
-      const { [key]: deletedKey, ...propsState } = this.state.propsState;
-      this.setState({ propsState });
+      const {[key]: deletedKey, ...propsState} = this.state.propsState;
+      this.setState({propsState});
     } else {
-      this.setState({ propsState: { ...this.state.propsState, [key]: value } });
+      this.setState({propsState: {...this.state.propsState, [key]: value}});
     }
   };
 
@@ -170,7 +173,7 @@ export default class extends Component {
     {
       types: ['func', /event/, /\) => void$/],
 
-      controller: ({ propKey }) => {
+      controller: ({propKey}) => {
         let classNames = styles.example;
 
         if (this.state.funcAnimate[propKey]) {
@@ -178,7 +181,7 @@ export default class extends Component {
           setTimeout(
             () =>
               this.setState({
-                funcAnimate: { ...this.state.funcAnimate, [propKey]: false },
+                funcAnimate: {...this.state.funcAnimate, [propKey]: false},
               }),
             2000,
           );
@@ -201,8 +204,8 @@ export default class extends Component {
 
     {
       types: ['enum'],
-      controller: ({ type }) => (
-        <List values={type.value.map(({ value }) => stripQuotes(value))} />
+      controller: ({type}) => (
+        <List values={type.value.map(({value}) => stripQuotes(value))} />
       ),
     },
 
@@ -225,18 +228,18 @@ export default class extends Component {
       return <List values={this.props.exampleProps[propKey]} />;
     }
 
-    const propControllerCandidate = this.propControllers.find(({ types }) =>
+    const propControllerCandidate = this.propControllers.find(({types}) =>
       types.some(t => ensureRegexp(t).test(type.name)),
     );
 
     return propControllerCandidate && propControllerCandidate.controller ? (
-      propControllerCandidate.controller({ propKey, type })
+      propControllerCandidate.controller({propKey, type})
     ) : (
-      <Input />
-    );
+        <Input />
+      );
   };
 
-  renderPropControllers = ({ props, allProps }) => {
+  renderPropControllers = ({props, allProps}) => {
     return Object.entries(props).map(([key, prop]) => (
       <Option
         key={key}
@@ -317,7 +320,7 @@ export default class extends Component {
               ...this.state.funcValues,
               [prop]: this.props.exampleProps[prop](...rest),
             },
-            funcAnimate: { ...this.state.funcAnimate, [prop]: true },
+            funcAnimate: {...this.state.funcAnimate, [prop]: true},
           });
         };
         return acc;
@@ -335,26 +338,27 @@ export default class extends Component {
     if (!this.props.isInteractive) {
       return React.createElement(this.props.component, componentProps);
     }
+    const component = React.createElement(this.props.component, componentProps);
 
     return (
       <Layout dataHook="auto-example">
         <Cell span={6}>
           {this._categorizedProps.reduce(
-            (components, { title, isOpen, props }, i) => {
+            (components, {title, isOpen, props}, i) => {
               const renderablePropControllers = this.renderPropControllers({
                 props,
                 allProps: componentProps, // TODO: ideally this should not be here
-              }).filter(({ props: { children } }) => children);
+              }).filter(({props: {children}}) => children);
 
               return renderablePropControllers.length
                 ? components.concat(
-                    React.createElement(SectionCollapse, {
-                      key: title,
-                      title,
-                      isOpen: isOpen || i === 0,
-                      children: renderablePropControllers,
-                    }),
-                  )
+                  React.createElement(SectionCollapse, {
+                    key: title,
+                    title,
+                    isOpen: isOpen || i === 0,
+                    children: renderablePropControllers,
+                  }),
+                )
                 : components;
             },
             [],
@@ -364,11 +368,12 @@ export default class extends Component {
         <Preview
           isRtl={this.state.isRtl}
           isDarkBackground={this.state.isDarkBackground}
-          onToggleRtl={isRtl => this.setState({ isRtl })}
+          onToggleRtl={isRtl => this.setState({isRtl})}
           onToggleBackground={isDarkBackground =>
-            this.setState({ isDarkBackground })
+            this.setState({isDarkBackground})
           }
-          children={React.createElement(this.props.component, componentProps)}
+          className={wrapperClassName}
+          children={componentWrapper ? componentWrapper({component}) : component}
         />
 
         {this.props.codeExample && (

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -342,7 +342,7 @@ export default class extends Component {
 
     const componentWrapper = this.props.componentWrapper
       ? React.cloneElement(this.props.componentWrapper({ component }), {
-          'data-hook': 'wrapper',
+          'data-hook': 'componentWrapper',
         })
       : undefined;
 

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -301,6 +301,7 @@ export default class extends Component {
     },
   };
 
+
   render() {
     const functionExampleProps = Object.keys(this.props.exampleProps).filter(
       prop =>
@@ -339,7 +340,11 @@ export default class extends Component {
       return React.createElement(this.props.component, componentProps);
     }
     const component = React.createElement(this.props.component, componentProps);
-
+    
+    const componentWrapper = this.props.componentWrapper? 
+    React.cloneElement(this.props.componentWrapper({ component }), {'data-hook': 'wrapper'}): 
+    undefined;
+    
     return (
       <Layout dataHook="auto-example">
         <Cell span={6}>
@@ -372,10 +377,7 @@ export default class extends Component {
           onToggleBackground={isDarkBackground =>
             this.setState({ isDarkBackground })
           }
-          className={wrapperClassName}
-          children={
-            componentWrapper ? componentWrapper({ component }) : component
-          }
+          children={componentWrapper || component}
         />
 
         {this.props.codeExample && (

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -1,12 +1,12 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import styles from './styles.scss';
 import NO_VALUE_TYPE from './no-value-type';
 import categorizeProps from './categorize-props';
 
-import {Option, Preview, Code, Toggle, Input, List} from './components';
-import {Layout, Cell} from '../ui/Layout';
+import { Option, Preview, Code, Toggle, Input, List } from './components';
+import { Layout, Cell } from '../ui/Layout';
 import SectionCollapse from './components/section-collapse';
 
 import matchFuncProp from './utils/match-func-prop';
@@ -124,17 +124,17 @@ export default class extends Component {
 
     this._categorizedProps = Object.entries(
       categorizeProps(
-        {...this.preparedComponentProps, ...this.parsedComponent.props},
+        { ...this.preparedComponentProps, ...this.parsedComponent.props },
         this.propsCategories,
       ),
     )
       .map(([, category]) => category)
       .sort(
-        ({order: aOrder = -1}, {order: bOrder = -1}) => aOrder - bOrder,
+        ({ order: aOrder = -1 }, { order: bOrder = -1 }) => aOrder - bOrder,
       );
   }
 
-  resetState = () => this.setState({propsState: this._initialPropsState});
+  resetState = () => this.setState({ propsState: this._initialPropsState });
 
   componentWillReceiveProps(nextProps) {
     this.setState({
@@ -148,24 +148,24 @@ export default class extends Component {
   prepareComponentProps = props =>
     typeof props === 'function'
       ? props(
-        // setState
-        componentProps =>
-          this.setState({
-            propsState: {...this.state.propsState, ...componentProps},
-          }),
+          // setState
+          componentProps =>
+            this.setState({
+              propsState: { ...this.state.propsState, ...componentProps },
+            }),
 
-        // getState
-        () => this.state.propsState || {},
-      )
+          // getState
+          () => this.state.propsState || {},
+        )
       : props;
 
   setProp = (key, value) => {
     if (value === NO_VALUE_TYPE) {
       // eslint-disable-next-line no-unused-vars
-      const {[key]: deletedKey, ...propsState} = this.state.propsState;
-      this.setState({propsState});
+      const { [key]: deletedKey, ...propsState } = this.state.propsState;
+      this.setState({ propsState });
     } else {
-      this.setState({propsState: {...this.state.propsState, [key]: value}});
+      this.setState({ propsState: { ...this.state.propsState, [key]: value } });
     }
   };
 
@@ -173,7 +173,7 @@ export default class extends Component {
     {
       types: ['func', /event/, /\) => void$/],
 
-      controller: ({propKey}) => {
+      controller: ({ propKey }) => {
         let classNames = styles.example;
 
         if (this.state.funcAnimate[propKey]) {
@@ -181,7 +181,7 @@ export default class extends Component {
           setTimeout(
             () =>
               this.setState({
-                funcAnimate: {...this.state.funcAnimate, [propKey]: false},
+                funcAnimate: { ...this.state.funcAnimate, [propKey]: false },
               }),
             2000,
           );
@@ -204,8 +204,8 @@ export default class extends Component {
 
     {
       types: ['enum'],
-      controller: ({type}) => (
-        <List values={type.value.map(({value}) => stripQuotes(value))} />
+      controller: ({ type }) => (
+        <List values={type.value.map(({ value }) => stripQuotes(value))} />
       ),
     },
 
@@ -228,18 +228,18 @@ export default class extends Component {
       return <List values={this.props.exampleProps[propKey]} />;
     }
 
-    const propControllerCandidate = this.propControllers.find(({types}) =>
+    const propControllerCandidate = this.propControllers.find(({ types }) =>
       types.some(t => ensureRegexp(t).test(type.name)),
     );
 
     return propControllerCandidate && propControllerCandidate.controller ? (
-      propControllerCandidate.controller({propKey, type})
+      propControllerCandidate.controller({ propKey, type })
     ) : (
-        <Input />
-      );
+      <Input />
+    );
   };
 
-  renderPropControllers = ({props, allProps}) => {
+  renderPropControllers = ({ props, allProps }) => {
     return Object.entries(props).map(([key, prop]) => (
       <Option
         key={key}
@@ -320,7 +320,7 @@ export default class extends Component {
               ...this.state.funcValues,
               [prop]: this.props.exampleProps[prop](...rest),
             },
-            funcAnimate: {...this.state.funcAnimate, [prop]: true},
+            funcAnimate: { ...this.state.funcAnimate, [prop]: true },
           });
         };
         return acc;
@@ -344,21 +344,21 @@ export default class extends Component {
       <Layout dataHook="auto-example">
         <Cell span={6}>
           {this._categorizedProps.reduce(
-            (components, {title, isOpen, props}, i) => {
+            (components, { title, isOpen, props }, i) => {
               const renderablePropControllers = this.renderPropControllers({
                 props,
                 allProps: componentProps, // TODO: ideally this should not be here
-              }).filter(({props: {children}}) => children);
+              }).filter(({ props: { children } }) => children);
 
               return renderablePropControllers.length
                 ? components.concat(
-                  React.createElement(SectionCollapse, {
-                    key: title,
-                    title,
-                    isOpen: isOpen || i === 0,
-                    children: renderablePropControllers,
-                  }),
-                )
+                    React.createElement(SectionCollapse, {
+                      key: title,
+                      title,
+                      isOpen: isOpen || i === 0,
+                      children: renderablePropControllers,
+                    }),
+                  )
                 : components;
             },
             [],
@@ -368,12 +368,14 @@ export default class extends Component {
         <Preview
           isRtl={this.state.isRtl}
           isDarkBackground={this.state.isDarkBackground}
-          onToggleRtl={isRtl => this.setState({isRtl})}
+          onToggleRtl={isRtl => this.setState({ isRtl })}
           onToggleBackground={isDarkBackground =>
-            this.setState({isDarkBackground})
+            this.setState({ isDarkBackground })
           }
           className={wrapperClassName}
-          children={componentWrapper ? componentWrapper({component}) : component}
+          children={
+            componentWrapper ? componentWrapper({ component }) : component
+          }
         />
 
         {this.props.codeExample && (

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -102,8 +102,8 @@ describe('AutoExample', () => {
     it('should render wrapper when given', () => {
       const testkit = new Testkit(AutoExample);
       testkit.when.created({
-        componentWrapper: ({ componentWrapper }) => (
-          <div className="classname">{componentWrapper}</div>
+        componentWrapper: ({ component }) => (
+          <div className="classname">{component}</div>
         ),
       });
       expect(testkit.get.exists('[data-hook*="wrapper"]')).toBeTruthy();

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -115,7 +115,7 @@ describe('AutoExample', () => {
     it('should not render wrapper when not given', () => {
       const testkit = new Testkit(AutoExample);
       testkit.when.created();
-      expect(testkit.get.exists('[data-hook*="wrapper"]')).toBeFalsy();
+      expect(testkit.get.exists('[data-hook*="componentWrapper"]')).toBeFalsy();
     });
   });
 });

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -1,4 +1,5 @@
-import AutoExample from './';
+import React from 'react';
+import AutoExample from '.';
 import Testkit from './testkit';
 
 describe('AutoExample', () => {
@@ -43,7 +44,7 @@ describe('AutoExample', () => {
       });
 
       // expeting only 1 because others should be collapsed
-      expect(testkit.get.options().length).toEqual(1);
+      expect(testkit.get.options()).toHaveLength(1);
     });
   });
 
@@ -93,7 +94,24 @@ describe('AutoExample', () => {
       testkit.when.created({
         codeExample: false,
       });
-      expect(testkit.get.codeBlock().length).toEqual(0);
+      expect(testkit.get.codeBlock()).toHaveLength(0);
+    });
+  });
+
+  describe('componentWrapper', () => {
+    it('should render wrapper when given', () => {
+      const testkit = new Testkit(AutoExample);
+      testkit.when.created({
+        componentWrapper: ({ componentWrapper }) => (
+          <div className="aha">{componentWrapper}</div>
+        ),
+      });
+      expect(testkit.get.exists('[data-hook*="wrapper"]')).toBeTruthy();
+    });
+    it('should not render wrapper when not given', () => {
+      const testkit = new Testkit(AutoExample);
+      testkit.when.created();
+      expect(testkit.get.exists('[data-hook*="wrapper"]')).toBeFalsy();
     });
   });
 });

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -100,13 +100,17 @@ describe('AutoExample', () => {
 
   describe('componentWrapper', () => {
     it('should render wrapper when given', () => {
+      const theme = 'componentWrapper-theme';
       const testkit = new Testkit(AutoExample);
       testkit.when.created({
         componentWrapper: ({ component }) => (
-          <div className="classname">{component}</div>
+          <div className={theme}>{component}</div>
         ),
       });
-      expect(testkit.get.exists('[data-hook*="wrapper"]')).toBeTruthy();
+      expect(
+        testkit.get.exists('[data-hook*="componentWrapper"]'),
+      ).toBeTruthy();
+      expect(testkit.get.exists(`[className*="${theme}"]`)).toBeTruthy();
     });
     it('should not render wrapper when not given', () => {
       const testkit = new Testkit(AutoExample);

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -103,7 +103,7 @@ describe('AutoExample', () => {
       const testkit = new Testkit(AutoExample);
       testkit.when.created({
         componentWrapper: ({ componentWrapper }) => (
-          <div className="aha">{componentWrapper}</div>
+          <div className="classname">{componentWrapper}</div>
         ),
       });
       expect(testkit.get.exists('[data-hook*="wrapper"]')).toBeTruthy();

--- a/packages/wix-storybook-utils/src/AutoExample/testkit.js
+++ b/packages/wix-storybook-utils/src/AutoExample/testkit.js
@@ -17,5 +17,6 @@ export default class AutoExampleTestkit {
   get = {
     options: () => this.component.find(Option),
     codeBlock: () => this.component.find(Code),
+    exists: selector => this.component.exists(selector),
   };
 }

--- a/packages/wix-storybook-utils/tsconfig.json
+++ b/packages/wix-storybook-utils/tsconfig.json
@@ -13,9 +13,5 @@
     "allowJs": true,
     "esModuleInterop": true
   },
-  "include": [
-    "./src/**/*.ts",
-    "./src/**/*.js",
-    "./src/**/*.tsx"
-  ]
+  "include": ["./src/**/*.ts", "./src/**/*.js", "./src/**/*.tsx"]
 }


### PR DESCRIPTION
@argshook do you agree with this?


A AutoExample Preview config to allow adding backoffice theme class to WSR components.

>Sorry for the formatting changes, my lint rules are probably not aligned.

A render function for the component (in the Preview). Typicaly this function can wrap the component in something usefull like a theme className if needed.
  Signature: ({component}) => JSXElement

  ```js
  export default {
    componentWrapper: ({component})=> <div className="theme">{component}</div>
  }
  ```
