### PR TITLE
GoogleMapsClient - Don't fail test when getting OVER_QUERY_LIMIT error

### DIFF
--- a/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsIframeClient.protractor.driver.ts
+++ b/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsIframeClient.protractor.driver.ts
@@ -3,12 +3,14 @@ import {ElementFinder} from 'protractor';
 
 export interface GoogleMapsIframeClientDriver extends BaseDriver {
   getParsedResults: () => Promise<any>;
+  getParsedError: () => Promise<{status: string, originalStatus: string, requestId: string}>;
   getResultsElementWrapper: () => ElementFinder;
   enterText: (text: string) => Promise<void>;
   selectByValue: (value: string) => Promise<void>;
+  isResponseSuccess: () => Promise<boolean>;
 }
 
-export const googleMapsIframeClientDriverFactory: DriverFactory<GoogleMapsIframeClientDriver> = component => {
+export const googleMapsIframeClientDriverFactory: DriverFactory<GoogleMapsIframeClientDriver> = (component): GoogleMapsIframeClientDriver => {
   const getButtons = () => component.$$('button');
   const input = component.$('input');
   const resultsElementWrapper = component.$('pre');
@@ -17,6 +19,14 @@ export const googleMapsIframeClientDriverFactory: DriverFactory<GoogleMapsIframe
     getParsedResults: async () => {
       const results = await resultsElementWrapper.getText();
       return JSON.parse(results);
+    },
+    getParsedError: async () => {
+      const results = await resultsElementWrapper.getText();
+      return JSON.parse(results);
+    },
+    isResponseSuccess: async ()=> {
+      const status = await resultsElementWrapper.getAttribute('data-hook');
+      return status === 'success';
     },
     getResultsElementWrapper: () => resultsElementWrapper,
     enterText: async (text: string) => {

--- a/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsIframeClient.ts
+++ b/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsIframeClient.ts
@@ -16,7 +16,7 @@ export class GoogleMapsIframeClient implements MapsClient {
     const {data} = event;
     if (data.requestId && this._promisesMap.has(data.requestId)) {
       const promise = this._promisesMap.get(data.requestId);
-      data.status === 'OK' ? promise.resolve(data.results) : promise.reject();
+      data.status === 'OK' ? promise.resolve(data.results) : promise.reject(data);
     }
   }
 

--- a/packages/wix-ui-core/src/clients/GoogleMaps/GoogleRequestHandler/GoogleRequestHandler.ts
+++ b/packages/wix-ui-core/src/clients/GoogleMaps/GoogleRequestHandler/GoogleRequestHandler.ts
@@ -65,7 +65,7 @@ export const googleRequestHandler = (eventEmitter, handlersName) => {
     const request = typeof event.data.request === 'string' ? {address: event.data.request} : event.data.request;
     context._geocoder.geocode(request, (results, status) => {
       if ((status !== context.googleInstance.maps.GeocoderStatus.OK) && (status !== context.googleInstance.maps.GeocoderStatus.ZERO_RESULTS)) {
-        event.source.postMessage({results, status: 'ERROR', requestId: event.data.requestId}, '*');
+        event.source.postMessage({results, status: 'ERROR', requestId: event.data.requestId, originalStatus: status}, '*');
       } else {
         event.source.postMessage({
           results: results.map(element =>

--- a/packages/wix-ui-core/stories/clients/GoogleMapsIframeClient-story.tsx
+++ b/packages/wix-ui-core/stories/clients/GoogleMapsIframeClient-story.tsx
@@ -6,8 +6,8 @@ const buttonStyle = {
     margin: '15px'
 };
 
-export class GoogleMapsIframeClientStory extends React.Component<{}, { inputValue: string, result: object[] }> {
-    state = {result: [], inputValue: ''};
+export class GoogleMapsIframeClientStory extends React.Component<{}, { inputValue: string, result: object[], error: any }> {
+    state = {result: [], inputValue: '', error: undefined };
     client = new GoogleMapsIframeClient();
 
     constructor(props: any) {
@@ -25,7 +25,13 @@ export class GoogleMapsIframeClientStory extends React.Component<{}, { inputValu
     }
 
     geocode(apiKey, lang) {
-        this.client.geocode(apiKey, lang, this.state.inputValue).then((result: object[]) => this.setState({result}));
+        this.client.geocode(apiKey, lang, this.state.inputValue)
+            .then((result: object[]) => {
+                this.setState({result})
+            })
+            .catch((err: any)=> {
+                this.setState({error: err})
+            });
     }
 
     placeDetails(apiKey, lang) {
@@ -73,7 +79,10 @@ export class GoogleMapsIframeClientStory extends React.Component<{}, { inputValu
                 >placeDetails
                 </button>
                 {this.state.result.length > 0 &&
-                <pre>{JSON.stringify(this.state.result, null, 4)}</pre>
+                    <pre data-hook="success">{JSON.stringify(this.state.result, null, 4)}</pre>
+                }
+                {this.state.error && 
+                    <pre data-hook="error">{JSON.stringify(this.state.error, null, 4)}</pre>
                 }
             </div>
         );


### PR DESCRIPTION
Well, it's either we eliminate querying 3rd party services in our automated tests,
or we need to ignore the OVER_QUERY_LIMIT error.

That is...  assuming that in production we have an real google account with very high limit ?
 
Because now the full error description we are getting from Google is:
> You have exceeded your daily request quota for this API. If you did not set a custom daily request quota, verify your project has an active billing account: http://g.co/dev/maps-no-account  For more information on usage limits and the Google Maps JavaScript API services please see: https://developers.google.com/maps/documentation/javascript/usage

Which means we have no account.
Is that the same in production?