### PR TITLE
<ButtonNext/> - Remove BaseProps

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -8,9 +8,9 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<any> {
   /** accepts suffix icon  */
   suffixIcon?: React.ReactElement<any>;
   /** callback need to be applied for onFocus event */
-  focusableOnFocus?: React.FocusEventHandler<HTMLInputElement>,
-  /**   callback need to be applied for onBlur event */
-  focusableOnBlur?: React.FocusEventHandler<HTMLInputElement>,
+  focusableOnFocus?: React.FocusEventHandler<HTMLButtonElement>,
+  /** callback need to be applied for onBlur event */
+  focusableOnBlur?: React.FocusEventHandler<HTMLButtonElement>,
 }
 
 const _addAffix = (Affix, classname) =>

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import { withFocusable } from '../../hocs/Focusable/FocusableHOC';
-import { BaseProps } from '../../types/BaseProps';
 import style from './button-next.st.css';
 
-export interface ButtonProps
-  extends BaseProps,
-    React.ButtonHTMLAttributes<any> {
+export interface ButtonProps extends React.ButtonHTMLAttributes<any> {
   /** accepts prefix icon */
   prefixIcon?: React.ReactElement<any>;
   /** accepts suffix icon  */
   suffixIcon?: React.ReactElement<any>;
+  /** callback need to be applied for onFocus event */
+  focusableOnFocus?: React.FocusEventHandler<HTMLInputElement>,
+  /**   callback need to be applied for onBlur event */
+  focusableOnBlur?: React.FocusEventHandler<HTMLInputElement>,
 }
 
 const _addAffix = (Affix, classname) =>


### PR DESCRIPTION
This pr removes interface extend `BasePros` because it allows any kind of prop.