### PR TITLE
<StoryPage/> - display API markdown if present in metadata

### DIFF
--- a/packages/wix-storybook-utils/src/StoryPage/index.test.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/index.test.tsx
@@ -135,6 +135,23 @@ describe('StoryPage', () => {
     });
   });
 
+  describe('API tab', () => {
+    it('Should render API markdown', () => {
+      testkit.when.created({
+        activeTabId: 'API',
+        component: () => '',
+        codeExample: false,
+        metadata: {
+          props: {},
+          readmeApi: 'data for markdown',
+          displayName: 'Component',
+        },
+      });
+
+      expect(testkit.get.api.markdown().length).toBe(1);
+    });
+  });
+
   describe('Testkit tab', () => {
     it('Should render both testkit markdown and auto generated testkit docs', () => {
       testkit.when.created({

--- a/packages/wix-storybook-utils/src/StoryPage/single-component-layout.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/single-component-layout.tsx
@@ -98,7 +98,7 @@ export const SingleComponentLayout: React.StatelessComponent<
         <Markdown data-hook="api-markdown" source={metadata.readmeApi} />
       )}
 
-      <AutoDocs parsedSource={metadata} />
+      <AutoDocs parsedSource={metadata} showTitle={!metadata.readmeApi} />
     </div>
 
     <div>

--- a/packages/wix-storybook-utils/src/StoryPage/single-component-layout.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/single-component-layout.tsx
@@ -93,7 +93,13 @@ export const SingleComponentLayout: React.StatelessComponent<
       )}
     </div>
 
-    <AutoDocs parsedSource={metadata} />
+    <div>
+      {metadata.readmeApi && (
+        <Markdown data-hook="api-markdown" source={metadata.readmeApi} />
+      )}
+
+      <AutoDocs parsedSource={metadata} />
+    </div>
 
     <div>
       {metadata.readmeTestkit && (

--- a/packages/wix-storybook-utils/src/StoryPage/testkit.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/testkit.tsx
@@ -5,6 +5,7 @@ import Markdown from '../Markdown';
 import AutoExample from '../AutoExample';
 import StoryPage from './index';
 import { AutoTestkit } from '../AutoTestkit/auto-testkit';
+
 export default class {
   component;
 
@@ -41,6 +42,13 @@ export default class {
       this.component.find('[dataHook="metadata-codeblock"]').find(Markdown),
 
     autoExample: () => this.component.find(AutoExample),
+
+    api: {
+      markdown: () => {
+        return this.component.find('[data-hook="api-markdown"]');
+      },
+    },
+
     testkit: {
       markdown: () => {
         return this.component.find('[data-hook="testkit-markdown"]');

--- a/packages/wix-storybook-utils/src/typings/metadata.ts
+++ b/packages/wix-storybook-utils/src/typings/metadata.ts
@@ -8,6 +8,7 @@ export interface Metadata {
     [s: string]: Prop;
   };
   readme?: string;
+  readmeApi?: string;
   readmeTestkit?: string;
   readmeAccessibility?: string;
   drivers?: Driver[];


### PR DESCRIPTION
This PR utilizes the changes in https://github.com/wix/react-autodocs-utils/pull/14 and displays the `readmeApi` metadata (if present) in the API tab.