### PR TITLE
`<Avatar/>` - Update spec

### DIFF
--- a/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
+++ b/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
@@ -86,14 +86,13 @@ export class ComponentsDemo extends React.Component<{}, {}>{
 | selector          | description                        | type | children pseudo-states |
 |:------------------|:-----------------------------------|:-----|:-----------------------|
 | root       | Allows styling the background      |      |                        |
-| ::image | Allows styling the image container |      |                        |
-| ::icon  | Allows styling the icon container  |      |                        |
-| ::text  | Allows styling the text            |     |                        |
+| ::content | Allows styling the content container |      |                        |
 
 ### States
 | state        | description                        | type |
 |:-------------|:-----------------------------------|:-----|
-| imgLoading     | true when the img is loading     | boolean    |
+| imgLoading   | true when the img is loading     | boolean  |
+| contentType  | Which content type is currently displayed | enum(image,icon,text) |
 
 ### Style Code Example
 

--- a/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
+++ b/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
@@ -38,6 +38,7 @@ name conversion examples:
 <br/> John Doe --> JD
 <br/> John H. Doe --> JHD
 <br/> John Hurley Stanley Kubrik Doe --> JHD
+<br/> john doe --> JD
 
 ## Technical Considerations
 
@@ -80,7 +81,7 @@ export class ComponentsDemo extends React.Component<{}, {}>{
 
 ## Style API
 
-#### Subcomponents (pseudo-elements)
+### Selectors (pseudo-elements)
 
 | selector          | description                        | type | children pseudo-states |
 |:------------------|:-----------------------------------|:-----|:-----------------------|
@@ -88,6 +89,11 @@ export class ComponentsDemo extends React.Component<{}, {}>{
 | ::image | Allows styling the image container |      |                        |
 | ::icon  | Allows styling the icon container  |      |                        |
 | ::text  | Allows styling the text            |     |                        |
+
+### States
+| state        | description                        | type |
+|:-------------|:-----------------------------------|:-----|
+| imgLoading     | true when the img is loading     | boolean    |
 
 ### Style Code Example
 


### PR DESCRIPTION
- Add initials capitalization
- Add `imgLoading` Style state
## Add `contentType` state 
- allows to style the `root` according to the display content type (image, icon, text)
- allows applying defaults for `root`, according to content Type.

Once we have this state, we don't need separate selectors for`::image`, `::icon`, `::text`, and they can be replaced with `::content`.

Note, that with `icon` content, the consumer passes a `ReactNode`, and we will have to append to it's `className` prop the `style.content` class, in order to support such a selector. (it won't be a pure render slot)

You could say that if the consumer passes `icon` node, they can do their own styling, 
but with having that in the Styling API, a design-system theme, can define styles for `:contentType(icon)::content`, so that the consumer doesn't have to worry about it.