### PR TITLE
Backoffice - textbutton, iconbutton, closebutton - remove backoffice scope

### DIFF
--- a/packages/wix-ui-core/src/themes/backoffice/close-button/close-button.st.css
+++ b/packages/wix-ui-core/src/themes/backoffice/close-button/close-button.st.css
@@ -67,22 +67,22 @@
 
 /* Inverted */
 
-.inverted {
+.closeButton.inverted {
   background-color: value(B50);
   color: value(B10);
 }
 
-.inverted:hover:not(:disabled) {
+.closeButton.inverted:hover:not(:disabled) {
   background-color: value(B40);
   color: value(B10);
 }
 
-.inverted:active:not(:disabled) {
+.closeButton.inverted:active:not(:disabled) {
   background-color: value(B30);
   color: value(B10);
 }
 
-.inverted:disabled {
+.closeButton.inverted:disabled {
   border-color: value(D55);
   color:  value(D80);
   background-color: value(D55);
@@ -90,72 +90,72 @@
 
 /* Skin light */
 
-.light {
+.closeButton.light {
   background-color: transparent;
   color: value(D80);
 }
 
-.light:hover:not(:disabled) {
+.closeButton.light:hover:not(:disabled) {
   background-color: transparent;
   color: value(B50);
 }
 
-.light:active:not(:disabled) {
+.closeButton.light:active:not(:disabled) {
   background-color: transparent;
   color: value(B40);
 }
 
-.light:disabled {
+.closeButton.light:disabled {
   color: value(D55);
   background-color: transparent;
 }
 
 /* Skin dark */
 
-.dark {
+.closeButton.dark {
   border-color: transparent;
   background-color: transparent;
   color: value(D10);
 }
 
-.dark:hover:not(:disabled) {
+.closeButton.dark:hover:not(:disabled) {
   border-color: transparent;
   background-color: transparent;
   color: value(D20);
 }
 
-.dark:active:not(:disabled) {
+.closeButton.dark:active:not(:disabled) {
   border-color: transparent;
   background-color: transparent;
   color: value(D10);
 }
 
-.dark:disabled {
+.closeButton.dark:disabled {
   color: value(D55);
   background-color: transparent;
 }
 
 /* Skin transparent */
 
-.transparent {
+.closeButton.transparent {
   border-color: value(s5);
   background-color: value(s5);
   color:  value(D80);
 }
 
-.transparent:hover:not(:disabled) {
+.closeButton.transparent:hover:not(:disabled) {
   border-color: value(s6);
   background-color: value(s6);
   color:  value(D80);
 }
 
-.transparent:active:not(:disabled) {
+.closeButton.transparent:active:not(:disabled) {
   border-color: value(s7);
   background-color: value(s7);
   color:  value(D80);
 }
 
-.transparent:disabled {
+.closeButton.transparent:disabled {
   border-color: value(D55);
   color:  value(D80);
   background-color: value(D55);

--- a/packages/wix-ui-core/src/themes/backoffice/close-button/close-button.st.css
+++ b/packages/wix-ui-core/src/themes/backoffice/close-button/close-button.st.css
@@ -23,7 +23,7 @@
   -st-extends: Button;
 }
 
-BackofficeTheme .closeButton {
+.closeButton {
   width: 18px;
   height: 18px;
   border-radius: 18px;
@@ -40,26 +40,26 @@ BackofficeTheme .closeButton {
   color: value(B10);
 }
 
-BackofficeTheme .closeButton:focus-visible {
+.closeButton:focus-visible {
   box-shadow: 0 0 0 3px value(F00);
 }
 
-BackofficeTheme .closeButton:hover:not(:disabled) {
+.closeButton:hover:not(:disabled) {
   color: value(B20);
   background-color: transparent;
 }
 
-BackofficeTheme .closeButton:active:not(:disabled) {
+.closeButton:active:not(:disabled) {
   color: value(B10);
   background-color: transparent;
 }
 
-BackofficeTheme .closeButton:disabled {
+.closeButton:disabled {
   color: value(D55);
   background-color: transparent;
 }
 
-BackofficeTheme .closeButton::content {
+.closeButton::content {
   line-height: 0;
   width: 100%;
   height: 100%;
@@ -67,22 +67,22 @@ BackofficeTheme .closeButton::content {
 
 /* Inverted */
 
-BackofficeTheme .inverted {
+.inverted {
   background-color: value(B50);
   color: value(B10);
 }
 
-BackofficeTheme .inverted:hover:not(:disabled) {
+.inverted:hover:not(:disabled) {
   background-color: value(B40);
   color: value(B10);
 }
 
-BackofficeTheme .inverted:active:not(:disabled) {
+.inverted:active:not(:disabled) {
   background-color: value(B30);
   color: value(B10);
 }
 
-BackofficeTheme .inverted:disabled {
+.inverted:disabled {
   border-color: value(D55);
   color:  value(D80);
   background-color: value(D55);
@@ -90,72 +90,72 @@ BackofficeTheme .inverted:disabled {
 
 /* Skin light */
 
-BackofficeTheme .light {
+.light {
   background-color: transparent;
   color: value(D80);
 }
 
-BackofficeTheme .light:hover:not(:disabled) {
+.light:hover:not(:disabled) {
   background-color: transparent;
   color: value(B50);
 }
 
-BackofficeTheme .light:active:not(:disabled) {
+.light:active:not(:disabled) {
   background-color: transparent;
   color: value(B40);
 }
 
-BackofficeTheme .light:disabled {
+.light:disabled {
   color: value(D55);
   background-color: transparent;
 }
 
 /* Skin dark */
 
-BackofficeTheme .dark {
+.dark {
   border-color: transparent;
   background-color: transparent;
   color: value(D10);
 }
 
-BackofficeTheme .dark:hover:not(:disabled) {
+.dark:hover:not(:disabled) {
   border-color: transparent;
   background-color: transparent;
   color: value(D20);
 }
 
-BackofficeTheme .dark:active:not(:disabled) {
+.dark:active:not(:disabled) {
   border-color: transparent;
   background-color: transparent;
   color: value(D10);
 }
 
-BackofficeTheme .dark:disabled {
+.dark:disabled {
   color: value(D55);
   background-color: transparent;
 }
 
 /* Skin transparent */
 
-BackofficeTheme .transparent {
+.transparent {
   border-color: value(s5);
   background-color: value(s5);
   color:  value(D80);
 }
 
-BackofficeTheme .transparent:hover:not(:disabled) {
+.transparent:hover:not(:disabled) {
   border-color: value(s6);
   background-color: value(s6);
   color:  value(D80);
 }
 
-BackofficeTheme .transparent:active:not(:disabled) {
+.transparent:active:not(:disabled) {
   border-color: value(s7);
   background-color: value(s7);
   color:  value(D80);
 }
 
-BackofficeTheme .transparent:disabled {
+.transparent:disabled {
   border-color: value(D55);
   color:  value(D80);
   background-color: value(D55);

--- a/packages/wix-ui-core/src/themes/backoffice/icon-button/icon-button.st.css
+++ b/packages/wix-ui-core/src/themes/backoffice/icon-button/icon-button.st.css
@@ -18,7 +18,7 @@
   -st-extends: Button;
 }
 
-BackofficeTheme .iconButton {
+.iconButton {
   width: 36px;
   height: 36px;
   border-radius: 18px;
@@ -36,29 +36,29 @@ BackofficeTheme .iconButton {
   color: white;
 }
 
-BackofficeTheme .iconButton:hover:not(:disabled) {
+.iconButton:hover:not(:disabled) {
   background-color: value(B20);
   border-color: value(B20);
   color: value(D80);
 }
 
-BackofficeTheme .iconButton:active:not(:disabled) {
+.iconButton:active:not(:disabled) {
   background-color: value(B10);
   border-color: value(B10);
   color: value(D80);
 }
 
-BackofficeTheme .iconButton:disabled {
+.iconButton:disabled {
   background-color: value(D55);
   border-color: value(D55);
   color: value(D80);
 }
 
-BackofficeTheme .iconButton:focus-visible {
+.iconButton:focus-visible {
   box-shadow: 0 0 0 3px value(F00);
 }
 
-BackofficeTheme .iconButton .content {
+.iconButton .content {
   line-height: 0;
   width: 100%;
   height: 100%;
@@ -66,25 +66,25 @@ BackofficeTheme .iconButton .content {
 
 /* special case inverted */
 
-BackofficeTheme .iconButton.inverted {
+.iconButton.inverted {
   border: none;
   background-color: value(D80);
   color: value(B20);
 }
 
-BackofficeTheme .iconButton.inverted:hover:not(:disabled) {
+.iconButton.inverted:hover:not(:disabled) {
   color: value(D80);
   border-color: transparent;
   background: value(B20);
 }
 
-BackofficeTheme .iconButton.inverted:active:not(:disabled) {
+.iconButton.inverted:active:not(:disabled) {
   background-color: value(B10);
   border-color: value(B10);
   color: value(D80);
 }
 
-BackofficeTheme .iconButton.inverted:disabled {
+.iconButton.inverted:disabled {
   background-color: value(D55);
   border-color: value(D55);
   color: value(D80);
@@ -92,25 +92,25 @@ BackofficeTheme .iconButton.inverted:disabled {
 
 /* special case inverted secondary */
 
-BackofficeTheme .iconButton.inverted.secondary {
+.iconButton.inverted.secondary {
   border: none;
   background-color: value(D80);
   color: value(B20);
 }
 
-BackofficeTheme .iconButton.inverted.secondary:hover:not(:disabled) {
+.iconButton.inverted.secondary:hover:not(:disabled) {
   color: value(D80);
   border-color: transparent;
   background: value(B20);
 }
 
-BackofficeTheme .iconButton.inverted.secondary:active:not(:disabled) {
+.iconButton.inverted.secondary:active:not(:disabled) {
   background-color: value(B10);
   border-color: value(B10);
   color: value(D80);
 }
 
-BackofficeTheme .iconButton.inverted.secondary:disabled {
+.iconButton.inverted.secondary:disabled {
   background-color: value(D55);
   border-color: value(D55);
   color: value(D80);
@@ -118,25 +118,25 @@ BackofficeTheme .iconButton.inverted.secondary:disabled {
 
 /* Priority */
 
-BackofficeTheme .iconButton.secondary {
+.iconButton.secondary {
   border: solid 1px value(B10);
   background: transparent;
   color: value(B10);
 }
 
-BackofficeTheme .iconButton.secondary:hover:not(:disabled) {
+.iconButton.secondary:hover:not(:disabled) {
   color: value(D80);
   border-color: transparent;
   background-color: value(B20);
 }
 
-BackofficeTheme .iconButton.secondary:active:not(:disabled) {
+.iconButton.secondary:active:not(:disabled) {
   background-color: value(B10);
   border-color: value(B10);
   color: value(D80);
 }
 
-BackofficeTheme .iconButton.secondary:disabled {
+.iconButton.secondary:disabled {
   border-color: value(D55);
   color: value(D55);
   background-color: transparent;
@@ -144,24 +144,24 @@ BackofficeTheme .iconButton.secondary:disabled {
 
 /* skin Light */
 
-BackofficeTheme .iconButton.light {
+.iconButton.light {
   border: none;
   background-color: value(D80);
   color: value(B20);
 }
 
-BackofficeTheme .iconButton.light:hover:not(:disabled) {
+.iconButton.light:hover:not(:disabled) {
   background-color: value(B50);
   color: value(B10);
   border-color: value(B50);
 }
 
-BackofficeTheme .iconButton.light:active:not(:disabled) {
+.iconButton.light:active:not(:disabled) {
   background-color: value(B40);
   color: value(B10);
 }
 
-BackofficeTheme .iconButton.light:disabled {
+.iconButton.light:disabled {
   background-color: value(D55);
   border-color: value(D55);
   color: value(D80);
@@ -169,25 +169,25 @@ BackofficeTheme .iconButton.light:disabled {
 
 /* skin Light secondary */
 
-BackofficeTheme .iconButton.light.secondary {
+.iconButton.light.secondary {
   border: solid 1px value(D80);
   background: transparent;
   color: value(D80);
 }
 
-BackofficeTheme .iconButton.light.secondary:hover:not(:disabled) {
+.iconButton.light.secondary:hover:not(:disabled) {
   background-color: value(B50);
   color: value(B10);
   border-color: value(B50);
 }
 
-BackofficeTheme .iconButton.light.secondary:active:not(:disabled) {
+.iconButton.light.secondary:active:not(:disabled) {
   background-color: value(B40);
   border: solid 1px value(B40);
   color: value(B10);
 }
 
-BackofficeTheme .iconButton.light.secondary:disabled {
+.iconButton.light.secondary:disabled {
   border-color: value(D55);
   color: value(D55);
   background-color: transparent;
@@ -195,19 +195,19 @@ BackofficeTheme .iconButton.light.secondary:disabled {
 
 /* sizes */
 
-BackofficeTheme .iconButton.small {
+.iconButton.small {
   width: 30px;
   height: 30px;
 }
 
 /* icon size */
 
-BackofficeTheme .iconButton.iconSmall {
+.iconButton.iconSmall {
   width: 18px;
   height: 18px;
 }
 
-BackofficeTheme .iconButton.iconMedium {
+.iconButton.iconMedium {
   width: 24px;
   height: 24px;
 }

--- a/packages/wix-ui-core/src/themes/backoffice/text-button/text-button.st.css
+++ b/packages/wix-ui-core/src/themes/backoffice/text-button/text-button.st.css
@@ -1,9 +1,4 @@
 :import {
-  -st-from: "../theme.st.css";
-  -st-default: BackofficeTheme;
-}
-
-:import {
   -st-from: '../../../components/button-next/button-next.st.css';
   -st-default: Button;
   -st-named: prefix, suffix, content;
@@ -23,7 +18,7 @@
   -st-extends: Button;
 }
 
-BackofficeTheme .textButton {
+.textButton {
   color: value(B10);
   background-color: transparent;
   text-decoration: none;
@@ -37,51 +32,51 @@ BackofficeTheme .textButton {
   height: 24px;
 }
 
-BackofficeTheme .textButton:hover:not(:disabled) {
+.textButton:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color: value(B20);
 }
 
-BackofficeTheme .textButton:active:not(:disabled) {
+.textButton:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color: value(B20);
 }
 
-BackofficeTheme .textButton:disabled {
+.textButton:disabled {
   background-color: transparent;
   border-color: transparent;
   color: value(D55);
 }
 
-BackofficeTheme .textButton:focus-visible {
+.textButton:focus-visible {
   box-shadow: 0 0 0 3px value(F00);
 }
 
 /* Secondary */
 
-BackofficeTheme .textButton.onHover {
+.textButton.onHover {
   background-color: transparent;
   border-color: transparent;
   color: value(B10);
 }
 
-BackofficeTheme .textButton.onHover:hover:not(:disabled) {
+.textButton.onHover:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color: value(B20);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.onHover:active:not(:disabled) {
+.textButton.onHover:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color: value(B20);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.onHover:disabled {
+.textButton.onHover:disabled {
   background-color: transparent;
   border-color: transparent;
   color: value(D55);
@@ -90,28 +85,28 @@ BackofficeTheme .textButton.onHover:disabled {
 
 /* Underlined */
 
-BackofficeTheme .textButton.always {
+.textButton.always {
   background-color: transparent;
   border-color: transparent;
   color: value(B10);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always:hover:not(:disabled) {
+.textButton.always:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color: value(B20);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always:active:not(:disabled) {
+.textButton.always:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color: value(B20);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always:disabled {
+.textButton.always:disabled {
   background-color: transparent;
   border-color: transparent;
   color: value(D55);
@@ -120,25 +115,25 @@ BackofficeTheme .textButton.always:disabled {
 
 /* Premium */
 
-BackofficeTheme .textButton.premium {
+.textButton.premium {
   background-color: transparent;
   border-color: transparent;
   color:value(P10);
 }
 
-BackofficeTheme .textButton.premium:hover:not(:disabled) {
+.textButton.premium:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(P20);
 }
 
-BackofficeTheme .textButton.premium:active:not(:disabled) { 
+.textButton.premium:active:not(:disabled) { 
   background-color: transparent;
   border-color: transparent;
   color:value(P10);
 }
 
-BackofficeTheme .textButton.premium:disabled {
+.textButton.premium:disabled {
   background-color: transparent;
   border-color: transparent;
   color:value(D55);
@@ -146,27 +141,27 @@ BackofficeTheme .textButton.premium:disabled {
 
 /* Premium secondary */
 
-BackofficeTheme .textButton.onHover.premium {
+.textButton.onHover.premium {
   background-color: transparent;
   border-color: transparent;
   color:value(P10);
 }
 
-BackofficeTheme .textButton.onHover.premium:hover:not(:disabled) {
+.textButton.onHover.premium:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(P20);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.onHover.premium:active:not(:disabled) {
+.textButton.onHover.premium:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(P10);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.onHover.premium:disabled {
+.textButton.onHover.premium:disabled {
   background-color: transparent;
   border-color: transparent;
   color:value(D55);
@@ -174,28 +169,28 @@ BackofficeTheme .textButton.onHover.premium:disabled {
 
 /* Premium underlined */
 
-BackofficeTheme .textButton.always.premium {
+.textButton.always.premium {
   background-color: transparent;
   border-color: transparent;
   color:value(P10);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.premium:hover:not(:disabled) {
+.textButton.always.premium:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(P20);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.premium:active:not(:disabled) {
+.textButton.always.premium:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(P10);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.premium:disabled {
+.textButton.always.premium:disabled {
   background-color: transparent;
   border-color: transparent;
   text-decoration: underline;
@@ -204,25 +199,25 @@ BackofficeTheme .textButton.always.premium:disabled {
 
 /* Light */
 
-BackofficeTheme .textButton.light {
+.textButton.light {
   background-color: transparent;
   border-color: transparent;
   color:value(D80);
 }
 
-BackofficeTheme .textButton.light:hover:not(:disabled) {
+.textButton.light:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D80);
 }
 
-BackofficeTheme .textButton.light:active:not(:disabled) {
+.textButton.light:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D80);
 }
 
-BackofficeTheme .textButton.light:disabled {
+.textButton.light:disabled {
   background-color: transparent;
   border-color: transparent;
   color:value(D55);
@@ -230,26 +225,26 @@ BackofficeTheme .textButton.light:disabled {
 
 /* Light secondary */
 
-BackofficeTheme .textButton.onHover.light {
+.textButton.onHover.light {
   background-color: transparent;
   border-color: transparent;
   color:value(D80);
 }
 
-BackofficeTheme .textButton.onHover.light:hover:not(:disabled) {
+.textButton.onHover.light:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D80);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.onHover.light:active:not(:disabled) {
+.textButton.onHover.light:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D80);
 }
 
-BackofficeTheme .textButton.onHover.light:disabled {
+.textButton.onHover.light:disabled {
   background-color: transparent;
   border-color: transparent;
   color:value(D55);
@@ -257,28 +252,28 @@ BackofficeTheme .textButton.onHover.light:disabled {
 
 /* Light underlined */
 
-BackofficeTheme .textButton.always.light {
+.textButton.always.light {
   background-color: transparent;
   border-color: transparent;
   color:value(D80);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.light:hover:not(:disabled) {
+.textButton.always.light:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
    color:value(D80);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.light:active:not(:disabled) {
+.textButton.always.light:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D80);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.light:disabled {
+.textButton.always.light:disabled {
   background-color: transparent;
   border-color: transparent;
   text-decoration: underline;
@@ -287,25 +282,25 @@ BackofficeTheme .textButton.always.light:disabled {
 
 /* Dark */
 
-BackofficeTheme .textButton.dark {
+.textButton.dark {
   background-color: transparent;
   border-color: transparent;
   color:value(D10);
 }
 
-BackofficeTheme .textButton.dark:hover:not(:disabled) {
+.textButton.dark:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D20);
 }
 
-BackofficeTheme .textButton.dark:active:not(:disabled) {
+.textButton.dark:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D10);
 }
 
-BackofficeTheme .textButton.dark:disabled {
+.textButton.dark:disabled {
   background-color: transparent;
   border-color: transparent;
   color:value(D55);
@@ -313,26 +308,26 @@ BackofficeTheme .textButton.dark:disabled {
 
 /* Dark secondary */
 
-BackofficeTheme .textButton.onHover.dark {
+.textButton.onHover.dark {
   background-color: transparent;
   border-color: transparent;
   color:value(D10);
 }
 
-BackofficeTheme .textButton.onHover.dark:hover:not(:disabled) {
+.textButton.onHover.dark:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   text-decoration: underline;
   color: value(D20);
 }
 
-BackofficeTheme .textButton.onHover.dark:active:not(:disabled) {
+.textButton.onHover.dark:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D10);
 }
 
-BackofficeTheme .textButton.onHover.dark:disabled {
+.textButton.onHover.dark:disabled {
   background-color: transparent;
   border-color: transparent;
   color:value(D55);
@@ -340,28 +335,28 @@ BackofficeTheme .textButton.onHover.dark:disabled {
 
 /* Dark underlined */
 
-BackofficeTheme .textButton.always.dark {
+.textButton.always.dark {
   background-color: transparent;
   border-color: transparent;
   color:value(D10);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.dark:hover:not(:disabled) {
+.textButton.always.dark:hover:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D20);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.dark:active:not(:disabled) {
+.textButton.always.dark:active:not(:disabled) {
   background-color: transparent;
   border-color: transparent;
   color:value(D10);
   text-decoration: underline;
 }
 
-BackofficeTheme .textButton.always.dark:disabled {
+.textButton.always.dark:disabled {
   background-color: transparent;
   border-color: transparent;
   color:value(D55);
@@ -370,41 +365,41 @@ BackofficeTheme .textButton.always.dark:disabled {
 
 /* weight */
 
-BackofficeTheme .textButton.normal {
+.textButton.normal {
   -st-mixin: weightNormal;
 }
 
 /* sizes */
 
-BackofficeTheme .textButton.small {
+.textButton.small {
   height: 18px;
   -st-mixin: sizeSmall;
 }
 
 /* affixes */
 
-BackofficeTheme .textButton .prefix {
+.textButton .prefix {
   padding-right: 6px;
   margin: 0;
   width: 24px;
   height: 24px;
 }
 
-BackofficeTheme .textButton .suffix {
+.textButton .suffix {
   padding-left: 6px;
   margin: 0;
   width: 24px;
   height: 24px;
 }
 
-BackofficeTheme .textButton.small .prefix {
+.textButton.small .prefix {
   padding-right: 6px;
   margin: 0;
   width: 18px;
   height: 18px;
 }
 
-BackofficeTheme .textButton.small .suffix {
+.textButton.small .suffix {
   padding-left: 6px;
   margin: 0;
   width: 18px;

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/close-Button/closeButton-inverted.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/close-Button/closeButton-inverted.tsx
@@ -34,7 +34,6 @@ export const CloseButtonInverted = ({ style }: CloseButtonInvertedProps) => (
     title="Close Buttons (inverted)"
     style={style}
     code={exampleStandard}
-    theme={backofficeTheme}
     description={descriptionPrimary}
   >
     <ButtonNext className={closeButton('inverted')}>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/close-Button/closeButton-sizes.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/close-Button/closeButton-sizes.tsx
@@ -42,7 +42,6 @@ export const CloseButtonSizes = ({ style }: CloseButtonSizesProps) => (
     title="Icon Buttons (sizes)"
     style={style}
     code={example}
-    theme={backofficeTheme}
     description={description}
   >
     <ButtonNext className={closeButton()}>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/close-Button/closeButton-standard.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/close-Button/closeButton-standard.tsx
@@ -44,7 +44,6 @@ export const CloseButtonStandard = ({ style }: CloseButtonStandardProps) => (
     title="Close Buttons (standard)"
     style={style}
     code={exampleStandard}
-    theme={backofficeTheme}
     description={descriptionPrimary}
   >
     <ButtonNext className={closeButton()}>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/icon-Button/iconButton-primary.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/icon-Button/iconButton-primary.tsx
@@ -37,7 +37,6 @@ export const IconButtonPrimary = ({ style }: IconButtonPrimaryProps) => (
     title="Icon Buttons (primary)"
     style={style}
     code={examplePrimary}
-    theme={backofficeTheme}
     description={descriptionPrimary}
   >
     <ButtonNext className={iconButton()}>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/icon-Button/iconButton-secondary.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/icon-Button/iconButton-secondary.tsx
@@ -37,7 +37,6 @@ export const IconButtonSecondary = ({ style }: IconButtonSecondaryProps) => (
     title="Icon Buttons (secondary)"
     style={style}
     code={exampleSecondary}
-    theme={backofficeTheme}
     description={secondaryDescription}
   >
     <ButtonNext className={iconButton('secondary')}>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/icon-Button/iconButton-sizes.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/icon-Button/iconButton-sizes.tsx
@@ -38,7 +38,6 @@ export const IconButtonSizes = ({ style }: IconButtonSizesProps) => (
     title="Icon Buttons (sizes)"
     style={style}
     code={example}
-    theme={backofficeTheme}
     description={description}
   >
     <ButtonNext className={iconButton('small')}>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-affixes.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-affixes.tsx
@@ -39,7 +39,6 @@ export const TextButtonAffixes = ({ style }: TextButtonAffixesProps) => (
     title="Text Buttons (affixes)"
     style={style}
     code={example}
-    theme={backofficeTheme}
     description={description}
   >
     <ButtonNext className={textButton()} prefixIcon={<ChevronDown />}>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-none.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-none.tsx
@@ -37,7 +37,6 @@ export const TextButtonNone = ({ style }: TextButtonNoneProps) => (
     style={style}
     code={example}
     description={description}
-    theme={backofficeTheme}
   >
     <ButtonNext className={textButton()}>standard</ButtonNext>
     <div

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-onhover.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-onhover.tsx
@@ -47,7 +47,6 @@ export const TextButtonOnHover = ({ style }: TextButtonOnHoverProps) => (
     style={style}
     code={example}
     description={description}
-    theme={backofficeTheme}
   >
     <ButtonNext className={secondary}>standard</ButtonNext>
     <div

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-sizes.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-sizes.tsx
@@ -38,7 +38,6 @@ export const TextButtonSizes = ({ style }: TextButtonSizesProps) => (
     title="Text Buttons (sizes)"
     style={style}
     code={example}
-    theme={backofficeTheme}
     description={description}
   >
     <ButtonNext className={textButton('small')} prefixIcon={<ChevronDown />}>

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-underline.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-underline.tsx
@@ -47,7 +47,6 @@ export const TextButtonUnderline = ({ style }: TextButtonUnderlineProps) => (
     style={style}
     code={example}
     description={description}
-    theme={backofficeTheme}
   >
     <ButtonNext className={underline}>standard</ButtonNext>
     <div

--- a/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-weights.tsx
+++ b/packages/wix-ui-core/stories/backoffice/button-next/showcase/text-Button/textButton-weights.tsx
@@ -32,7 +32,6 @@ export const TextButtonWeights = ({ style }: TextButtonWeightsProps) => (
     title="Text Buttons (weights)"
     style={style}
     code={example}
-    theme={backofficeTheme}
     description={description}
   >
     <ButtonNext className={textButton()}>thin</ButtonNext>


### PR DESCRIPTION
This PR removes backoffice scope for textbutton, iconbutton and closebutton stylesheets. The reason for this is because these components are variation components of a core Button and it will not have any default values when applied with Backoffice scope wrapper. Additional classes must be passed instead.