### PR TITLE
BackofficeTheme.root fails on yoshi test --protractor

### DIFF
--- a/packages/wix-ui-core/src/themes/backoffice/index.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/index.ts
@@ -12,8 +12,7 @@ const getClassNames = (values, stylesheet, rootcls?) => {
   return classNames(stylesheet[rootcls], clsArray);
 };
 
-export const avatar = (...values) =>
-  getClassNames(values, Avatar);
+export const avatar = (...values) => getClassNames(values, Avatar);
 export const buttonNext = (...values) =>
   getClassNames(values, ButtonNext, 'button');
 export const iconButton = (...values) =>
@@ -22,4 +21,4 @@ export const textButton = (...values) =>
   getClassNames(values, TextButton, 'textButton');
 export const closeButton = (...values) =>
   getClassNames(values, CloseButton, 'closeButton');
-export const backofficeTheme = BackofficeTheme.root;
+export const backofficeTheme = (BackofficeTheme && BackofficeTheme.root) || {};

--- a/packages/wix-ui-core/src/themes/backoffice/index.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/index.ts
@@ -21,4 +21,6 @@ export const textButton = (...values) =>
   getClassNames(values, TextButton, 'textButton');
 export const closeButton = (...values) =>
   getClassNames(values, CloseButton, 'closeButton');
+// FIX ME. I fail on yoshi test --protractor when used
+// only with BackofficeTheme.root
 export const backofficeTheme = (BackofficeTheme && BackofficeTheme.root) || {};


### PR DESCRIPTION
This PR fixes an issue in wix-style-react where when yoshi test --protractor is running  it gets:
```js
rror: TypeError: Cannot read property 'root' of undefined
    at Object.<anonymous> (/Users/mykolass/Documents/wix-ui/packages/wix-ui-core/src/themes/backoffice/index.ts:24:48)
    at Module._compile (module.js:635:30)
    at Module._extensions..js (module.js:646:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/mykolass/Documents/wix-style-react/node_modules/yoshi/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/mykolass/Documents/wix-ui/packages/wix-ui-core/themes/backoffice/index.js:1:18)
```

Although this is a workaround and should be investigated in a future it is a big blocker for me to release `CloseButton`.