### PR TITLE
`<ButtonNext/>` - Theme - change API to be prop object

### DIFF
--- a/packages/wix-ui-core/src/themes/backoffice/button/button-styles.spec.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/button/button-styles.spec.ts
@@ -1,28 +1,52 @@
-import button, {SizeType} from './button-styles';
+import {button, SizeType, SkinType} from './button-styles';
 
 describe('button-styles', () => {
 
   /*
-  * Gets the 2nd class name and strips aways the namespace
-  * That is, assumming the 1st class name is the 'button'
-  */
-  const getClassName = (classes) => classes.split(' ')[1].split('--')[1];
+   * Parses classes string, and constructs a class name array.
+   * Class names are stripped from their namespace prefix.
+   */
+  function parseClasses(classes: string) {
+    return classes.split(' ').map(c => c.split('--')[1]);
+  } 
+
+  function testProp<T extends string>(propName: string, values: T[], defaultValue?: T) {
+    values.forEach((value)=>{
+      const classes = button({[propName]: value});
+      if (value === defaultValue) {
+        expect(parseClasses(classes)).not.toContain(value);;
+      } else {
+        expect(parseClasses(classes)).toContain(value);
+      }
+    });
+  }
 
   it('button', () => {
     const classes = button();
-    expect(classes.split('--')[1]).toBe('button');
+    expect(parseClasses(classes)).toContain('button');
   });
   
   it('size', () => {
-    ['tiny', 'small', 'large'].forEach((size)=>{
-      const classes = button({size: size as SizeType});
-      expect(getClassName(classes)).toBe(size);
-    });
+    testProp<SizeType>('size', ['tiny', 'small', 'medium', 'large'], 'medium');
+  });
+
+  it('skin', () => {
+    testProp<SkinType>('skin', ['destructive', 'premium', 'transparent']);
   });
   
   it('light', ()=> {
     const classes = button({light: true});
-    expect(getClassName(classes)).toBe('light');
+    expect(parseClasses(classes)).toContain('light');
+  });
+
+  it('dark', ()=> {
+    const classes = button({dark: true});
+    expect(parseClasses(classes)).toContain('dark');
+  });
+
+  it('secondary', ()=> {
+    const classes = button({secondary: true});
+    expect(parseClasses(classes)).toContain('secondary');
   });
 })
 

--- a/packages/wix-ui-core/src/themes/backoffice/button/button-styles.spec.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/button/button-styles.spec.ts
@@ -1,0 +1,28 @@
+import button, {SizeType} from './button-styles';
+
+describe('button-styles', () => {
+
+  /*
+  * Gets the 2nd class name and strips aways the namespace
+  * That is, assumming the 1st class name is the 'button'
+  */
+  const getClassName = (classes) => classes.split(' ')[1].split('--')[1];
+
+  it('button', () => {
+    const classes = button();
+    expect(classes.split('--')[1]).toBe('button');
+  });
+  
+  it('size', () => {
+    ['tiny', 'small', 'large'].forEach((size)=>{
+      const classes = button({size: size as SizeType});
+      expect(getClassName(classes)).toBe(size);
+    });
+  });
+  
+  it('light', ()=> {
+    const classes = button({light: true});
+    expect(getClassName(classes)).toBe('light');
+  });
+})
+

--- a/packages/wix-ui-core/src/themes/backoffice/button/button-styles.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/button/button-styles.ts
@@ -1,21 +1,27 @@
 import style from './button.st.css';
 import classNames from 'classnames';
 
-export type SizeType = 'tiny' | 'small' | 'large';
+export type SizeType = 'tiny' | 'small' | 'medium' | 'large';
+export type SkinType = 'destructive' | 'premium' | 'transparent';
 
 interface ButtonStyleProps {
   size?: SizeType;
+  skin?: SkinType;
   light?: boolean;
+  dark?: boolean;
+  secondary?: boolean;
 }
 
 export function button(props : ButtonStyleProps = {}) : string {
   
-  const sizeClass = style[props.size];
   return classNames(
     style.button,
     {
       [style.light]: props.light,
+      [style.dark]: props.dark,
+      [style.secondary]: props.secondary,
     },
-    sizeClass
+    style[props.size],
+    style[props.skin]
   );
 }

--- a/packages/wix-ui-core/src/themes/backoffice/button/button-styles.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/button/button-styles.ts
@@ -1,0 +1,21 @@
+import style from './button.st.css';
+import classNames from 'classnames';
+
+export type SizeType = 'tiny' | 'small' | 'large';
+
+interface ButtonStyleProps {
+  size?: SizeType;
+  light?: boolean;
+}
+
+export function button(props : ButtonStyleProps = {}) : string {
+  
+  const sizeClass = style[props.size];
+  return classNames(
+    style.button,
+    {
+      [style.light]: props.light,
+    },
+    sizeClass
+  );
+}

--- a/packages/wix-ui-core/src/themes/backoffice/index.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/index.ts
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 
 import Avatar from './avatar/avatar.st.css';
-import ButtonNext from './button/button.st.css';
 import IconButton from './icon-button/icon-button.st.css';
 import TextButton from './text-button/text-button.st.css';
 import CloseButton from './close-button/close-button.st.css';
@@ -14,8 +13,9 @@ const getClassNames = (values, stylesheet, rootcls) => {
 
 export const avatar = (...values) =>
   getClassNames(values, Avatar, 'avatar');
-export const buttonNext = (...values) =>
-  getClassNames(values, ButtonNext, 'button');
+
+export {button as Button} from './button/button-styles';
+
 export const iconButton = (...values) =>
   getClassNames(values, IconButton, 'iconButton');
 export const textButton = (...values) =>

--- a/packages/wix-ui-core/src/themes/backoffice/index.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/index.ts
@@ -14,7 +14,7 @@ const getClassNames = (values, stylesheet, rootcls) => {
 export const avatar = (...values) =>
   getClassNames(values, Avatar, 'avatar');
 
-export {button as Button} from './button/button-styles';
+export {button} from './button/button-styles';
 
 export const iconButton = (...values) =>
   getClassNames(values, IconButton, 'iconButton');

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/button/button-affixes.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/button/button-affixes.tsx
@@ -5,19 +5,19 @@ import CodeShowcase from 'wix-storybook-utils/CodeShowcase';
 import { ButtonNext } from '../../../../../src/components/button-next';
 import {
   backofficeTheme,
-  buttonNext
+  button
 } from '../../../../../src/themes/backoffice';
 
 const example = `import * as React from "react";
-import { ButtonNext, buttonNext } from "wix-ui-core/button-next";
+import { ButtonNext, Button } from "wix-ui-core/button-next";
 import Add from "wix-ui-icons-common/Add";
 
 export default () => (
   <React.Fragment>
-    <ButtonNext className={buttonNext()} prefixIcon={<Add />}>
+    <ButtonNext className={Button()} prefixIcon={<Add />}>
       prefix
     </ButtonNext>
-    <ButtonNext className={buttonNext()} suffixIcon={<Add />}>
+    <ButtonNext className={Button()} suffixIcon={<Add />}>
       suffix
     </ButtonNext>
   </React.Fragment>
@@ -41,10 +41,10 @@ export const ButtonAffixes = ({ style }: ButtonAffixesProps) => (
     theme={backofficeTheme}
     description={description}
   >
-    <ButtonNext className={buttonNext()} prefixIcon={<Add />}>
+    <ButtonNext className={button()} prefixIcon={<Add />}>
       prefix
     </ButtonNext>
-    <ButtonNext className={buttonNext()} suffixIcon={<Add />}>
+    <ButtonNext className={button()} suffixIcon={<Add />}>
       suffix
     </ButtonNext>
   </CodeShowcase>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/button/button-primary.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/button/button-primary.tsx
@@ -3,7 +3,7 @@ import CodeShowcase from 'wix-storybook-utils/CodeShowcase';
 
 import { ButtonNext } from '../../../../../src/components/button-next';
 import {
-  buttonNext,
+  button,
   backofficeTheme
 } from '../../../../../src/themes/backoffice';
 
@@ -13,12 +13,12 @@ import { buttonNext } from "wix-ui-core/themes/backoffice";
 
 export default () => (
   <React.Fragment>
-    <ButtonNext className={buttonNext()}>default</ButtonNext>
-    <ButtonNext className={buttonNext("destructive")}>destructive</ButtonNext>
-    <ButtonNext className={buttonNext("premium")}>premium</ButtonNext>
-    <ButtonNext className={buttonNext("dark")}>dark</ButtonNext>
-    <ButtonNext className={buttonNext("light")}>light</ButtonNext>
-    <ButtonNext className={buttonNext("transparent")}>transparent</ButtonNext>
+    <ButtonNext className={button()}>default</ButtonNext>
+    <ButtonNext className={button({skin: "destructive"})}>destructive</ButtonNext>
+    <ButtonNext className={button({skin: "premium"})}>premium</ButtonNext>
+    <ButtonNext className={button({dark: true})}>dark</ButtonNext>
+    <ButtonNext className={button({light: true})}>light</ButtonNext>
+    <ButtonNext className={button({skin: "transparent"})}>transparent</ButtonNext>
   </React.Fragment>
 );`;
 
@@ -42,16 +42,16 @@ export const ButtonPrimary = ({ style }: ButtonPrimaryProps) => (
     description={description}
     theme={backofficeTheme}
   >
-    <ButtonNext className={buttonNext()}>standard</ButtonNext>
-    <ButtonNext className={buttonNext(`destructive`)}>destructive</ButtonNext>
-    <ButtonNext className={buttonNext(`premium`)}>premium</ButtonNext>
+    <ButtonNext className={button()}>standard</ButtonNext>
+    <ButtonNext className={button({skin: `destructive`})}>destructive</ButtonNext>
+    <ButtonNext className={button({skin: `premium`})}>premium</ButtonNext>
     <div
       style={{
         background: '#fef0ba',
         padding: '2px'
       }}
     >
-      <ButtonNext className={buttonNext(`dark`)}>dark</ButtonNext>
+      <ButtonNext className={button({dark: true})}>dark</ButtonNext>
     </div>
     <div
       style={{
@@ -59,7 +59,7 @@ export const ButtonPrimary = ({ style }: ButtonPrimaryProps) => (
         padding: '2px'
       }}
     >
-      <ButtonNext className={buttonNext(`light`)}>light</ButtonNext>
+      <ButtonNext className={button({light: true})}>light</ButtonNext>
     </div>
     <div
       style={{
@@ -67,7 +67,7 @@ export const ButtonPrimary = ({ style }: ButtonPrimaryProps) => (
         padding: '2px'
       }}
     >
-      <ButtonNext className={buttonNext(`transparent`)}>transparent</ButtonNext>
+      <ButtonNext className={button({skin: `transparent`})}>transparent</ButtonNext>
     </div>
   </CodeShowcase>
 );

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/button/button-secondary.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/button/button-secondary.tsx
@@ -3,20 +3,20 @@ import * as React from 'react';
 import CodeShowcase from 'wix-storybook-utils/CodeShowcase';
 import { ButtonNext } from '../../../../../src/components/button-next';
 import {
-  buttonNext,
+  button,
   backofficeTheme
 } from '../../../../../src/themes/backoffice';
 
 export const example = `import * as React from "react";
 import { ButtonNext } from "wix-ui-core/button-next";
-import { buttonNext } from "wix-ui-core/themes/backoffice";
+import { button } from "wix-ui-core/themes/backoffice";
 
-const secondary = buttonNext('secondary');
-const premiumSecondary = buttonNext('premium', 'secondary');
-const darkSecondary = buttonNext('dark', 'secondary');
-const lightSecondary = buttonNext('light', 'secondary');
-const destructiveSecondary = buttonNext('destructive', 'secondary');
-const transparentSecondary = buttonNext('transparent', 'secondary')
+const secondary = button({secondary: true});
+const premiumSecondary = button({skin: 'premium', secondary: true});
+const darkSecondary = button({dark: true, secondary: true});
+const lightSecondary = button({light: true, secondary: true});
+const transparentSecondary = button({skin: 'transparent', secondary: true});
+const destructiveSecondary = button({skin: 'destructive', secondary: true});
 
 export default () => (
   <React.Fragment>
@@ -37,12 +37,12 @@ const description = (
   </div>
 );
 
-const secondary = buttonNext(`secondary`);
-const premiumSecondary = buttonNext(`premium`, 'secondary');
-const darkSecondary = buttonNext(`dark`, 'secondary');
-const lightSecondary = buttonNext(`light`, 'secondary');
-const transparentSecondary = buttonNext(`transparent`, 'secondary');
-const destructiveSecondary = buttonNext(`destructive`, 'secondary');
+const secondary = button({secondary: true});
+const premiumSecondary = button({skin: 'premium', secondary: true});
+const darkSecondary = button({dark: true, secondary: true});
+const lightSecondary = button({light: true, secondary: true});
+const transparentSecondary = button({skin: 'transparent', secondary: true});
+const destructiveSecondary = button({skin: 'destructive', secondary: true});
 
 interface ButtonSecondaryProps {
   style?: object;

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/button/button-sizes.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/button/button-sizes.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import CodeShowcase from 'wix-storybook-utils/CodeShowcase';
 import { ButtonNext } from '../../../../../src/components/button-next';
 import {
-  buttonNext,
+  button,
   backofficeTheme
 } from '../../../../../src/themes/backoffice';
 
@@ -13,10 +13,10 @@ import { buttonNext } from "wix-ui-core/themes/backoffice";
 
 export default () => (
   <React.Fragment>
-    <ButtonNext className={buttonNext('tiny')}>tiny</ButtonNext>
-    <ButtonNext className={buttonNext('small')}>small</ButtonNext>
-    <ButtonNext className={buttonNext('medium')}>medium</ButtonNext>
-    <ButtonNext className={buttonNext('large')}>large</ButtonNext>
+    <ButtonNext className={button({size: 'tiny'})}>tiny</ButtonNext>
+    <ButtonNext className={button({size: 'small'})}>small</ButtonNext>
+    <ButtonNext className={button({size: 'medium'})}>medium</ButtonNext>
+    <ButtonNext className={button({size: 'large'})}>large</ButtonNext>
   </React.Fragment>
 );`;
 
@@ -40,9 +40,9 @@ export const ButtonSizes = ({ style }: ButtonSizesProps) => (
     theme={backofficeTheme}
     description={description}
   >
-    <ButtonNext className={buttonNext('tiny')}>tiny</ButtonNext>
-    <ButtonNext className={buttonNext('small')}>small</ButtonNext>
-    <ButtonNext className={buttonNext('medium')}>medium</ButtonNext>
-    <ButtonNext className={buttonNext('large')}>large</ButtonNext>
+    <ButtonNext className={button({size: 'tiny'})}>tiny</ButtonNext>
+    <ButtonNext className={button({size: 'small'})}>small</ButtonNext>
+    <ButtonNext className={button({size: 'medium'})}>medium</ButtonNext>
+    <ButtonNext className={button({size: 'large'})}>large</ButtonNext>
   </CodeShowcase>
 );


### PR DESCRIPTION
instead of :
```js
<ButtonNext className={button('primary', 'secondary')}/>
```

We'll have:

```js
<ButtonNext className={button({skin: 'primary', secondary: true})}/>
```

I did it only got ButtonNext.
If it look good, we can do it for all the rest.