### PR TITLE
`<Avatar/> - Add nameToInitials improvements, title, aria-labal

### DIFF
--- a/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
+++ b/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
@@ -17,7 +17,6 @@ Elements are "container" and content, which could be classified to either "text"
 | imgProps  | Omit<HTMLImageAttributes, 'alt'> |              |            | the source url to load image from                                      |
 | icon      | JSX Element                      |              |            | an SVG icon component                                                  |
 | text      | string                      |              |            | raw text to display as content                                                  |
-| tabIndex  | number                           | 0            |            | the `tabIndex` value to put on the root                                |
 | title     | string                           | 0            |            | the `title` attribute to put on the root. Defaults to `name` prop      |
 | ariaLabel | string                           | 0            |            | the `aria-label` attribute to put on the root. Defaults to `name` prop |
 

--- a/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
+++ b/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
@@ -19,6 +19,7 @@ Elements are "container" and content, which could be classified to either "text"
 | text      | string                      |              |            | raw text to display as content                                                  |
 | title     | string                           | 0            |            | the `title` attribute to put on the root. Defaults to `name` prop      |
 | ariaLabel | string                           | 0            |            | the `aria-label` attribute to put on the root. Defaults to `name` prop |
+| initialsLimit | number 2 | 3 | 2 | | Sets a letter limit to generated initials.
 
 
 ## General Behavior
@@ -29,15 +30,22 @@ this component will display content based on the props provided:
 * If `text` is provided it will display the string.
 * If none of the above props is provided, the component will convert `name` to initials and display that.
 
-Alternative content:<br>
+### Image Fallback
 If image fails to load, the component will display either `icon` or `text` or `name` initials, in that order.
 This alternative will also be shown while image in loading state.
 
-name conversion examples:
+### Name To Initials
+By default if `text` is not provided, then initials text would be generated from the `name`.
+Initials is limited by default to 3 letters.
+Examples:
+
 <br/> John Doe --> JD
 <br/> John H. Doe --> JHD
 <br/> John Hurley Stanley Kubrik Doe --> JHD
 <br/> john doe --> JD
+
+* If `initialsLimit` is set to 2, then first and last name parts are used.
+* Generated initials will always be uppercase.
 
 ## Technical Considerations
 

--- a/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
+++ b/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
@@ -10,7 +10,12 @@ export interface AvatarDriver extends BaseUniDriver{
   getContentType: () => Promise<ContentType>;
   /** Get the text content (generated initials) */
   getTextContent: ()=> Promise<string>;
+  /** Wether the image wass loaded */
   isImageLoaded: () => Promise<boolean>;
+  /** Get the native HTML title attribute */
+  getTitle: () =>  Promise<string>;
+  /** Get the native HTML aria-label attribute */
+  getAriaLabel: () =>  Promise<string>;
 }
 
 export const avatarDriverFactory = (base: UniDriver): AvatarDriver => {
@@ -20,6 +25,8 @@ export const avatarDriverFactory = (base: UniDriver): AvatarDriver => {
     ...baseUniDriverFactory(base),
     getContentType,
     getTextContent: ()=> base.$('[data-hook="text-container"]').text(),
-    isImageLoaded: async () => ((await base.attr('data-img-loaded')) === 'true')
+    isImageLoaded: async () => ((await base.attr('data-img-loaded')) === 'true'),
+    getTitle: ()=> base.attr('title'),
+    getAriaLabel: () => base.attr('aria-label') 
   }
 };

--- a/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
+++ b/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
@@ -12,10 +12,6 @@ export interface AvatarDriver extends BaseUniDriver{
   getTextContent: ()=> Promise<string>;
   /** Wether the image wass loaded */
   isImageLoaded: () => Promise<boolean>;
-  /** Get the native HTML title attribute */
-  getTitle: () =>  Promise<string>;
-  /** Get the native HTML aria-label attribute */
-  getAriaLabel: () =>  Promise<string>;
 }
 
 export const avatarDriverFactory = (base: UniDriver): AvatarDriver => {
@@ -25,8 +21,6 @@ export const avatarDriverFactory = (base: UniDriver): AvatarDriver => {
     ...baseUniDriverFactory(base),
     getContentType,
     getTextContent: ()=> base.$('[data-hook="text-container"]').text(),
-    isImageLoaded: async () => ((await base.attr('data-img-loaded')) === 'true'),
-    getTitle: ()=> base.attr('title'),
-    getAriaLabel: () => base.attr('aria-label') 
+    isImageLoaded: async () => ((await base.attr('data-img-loaded')) === 'true')
   }
 };

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -4,7 +4,7 @@ import * as eventually from 'wix-eventually';
 import { reactUniDriver, UniDriver } from 'unidriver';
 import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { Avatar , AvatarProps} from '.';
-import { nameToInitials } from './avatar';
+import { nameToInitials } from './util';
 import { avatarDriverFactory } from './avatar.driver';
 import styles from './avatar.st.css';
 

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {StylableDOMUtil} from '@stylable/dom-test-kit';
 import * as eventually from 'wix-eventually';
-import { reactUniDriver, UniDriver } from 'unidriver';
+import { reactUniDriver } from 'unidriver';
 import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { Avatar , AvatarProps} from '.';
 import { nameToInitials } from './util';
@@ -18,6 +18,7 @@ describe('Avatar', () => {
     .unmountAfterEachTest();
 
   const createDriver = testContainer.createUniRenderer(avatarDriverFactory);
+
   const createDriverFromContainer = () => {
     const base = reactUniDriver(testContainer.componentNode);
     return avatarDriverFactory(base);
@@ -224,6 +225,43 @@ describe('Avatar', () => {
 
     it('should be uppercase given lowercase name parts', () => {
       expect(nameToInitials('john hurley stanley kubrik doe')).toBe('JHD');
+    });
+  })
+  
+  describe('className prop', () => {
+    it('should pass className prop onto root elemenet', async () => {
+      const className = 'foo';
+      testContainer.renderSync(<Avatar className={className}/>);
+      const driver = reactUniDriver(testContainer.componentNode);
+      expect(await driver.attr('class')).toContain(className);
+    });
+  })
+
+  describe('title prop', () => {
+    it('should pass title prop onto root elemenet', async () => {
+      const title = 'Avatar for John Doe';
+      const driver = createDriver(<Avatar title={title}/>);
+      expect(await driver.getTitle()).toBe(title);
+    });
+
+    it('should have default value for title if name is provided', async () => {
+      const name = 'John Doe';
+      const driver = createDriver(<Avatar name={name}/>);
+      expect(await driver.getTitle()).toBe(name);
+    });
+  })
+
+  describe('aria-label prop', () => {
+    it('should pass aria-label prop onto root elemenet', async () => {
+      const ariaLabel = 'Avatar for John Doe';
+      const driver = createDriver(<Avatar ariaLabel={ariaLabel}/>);
+      expect(await driver.getAriaLabel()).toBe(ariaLabel);
+    });
+
+    it('should have default value for aria-label if name is provided', async () => {
+      const name = 'John Doe';
+      const driver = createDriver(<Avatar name={name}/>);
+      expect(await driver.getAriaLabel()).toBe(name);
     });
   })
   

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -4,6 +4,7 @@ import * as eventually from 'wix-eventually';
 import { reactUniDriver, UniDriver } from 'unidriver';
 import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { Avatar , AvatarProps} from '.';
+import { nameToInitials } from './avatar';
 import { avatarDriverFactory } from './avatar.driver';
 import styles from './avatar.st.css';
 
@@ -196,6 +197,36 @@ describe('Avatar', () => {
     });
   });
 
+  describe('nameToInitials', () => {
+    it('should be empty string given undefined name', () => {
+      expect(nameToInitials()).toBe('');
+    });
+
+    it('should be empty string given empty name', () => {
+      expect(nameToInitials('')).toBe('');
+    });
+
+    it('should be first initial given 1 name part', () => {
+      expect(nameToInitials('John')).toBe('J');
+    });
+
+    it('should be first and last initials given 2 name parts', () => {
+      expect(nameToInitials('John Doe')).toBe('JD');
+    });
+
+    it('should be 3 initials given 3 name parts', () => {
+      expect(nameToInitials('John H. Doe')).toBe('JHD');
+    });
+
+    it('should be 3 initials given 5 name parts', () => {
+      expect(nameToInitials('John Hurley Stanley Kubrik Doe')).toBe('JHD');
+    });
+
+    it('should be uppercase given lowercase name parts', () => {
+      expect(nameToInitials('john hurley stanley kubrik doe')).toBe('JHD');
+    });
+  })
+  
   describe(`Styling`, () => {
     describe('content pseudo element', () => {
       it('should have content class when text displayed', async () => {

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -199,39 +199,88 @@ describe('Avatar', () => {
   });
 
   describe('nameToInitials', () => {
-    it('should be empty string given undefined name', () => {
-      expect(nameToInitials()).toBe('');
-    });
+    describe('limit = 3', () => { 
+      it('should render Avatar with 3 letter initials', async () => {
+        const driver = createDriver(
+          <Avatar 
+            name="John Smith Junir Doe"
+            initialsLimit={3}
+          />);
+        expect(await driver.getTextContent()).toBe('JSD');
+      });
 
-    it('should be empty string given empty name', () => {
-      expect(nameToInitials('')).toBe('');
-    });
+      it('should be empty string given undefined name', () => {
+        expect(nameToInitials()).toBe('');
+      });
+      
+      it('should be empty string given empty name', () => {
+        expect(nameToInitials('', 3)).toBe('');
+      });
+      
+      it('should be first initial given 1 name part', () => {
+        expect(nameToInitials('John', 3)).toBe('J');
+      });
+      
+      it('should be first and last initials given 2 name parts', () => {
+        expect(nameToInitials('John Doe', 3)).toBe('JD');
+      });
+      
+      it('should be 3 initials given 3 name parts', () => {
+        expect(nameToInitials('John H. Doe', 3)).toBe('JHD');
+      });
+      
+      it('should be 3 initials given 5 name parts', () => {
+        expect(nameToInitials('John Hurley Stanley Kubrik Doe', 3)).toBe('JHD');
+      });
+      
+      it('should be uppercase given lowercase name parts', () => {
+        expect(nameToInitials('john hurley stanley kubrik doe', 3)).toBe('JHD');
+      });
+    })
 
-    it('should be first initial given 1 name part', () => {
-      expect(nameToInitials('John')).toBe('J');
-    });
+    describe('limit = 2 (default)', () => { 
+      it('should render Avatar with 2 letter initials', async () => {
+        const driver = createDriver(
+          <Avatar 
+            name="John Smith Junir Doe"
+          />);
+        expect(await driver.getTextContent()).toBe('JD');
+      });
 
-    it('should be first and last initials given 2 name parts', () => {
-      expect(nameToInitials('John Doe')).toBe('JD');
-    });
-
-    it('should be 3 initials given 3 name parts', () => {
-      expect(nameToInitials('John H. Doe')).toBe('JHD');
-    });
-
-    it('should be 3 initials given 5 name parts', () => {
-      expect(nameToInitials('John Hurley Stanley Kubrik Doe')).toBe('JHD');
-    });
-
-    it('should be uppercase given lowercase name parts', () => {
-      expect(nameToInitials('john hurley stanley kubrik doe')).toBe('JHD');
-    });
+      it('should be empty string given undefined name', () => {
+        expect(nameToInitials()).toBe('');
+      });
+      
+      it('should be empty string given empty name', () => {
+        expect(nameToInitials('')).toBe('');
+      });
+      
+      it('should be first initial given 1 name part', () => {
+        expect(nameToInitials('John')).toBe('J');
+      });
+      
+      it('should be first and last initials given 2 name parts', () => {
+        expect(nameToInitials('John Doe')).toBe('JD');
+      });
+      
+      it('should be 3 initials given 3 name parts', () => {
+        expect(nameToInitials('John H. Doe')).toBe('JD');
+      });
+      
+      it('should be 3 initials given 5 name parts', () => {
+        expect(nameToInitials('John Hurley Stanley Kubrik Doe')).toBe('JD');
+      });
+      
+      it('should be uppercase given lowercase name parts', () => {
+        expect(nameToInitials('john hurley stanley kubrik doe')).toBe('JD');
+      });
+    })
   })
-  
+    
   describe('className prop', () => {
     it('should pass className prop onto root elemenet', async () => {
-      const className = 'foo';
-      testContainer.renderSync(<Avatar className={className}/>);
+        const className = 'foo';
+        testContainer.renderSync(<Avatar className={className}/>);
       const driver = reactUniDriver(testContainer.componentNode);
       expect(await driver.attr('class')).toContain(className);
     });

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -290,13 +290,15 @@ describe('Avatar', () => {
     it('should pass title prop onto root elemenet', async () => {
       const title = 'Avatar for John Doe';
       const driver = createDriver(<Avatar title={title}/>);
-      expect(await driver.getTitle()).toBe(title);
+      const unDriver = reactUniDriver(testContainer.componentNode);
+      expect(await unDriver.attr('title')).toBe(title);
     });
 
     it('should have default value for title if name is provided', async () => {
       const name = 'John Doe';
       const driver = createDriver(<Avatar name={name}/>);
-      expect(await driver.getTitle()).toBe(name);
+      const unDriver = reactUniDriver(testContainer.componentNode);
+      expect(await unDriver.attr('title')).toBe(name);
     });
   })
 
@@ -304,13 +306,15 @@ describe('Avatar', () => {
     it('should pass aria-label prop onto root elemenet', async () => {
       const ariaLabel = 'Avatar for John Doe';
       const driver = createDriver(<Avatar ariaLabel={ariaLabel}/>);
-      expect(await driver.getAriaLabel()).toBe(ariaLabel);
+      const unDriver = reactUniDriver(testContainer.componentNode);
+      expect(await unDriver.attr('aria-label')).toBe(ariaLabel);
     });
 
     it('should have default value for aria-label if name is provided', async () => {
       const name = 'John Doe';
       const driver = createDriver(<Avatar name={name}/>);
-      expect(await driver.getAriaLabel()).toBe(name);
+      const unDriver = reactUniDriver(testContainer.componentNode);
+      expect(await unDriver.attr('aria-label')).toBe(name);
     });
   })
   

--- a/packages/wix-ui-core/src/components/avatar/avatar.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.tsx
@@ -132,8 +132,7 @@ export class Avatar extends React.Component<AvatarProps, AvatarState> {
     switch (contentType) {
       case 'text': {
         const { name, text } = this.props;
-        // TODO: Make initials logic more robust and tested.
-        const textContent = text || (name && name.split(' ').map(s=>s[0]).join('')) || '';
+        const textContent = text || nameToInitials(name);
         return (
           <div className={style.content} data-hook="text-container">
             {textContent}
@@ -167,3 +166,18 @@ export class Avatar extends React.Component<AvatarProps, AvatarState> {
   }
 }
 
+/**
+ * Convert a space delimited full name to capitalized initials.
+ * Returned initials would not exceed 3 letters.
+ * If name has more than 3 parts, then the 1st, 2nd and last parts would be used.
+ */
+export function nameToInitials(name?: string) {
+  if (!name) {
+    return '';
+  }
+  let initials = name.split(' ').map(s=>s[0]).join('');
+  if (initials.length > 3 ) {
+    initials = initials[0]+initials[1]+initials[initials.length-1];
+  }
+  return initials.toUpperCase();
+}

--- a/packages/wix-ui-core/src/components/avatar/avatar.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.tsx
@@ -109,14 +109,15 @@ export class Avatar extends React.Component<AvatarProps, AvatarState> {
   }
 
   render() {
-    const { name, text, icon, imgProps, ...rest} = this.props;
+    const { name, text, icon, imgProps, title, ariaLabel,  ...rest} = this.props;
 
     const contentType = this.getCurrentContentType();
     return (
       <div 
         data-content-type={ contentType } // for testing
         data-img-loaded={ this.state.imgLoaded } // for testing
-        {...rest}
+        title={ title || name }
+        aria-label={ ariaLabel || name }
         {...style('root',
           {
            imgLoaded: this.state.imgLoaded,

--- a/packages/wix-ui-core/src/components/avatar/avatar.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.tsx
@@ -17,6 +17,8 @@ export interface AvatarProps extends BaseProps {
   icon?: React.ReactElement<any>;
   /* Props for an <img> tag to be rendered as content. */
   imgProps?: React.ImgHTMLAttributes<HTMLImageElement> & {['data-hook']?: string};
+  /* Limit the number of letters in the generated initials (from name). May be 2 or 3 only. */
+  initialsLimit?: 2 | 3;
 }
 
 interface AvatarState {
@@ -134,7 +136,7 @@ export class Avatar extends React.Component<AvatarProps, AvatarState> {
     switch (contentType) {
       case 'text': {
         const { name, text } = this.props;
-        const textContent = text || nameToInitials(name);
+        const textContent = text || nameToInitials(name, this.props.initialsLimit);
         return (
           <div className={style.content} data-hook="text-container">
             {textContent}

--- a/packages/wix-ui-core/src/components/avatar/avatar.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { BaseProps } from '../../types/BaseProps';
 import style from './avatar.st.css';
 import {ContentType} from './types';
+import {nameToInitials} from './util';
 
 export interface AvatarProps extends BaseProps {
   /* Css class name to be applied to the root element */
@@ -164,20 +165,4 @@ export class Avatar extends React.Component<AvatarProps, AvatarState> {
       }
     }
   }
-}
-
-/**
- * Convert a space delimited full name to capitalized initials.
- * Returned initials would not exceed 3 letters.
- * If name has more than 3 parts, then the 1st, 2nd and last parts would be used.
- */
-export function nameToInitials(name?: string) {
-  if (!name) {
-    return '';
-  }
-  let initials = name.split(' ').map(s=>s[0]).join('');
-  if (initials.length > 3 ) {
-    initials = initials[0]+initials[1]+initials[initials.length-1];
-  }
-  return initials.toUpperCase();
 }

--- a/packages/wix-ui-core/src/components/avatar/util.ts
+++ b/packages/wix-ui-core/src/components/avatar/util.ts
@@ -1,15 +1,27 @@
 /**
  * Convert a space delimited full name to capitalized initials.
- * Returned initials would not exceed 3 letters.
- * If name has more than 3 parts, then the 1st, 2nd and last parts would be used.
+ * Returned initials would not exceed 3 or 2 letters, according to provided `limit`.
+ * @param limit number If set to 3, then if name has more than 3 parts,
+ *  then the 1st, 2nd and last parts would be used. If set to 2, then first and last parts are used.
  */
-export function nameToInitials(name?: string) {
+export function nameToInitials(name?: string, limit: 2 | 3 = 2) {
   if (!name) {
     return '';
   }
+
+  if (limit < 2 || limit > 3) {
+    limit = 2;
+  }
+
   let initials = name.split(' ').map(s=>s[0]).join('');
-  if (initials.length > 3 ) {
+ 
+  if (limit === 2 && initials.length > 2) {
+    initials = initials[0]+initials[initials.length-1];
+  }
+
+  if (limit === 3 && initials.length > 3) {
     initials = initials[0]+initials[1]+initials[initials.length-1];
   }
+
   return initials.toUpperCase();
 }

--- a/packages/wix-ui-core/src/components/avatar/util.ts
+++ b/packages/wix-ui-core/src/components/avatar/util.ts
@@ -1,0 +1,15 @@
+/**
+ * Convert a space delimited full name to capitalized initials.
+ * Returned initials would not exceed 3 letters.
+ * If name has more than 3 parts, then the 1st, 2nd and last parts would be used.
+ */
+export function nameToInitials(name?: string) {
+  if (!name) {
+    return '';
+  }
+  let initials = name.split(' ').map(s=>s[0]).join('');
+  if (initials.length > 3 ) {
+    initials = initials[0]+initials[1]+initials[initials.length-1];
+  }
+  return initials.toUpperCase();
+}

--- a/packages/wix-ui-core/stories/backoffice/avatar/index.tsx
+++ b/packages/wix-ui-core/stories/backoffice/avatar/index.tsx
@@ -14,7 +14,7 @@ const description = (
   </div>
 );
 
-const NAME = "John H Doe";
+const NAME = 'John H Doe';
 
 const AvatarStory = () => (
   <div style={{ margin: '0px 0 16px', paddingLeft: '20px' }}>

--- a/packages/wix-ui-core/stories/backoffice/avatar/index.tsx
+++ b/packages/wix-ui-core/stories/backoffice/avatar/index.tsx
@@ -14,38 +14,40 @@ const description = (
   </div>
 );
 
+const NAME = "John H Doe";
+
 const AvatarStory = () => (
   <div style={{ margin: '0px 0 16px', paddingLeft: '20px' }}>
     <CodeShowcase
       title="Default"
       theme={backofficeTheme}
     >
-      <Avatar name="John Doe" />
+      <Avatar name={NAME} />
     </CodeShowcase>
 
     <CodeShowcase
       title="Text with BG Colors"
       theme={backofficeTheme}
     >
-      <Avatar className={avatar('colorBlue')} name="John Doe" />
-      <Avatar className={avatar('colorGreen')} name="John Doe" />
-      <Avatar className={avatar('colorGrey')} name="John Doe" />
-      <Avatar className={avatar('colorRed')} name="John Doe" />
-      <Avatar className={avatar('colorOrange')} name="John Doe" />
+      <Avatar className={avatar('colorBlue')} name={NAME} />
+      <Avatar className={avatar('colorGreen')} name={NAME} />
+      <Avatar className={avatar('colorGrey')} name={NAME} />
+      <Avatar className={avatar('colorRed')} name={NAME} />
+      <Avatar className={avatar('colorOrange')} name={NAME} />
     </CodeShowcase>
 
     <CodeShowcase
       title="Sizes"
       theme={backofficeTheme}
     >
-      <Avatar className={avatar('size90')} name="John Doe" />
-      <Avatar className={avatar('size72')} name="John Doe" />
-      <Avatar className={avatar('size60')} name="John Doe" />
-      <Avatar className={avatar('size48')} name="John Doe" />
-      <Avatar className={avatar('size36')} name="John Doe" />
-      <Avatar className={avatar('size30')} name="John Doe" />
-      <Avatar className={avatar('size24')} name="John Doe" />
-      <Avatar className={avatar('size18')} name="John Doe" />
+      <Avatar className={avatar('size90')} name={NAME} />
+      <Avatar className={avatar('size72')} name={NAME} />
+      <Avatar className={avatar('size60')} name={NAME} />
+      <Avatar className={avatar('size48')} name={NAME} />
+      <Avatar className={avatar('size36')} name={NAME} />
+      <Avatar className={avatar('size30')} name={NAME} />
+      <Avatar className={avatar('size24')} name={NAME} />
+      <Avatar className={avatar('size18')} name={NAME} />
     </CodeShowcase>
 
     <CodeShowcase


### PR DESCRIPTION
- improve nameToInitials logic
- Add title & aria-label props

## name To initials
backoffice design changed so that they want to limit to 2 letters.
I added that as a prop `initialsLimit` that can be set to either 2 or 3.
Since I still think that 3 letter initials could be useful for other design systems,
and we can save them the bother of writing and testing  their own `nameToInitials` function.