### PR TITLE
a11y: fix dropdown up/down key press scrolling the page

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
@@ -110,7 +110,9 @@ export class DropdownContent extends React.PureComponent<DropdownContentProps, D
         return this.hoverNextItem(1);
       }
       case 'ArrowLeft':
-      case 'ArrowRight': return;
+      case 'ArrowRight': {
+          evt.preventDefault();
+          return;}
       default: this.setHoveredIndex(NOT_HOVERED_INDEX);
     }
   }

--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
@@ -99,12 +99,14 @@ export class DropdownContent extends React.PureComponent<DropdownContentProps, D
     return isValidIndex ? options[hoveredIndex] : null;
   }
 
-  onKeyDown(eventKey: string) {
+  onKeyDown(eventKey: string, evt: React.KeyboardEvent<HTMLElement>) {
     switch (eventKey) {
       case 'ArrowUp': {
-        return this.hoverNextItem(-1);
+          evt.preventDefault();
+          return this.hoverNextItem(-1);
       }
       case 'ArrowDown': {
+        evt.preventDefault();
         return this.hoverNextItem(1);
       }
       case 'ArrowLeft':

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
@@ -27,7 +27,7 @@ describe('Dropdown', () => {
       initialSelectedIds: [],
     }, props)}
     >
-      <span>Dropdown</span>
+      <span data-hook="open-dropdown-button">Dropdown</span>
     </Dropdown>
   );
 
@@ -60,15 +60,23 @@ describe('Dropdown', () => {
 
     it('should preventDefault on up/down arrows key press inside dropdown content in order to prevent outer scroll', () => {
       const driver = createDriver(createDropdown({options}));
+      const preventDefaultSpy = jest.fn();
       driver.click();
 
-      const arrowDownPreventDefaultSpy = jest.fn();
-      driver.popoverKeyDown('ArrowDown', arrowDownPreventDefaultSpy);
-      expect(arrowDownPreventDefaultSpy).toHaveBeenCalled();
+      Simulate.keyDown(document.querySelector('[data-hook="open-dropdown-button"]'), {key: 'ArrowDown', preventDefault: preventDefaultSpy})
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      preventDefaultSpy.mockClear();
 
-      const arrowUpPreventDefaultSpy = jest.fn();
-      driver.popoverKeyDown('ArrowUp', arrowUpPreventDefaultSpy);
-      expect(arrowUpPreventDefaultSpy).toHaveBeenCalled();
+      Simulate.keyDown(document.querySelector('[data-hook="open-dropdown-button"]'), {key: 'ArrowUp', preventDefault: preventDefaultSpy})
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      preventDefaultSpy.mockClear();
+
+      Simulate.keyDown(document.querySelector('[data-hook="open-dropdown-button"]'), {key: 'ArrowLeft', preventDefault: preventDefaultSpy})
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      preventDefaultSpy.mockClear();
+
+      Simulate.keyDown(document.querySelector('[data-hook="open-dropdown-button"]'), {key: 'ArrowRight', preventDefault: preventDefaultSpy})
+      expect(preventDefaultSpy).toHaveBeenCalled();
     });
 
     it('should show content on hover', async () => {

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
@@ -58,6 +58,19 @@ describe('Dropdown', () => {
       await eventually(() => expect(driver.isContentElementExists()).toBeFalsy());
     });
 
+    it('should preventDefault on up/down arrows key press inside dropdown content in order to prevent outer scroll', () => {
+      const driver = createDriver(createDropdown({options}));
+      driver.click();
+
+      const arrowDownPreventDefaultSpy = jest.fn();
+      driver.popoverKeyDown('ArrowDown', arrowDownPreventDefaultSpy);
+      expect(arrowDownPreventDefaultSpy).toHaveBeenCalled();
+
+      const arrowUpPreventDefaultSpy = jest.fn();
+      driver.popoverKeyDown('ArrowUp', arrowUpPreventDefaultSpy);
+      expect(arrowUpPreventDefaultSpy).toHaveBeenCalled();
+    });
+
     it('should show content on hover', async () => {
       const driver = createDriver(createDropdown({options, openTrigger: HOVER}));
 

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -144,7 +144,7 @@ export class DropdownComponent extends React.PureComponent<DropdownProps & Injec
     }
 
     this.open(() => {
-      this.dropdownContentRef && this.dropdownContentRef.onKeyDown(eventKey);
+      this.dropdownContentRef && this.dropdownContentRef.onKeyDown(eventKey, evt);
       switch (eventKey) {
         case 'Enter': {
           this.onKeyboardSelect();

--- a/packages/wix-ui-core/src/components/popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.driver.ts
@@ -17,6 +17,5 @@ export const popoverDriverFactory = ({element, eventTrigger}) => ({
     return {top, left, right, bottom};
   },
   inlineStyles: () => element.style,
-  getElementId: () => element.id,
-  popoverKeyDown: (key, preventDefault?) => eventTrigger.keyDown(element.querySelector('[data-hook="popover-element"]'), preventDefault ? {key, preventDefault} : {key})
+  getElementId: () => element.id
 });

--- a/packages/wix-ui-core/src/components/popover/Popover.driver.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.driver.ts
@@ -17,5 +17,6 @@ export const popoverDriverFactory = ({element, eventTrigger}) => ({
     return {top, left, right, bottom};
   },
   inlineStyles: () => element.style,
-  getElementId: () => element.id
+  getElementId: () => element.id,
+  popoverKeyDown: (key, preventDefault?) => eventTrigger.keyDown(element.querySelector('[data-hook="popover-element"]'), preventDefault ? {key, preventDefault} : {key})
 });

--- a/packages/wix-ui-core/stories/Dropdown.story.tsx
+++ b/packages/wix-ui-core/stories/Dropdown.story.tsx
@@ -1,0 +1,56 @@
+import {InputWithOptions} from '../src/components/input-with-options';
+import {Option} from '../src/components/dropdown-option';
+import {generateOptions} from '../src/components/dropdown-option/OptionsExample';
+import {Dropdown} from '../src/components/dropdown';
+import * as React from 'react';
+
+const options = generateOptions();
+
+export default {
+  category: 'Base Components',
+  storyName: 'Dropdown',
+  component: Dropdown,
+  componentPath: '../src/components/dropdown',
+
+  componentProps: {
+    'data-hook': 'storybook-dropdown',
+    options,
+    openTrigger: 'click',
+    fixedFooter: 'Fixed Footer',
+    fixedHeader: 'Fixed Header',
+    children: <button>Choose</button>
+  },
+
+  exampleProps: {
+    onSelect: (option: Option) => option.value,
+    onDeselect: (option: Option) => option.value,
+    placement: [
+      'auto-start',
+      'auto',
+      'auto-end',
+      'top-start',
+      'top',
+      'top-end',
+      'right-start',
+      'right',
+      'right-end',
+      'bottom-end',
+      'bottom',
+      'bottom-start',
+      'left-end',
+      'left',
+      'left-start'
+    ],
+
+    options: [
+      {value: options.slice(0, 1), label: '1 example option'},
+      {value: options.slice(0, 5), label: '5 example options'},
+      {value: options, label: '20 example options'}
+    ],
+
+    initialSelectedIds: [
+      {value: [1], label: '[1]'},
+      {value: [1, 3, 4], label: '[1, 3, 4]'}
+    ]
+  }
+};

--- a/packages/wix-ui-core/stories/index.tsx
+++ b/packages/wix-ui-core/stories/index.tsx
@@ -31,6 +31,7 @@ Components.add('Divider', () => <DividerStory />);
 Components.add('GoogleMapsIframeClient', () => <GoogleMapsIframeClientStory />);
 import './Input/Input.story';
 import './InputWithOptions.story';
+import './Dropdown.story';
 import './IconWithOptions.story';
 import './Label.story';
 import './LabelWithOptions.story';


### PR DESCRIPTION
This fix unintended behavior where pressing up & down arrows scroll the outer page as well as selecting dropdown items