### PR TITLE
chore(package.json): add src to be distributed in module pack

### DIFF
--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -13,6 +13,7 @@
   "types": "./dist/src/index.d.js",
   "homepage": "https://github.com/wix/wix-ui#readme",
   "files": [
+    "src",
     "dist",
     "*.js",
     "*.d.ts",


### PR DESCRIPTION
it is required for automated documentation tools. Since wix-style-react,
wix-ui-core, wix-ui-backoffice and friends use wix-ui-test-utils and
extend some of testkit drivers with, for example, uni-driver-factory, it
is required for testkit parser to read full source of it in order to
provide full testkit API documentation