### PR TITLE
wix-ui-test-utils - jest-setup: Add consoleErrors api

### DIFF
--- a/packages/wix-ui-test-utils/src/jest-setup/index.ts
+++ b/packages/wix-ui-test-utils/src/jest-setup/index.ts
@@ -8,6 +8,11 @@ console.error = (...args: any[]) => {
   originConsoleError.apply(console, args);
 };
 
+export const consoleErrors = {
+   reset:  () => errors = [],
+   get: () => errors.slice().map(args => args.reduce((acc: string, arg: any) => {return acc + arg; }, ''))
+};
+
 beforeEach(() => errors = []);
 
 afterEach(() => {


### PR DESCRIPTION
To allow testing for prop types errors.

prop-types errors go as console.error.

Allowing to reset the accumulated errors, in order to make jest test pass (since we are testing prop types) and we expect an error.