### PR TITLE
`<Avatar/>` - Add placeholder instead of `icon`

### DIFF
--- a/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
+++ b/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
@@ -21,14 +21,15 @@ Elements are "container" and content, which could be classified to either "text"
 | ariaLabel | string                           | 0            |            | the `aria-label` attribute to put on the root. Defaults to `name` prop |
 | initialsLimit | number 2 | 3 | 2 | | Sets a letter limit to generated initials.
 
-
 ## General Behavior
 
 this component will display content based on the props provided:
+
 * If `imgProps` is provided (and successfully loaded), it will display an image as content with the provided properties.
+
+* If `text` | `name` is provided it will display the string.
+  * If `text` is not provided but `name` is, then the displayed string would be initials that are generated from the name.
 * If an element is provided in `icon` it will display it.
-* If `text` is provided it will display the string.
-* If none of the above props is provided, the component will convert `name` to initials and display that.
 
 ### Image Fallback
 If image fails to load, the component will display either `icon` or `text` or `name` initials, in that order.

--- a/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
+++ b/packages/wix-ui-core/src/components/avatar/COMPONENT_SPEC.md
@@ -15,7 +15,7 @@ Elements are "container" and content, which could be classified to either "text"
 |:----------|:---------------------------------|:-------------|:-----------|:-----------------------------------------------------------------------|
 | name      | string                           |              |            | The name of the avatar user. Initials will be generated from the name  |
 | imgProps  | Omit<HTMLImageAttributes, 'alt'> |              |            | the source url to load image from                                      |
-| icon      | JSX Element                      |              |            | an SVG icon component                                                  |
+| placeholder      | JSX Element                      |              |            | an SVG icon component                                                  |
 | text      | string                      |              |            | raw text to display as content                                                  |
 | title     | string                           | 0            |            | the `title` attribute to put on the root. Defaults to `name` prop      |
 | ariaLabel | string                           | 0            |            | the `aria-label` attribute to put on the root. Defaults to `name` prop |
@@ -29,10 +29,10 @@ this component will display content based on the props provided:
 
 * If `text` | `name` is provided it will display the string.
   * If `text` is not provided but `name` is, then the displayed string would be initials that are generated from the name.
-* If an element is provided in `icon` it will display it.
+* If an element is provided in `placeholder` it will display it.
 
 ### Image Fallback
-If image fails to load, the component will display either `icon` or `text` or `name` initials, in that order.
+If image fails to load, the component will display either `placeholder` or `text` or `name` initials, in that order.
 This alternative will also be shown while image in loading state.
 
 ### Name To Initials
@@ -79,7 +79,7 @@ export class ComponentsDemo extends React.Component<{}, {}>{
                         sizes="(max-width: 320px) 280px, 800px"
                         src="elva-fairy-800w.jpg"
                     }}
-                    icon={<AvatarIcon/>}
+                    placeholder={<AvatarIcon/>}
                     />
             </div>
         )
@@ -100,7 +100,7 @@ export class ComponentsDemo extends React.Component<{}, {}>{
 | state        | description                        | type |
 |:-------------|:-----------------------------------|:-----|
 | imgLoaded   | true when the img was loaded     | boolean  |
-| contentType  | Which content type is currently displayed | enum(image,icon,text) |
+| contentType  | Which content type is currently displayed | enum(image,placeholder,text) |
 
 ### Style Code Example
 
@@ -115,7 +115,7 @@ export class ComponentsDemo extends React.Component<{}, {}>{
 .avatar {
   -st-extends: Avatar;
 }
-.avatar::text-container {
+.avatar:contentType(text)::content {
   color: red;
 }
 ```

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -11,7 +11,7 @@ import styles from './avatar.st.css';
 /** jsdom simulates loading of the image regardless of the src URL */
 const TEST_IMG_URL = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 const INVALID_TEST_IMG_URL = '12345';
-const ICON_AS_TEXT = <span>XXXXX</span>;
+const PLACEHOLDER_AS_TEXT = <span>XXXXX</span>;
 
 describe('Avatar', () => {
   const testContainer = new ReactDOMTestContainer()
@@ -28,10 +28,9 @@ describe('Avatar', () => {
     async () => expect((await driver.getContentType()) === 'image').toBeTruthy()
   );
 
-  it('should render an empty text by default', async () => {
+  it('should render an empty placeholder by default', async () => {
     const driver = createDriver(<Avatar />);
-    expect((await driver.getContentType()) === 'text').toBe(true);
-    expect(await driver.getTextContent()).toBe('');
+    expect((await driver.getContentType()) === 'placeholder').toBe(true);
   });
   
   describe(`content type resolution`, () => {
@@ -46,9 +45,9 @@ describe('Avatar', () => {
       expect((await driver.getContentType()) === 'text').toBe(true);
     });
 
-    it('should render an icon', async () => {
-      const driver = createDriver(<Avatar icon={ICON_AS_TEXT} />);
-      expect((await driver.getContentType()) === 'icon').toBe(true);
+    it('should render an placeholder', async () => {
+      const driver = createDriver(<Avatar placeholder={PLACEHOLDER_AS_TEXT} />);
+      expect((await driver.getContentType()) === 'placeholder').toBe(true);
     });
     
     it('should render an image', async () => {
@@ -56,19 +55,28 @@ describe('Avatar', () => {
       await expectImgEventuallyLoaded(driver);
     });
 
-    it('should render an icon when given icon and text', async () => {
+    it('should render a text when given placeholder and text', async () => {
       const driver = createDriver(
         <Avatar 
           text="JD"
-          icon={ICON_AS_TEXT} 
+          placeholder={PLACEHOLDER_AS_TEXT} 
         />);
-      expect((await driver.getContentType()) === 'icon').toBe(true);
+      expect((await driver.getContentType()) === 'text').toBe(true);
     });
 
-    it('should render an image when given icon and image', async () => {
+    it('should render a text when given placeholder and name', async () => {
       const driver = createDriver(
         <Avatar 
-          icon={ICON_AS_TEXT} 
+          name="John Doe"
+          placeholder={PLACEHOLDER_AS_TEXT} 
+        />);
+      expect((await driver.getContentType()) === 'text').toBe(true);
+    });
+
+    it('should render an image when given placeholder and image', async () => {
+      const driver = createDriver(
+        <Avatar 
+          placeholder={PLACEHOLDER_AS_TEXT} 
           imgProps={{src:TEST_IMG_URL}}
         />);
         await expectImgEventuallyLoaded(driver);
@@ -122,15 +130,15 @@ describe('Avatar', () => {
     });
   });
 
-  describe(`'icon' prop`, () => {
-    it('should render specified icon content', async () => {
-      const dataHook = 'avatar_test_icon';
+  describe(`'placeholder' prop`, () => {
+    it('should render specified placeholder content', async () => {
+      const dataHook = 'avatar_test_placeholder';
       testContainer.renderSync(
         <Avatar 
-          icon={<span data-hook={dataHook}>XXXX</span>}
+          placeholder={<span data-hook={dataHook}>XXXX</span>}
         />);
-      const iconElem = testContainer.componentNode.querySelector(`[data-hook="${dataHook}"]`);
-      expect(iconElem.textContent).toBe('XXXX');
+      const placeholderElem = testContainer.componentNode.querySelector(`[data-hook="${dataHook}"]`);
+      expect(placeholderElem.textContent).toBe('XXXX');
     });
   });
 
@@ -326,8 +334,8 @@ describe('Avatar', () => {
         expect(utils.select('.content').textContent).toBe('JD');
       });
       
-      it('should have content class when icon displayed', async () => {
-        testContainer.renderSync(<Avatar icon={ICON_AS_TEXT}/>);
+      it('should have content class when placeholder displayed', async () => {
+        testContainer.renderSync(<Avatar placeholder={PLACEHOLDER_AS_TEXT}/>);
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
         expect(utils.select('.content').textContent).toBe('XXXXX');
       });
@@ -382,12 +390,12 @@ describe('Avatar', () => {
         expect(utils.getStyleState(testContainer.componentNode, 'contentType')).toBe('text');
       });
 
-      it('should be icon', () => {
+      it('should be placeholder', () => {
         testContainer.renderSync(
-          <Avatar icon={ICON_AS_TEXT} />
+          <Avatar placeholder={PLACEHOLDER_AS_TEXT} />
         );
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
-        expect(utils.getStyleState(testContainer.componentNode, 'contentType')).toBe('icon');
+        expect(utils.getStyleState(testContainer.componentNode, 'contentType')).toBe('placeholder');
       });
 
       it('should be image', async () => {

--- a/packages/wix-ui-core/src/components/avatar/avatar.st.css
+++ b/packages/wix-ui-core/src/components/avatar/avatar.st.css
@@ -1,5 +1,5 @@
 .root {
-  -st-states: imgLoaded(boolean), contentType(enum(text, icon, image));
+  -st-states: imgLoaded(boolean), contentType(enum(text, placeholder, image));
 }
 
 .content {}

--- a/packages/wix-ui-core/src/components/avatar/avatar.story.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.story.tsx
@@ -25,7 +25,7 @@ export default {
   componentWrapper: defaultThemeWrapper,
   exampleProps: {
     className: [{label: 'defaultTheme', value: avatar()}],
-    icon: [{label: 'Icon1', value: <User />}],
+    placeholder: [{label: 'Icon1', value: <User style={{height: 'inherit', width: 'inherit'}}/>}],
     imgProps: [
       {label: 'image1', value:{src:'https://static.wixstatic.com/media/9ab0d1_8f1d1bd00e6c4bcd8764e1cae938f872~mv1.png'}},
       {label: 'image_non_existing_url', value:{src:'https://static.wixstatic.com/media/123454321.png'}}

--- a/packages/wix-ui-core/src/components/avatar/avatar.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.tsx
@@ -13,8 +13,8 @@ export interface AvatarProps extends BaseProps {
   name?: string;
   /* Text to render as content. */
   text?: string;
-  /* A node with an icon to be rendered as content. */
-  icon?: React.ReactElement<any>;
+  /* A node with a placeholder to be rendered as content. Will be displayed if no `text`, `name` or `imgProps` are provided. */
+  placeholder?: React.ReactElement<any>;
   /* Props for an <img> tag to be rendered as content. */
   imgProps?: React.ImgHTMLAttributes<HTMLImageElement> & {['data-hook']?: string};
   /* Limit the number of letters in the generated initials (from name). May be 2 or 3 only. */
@@ -25,29 +25,32 @@ interface AvatarState {
   imgLoaded: boolean;  
 }
 
-const DEFAULT_CONTENT_TYPE : ContentType= 'text' ;
+const DEFAULT_CONTENT_TYPE : ContentType= 'placeholder' ;
 /**
- * Avatar is a type of element that visually represents a user, either as an image, icon or text.
+ * Avatar is a type of element that visually represents a user, either as an image, placeholder or text.
  * 
- * <p>There are 3 props for corresponding content types: `text`, `icon` and `imgProps`.
+ * <p>There are 3 props for corresponding content types: `text`, `placeholder` and `imgProps`.
  * If more than one of these props is supplied (with `name` prop giving default value to the `text` prop),
- * then the resolved content type for display goes according to this priority: image -> icon -> text.
+ * then the resolved content type for display goes according to this priority: image -> text -> placeholder.
  */
 export class Avatar extends React.Component<AvatarProps, AvatarState> {
   static displayName = 'Avatar';
   
+  static defaultProps = {
+    placeholder: null
+  }
   state: AvatarState = { imgLoaded: false }
   
   img : HTMLImageElement;
 
   /** This is the resolved content type the the consumer wants to display */
   getRequestedContentType(props) : ContentType {
-    const { name, text, icon, imgProps} = props;
+    const { name, text, placeholder, imgProps} = props;
 
     return (
       imgProps ? 'image' :
-      icon ? 'icon' :
       text || name ? 'text' :
+      placeholder ? 'placeholder' :
       DEFAULT_CONTENT_TYPE
     );
   }
@@ -57,10 +60,10 @@ export class Avatar extends React.Component<AvatarProps, AvatarState> {
     const requestedType = this.getRequestedContentType(this.props);
 
     if (requestedType === 'image' && !this.state.imgLoaded) {
-      const { name, text, icon} = this.props;
+      const { name, text, placeholder} = this.props;
       return (
-          icon ? 'icon' :
-          text || name ? 'text' :
+        text || name ? 'text' :
+        placeholder ? 'placeholder' :
           DEFAULT_CONTENT_TYPE
       );
     } else {
@@ -111,7 +114,7 @@ export class Avatar extends React.Component<AvatarProps, AvatarState> {
   }
 
   render() {
-    const { name, text, icon, imgProps, title, ariaLabel,  ...rest} = this.props;
+    const { name, text, placeholder, imgProps, title, ariaLabel,  ...rest} = this.props;
 
     const contentType = this.getCurrentContentType();
     return (
@@ -144,10 +147,10 @@ export class Avatar extends React.Component<AvatarProps, AvatarState> {
         );
       }
   
-      case 'icon': {
-        const icon = this.props.icon;
-        return React.cloneElement(icon,
-            { className:classNames(icon.props.className, style.content) }
+      case 'placeholder': {
+        const {placeholder} = this.props;
+        return placeholder === null ? null : React.cloneElement(placeholder,
+            { className:classNames(placeholder.props.className, style.content) }
           );
       }
   

--- a/packages/wix-ui-core/src/components/avatar/storySettings.ts
+++ b/packages/wix-ui-core/src/components/avatar/storySettings.ts
@@ -2,6 +2,6 @@ import { StorySettings, Category } from '../../../stories/utils';
 
 export const storySettings : StorySettings = {
   category: Category.COMPNENTS,
-  storyName: 'WIP - Avatar',
+  storyName: 'Avatar',
   dataHook: 'storybook-avatar'
 };

--- a/packages/wix-ui-core/src/components/avatar/types.ts
+++ b/packages/wix-ui-core/src/components/avatar/types.ts
@@ -1,1 +1,1 @@
-export type ContentType = 'text' | 'icon' | 'image';
+export type ContentType = 'text' | 'placeholder' | 'image';

--- a/packages/wix-ui-core/src/themes/backoffice/avatar/avatar.st.css
+++ b/packages/wix-ui-core/src/themes/backoffice/avatar/avatar.st.css
@@ -35,7 +35,7 @@ BackofficeTheme Avatar:contentType(image)::content {
 }
 
 /* Colors */
-BackofficeTheme Avatar:contentType(icon) {
+BackofficeTheme Avatar:contentType(placeholder) {
   background-color: value(B40);
 }
 


### PR DESCRIPTION
The logic should change from :
`img -> icon -> (text | name)`
to
`img -> (text | name) -> icon`
The idea is, that if we have `text |name` then we can display initials.
We display an icon only when we don't have `text | name`. That icon will usually be a generic placeholder, not something specific of the user.
This change is coming form WixStyleReact UX spec. which is the only spec we have right now.

In WSR:
`<Avatar />` - show placeholder icon
`<Avatar name="John Doe"/>` - show initials


## Also make Avatar not WIP anymore