### PR TITLE
Wix ui test utils/fix vanilla unitestkit creator

### DIFF
--- a/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
+++ b/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
@@ -63,7 +63,7 @@ export async function isUniEnzymeTestkitExists<T extends BaseUniDriver> (
   mount: MountFunctionType
   ) {
     const dataHook = 'myDataHook';
-    const elementToRender = React.cloneElement(Element , {'data-hook': dataHook});
+    const elementToRender = React.cloneElement(Element , {'data-hook': dataHook, dataHook});
     const wrapper = mount(elementToRender);
     const testkit = testkitFactory({wrapper, dataHook});
     return await testkit.exists();

--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -73,7 +73,8 @@ export async function isUniTestkitExists<T extends BaseUniDriver>(
   const div = document.createElement('div');
   const dataHook = 'myDataHook';
   const elementToRender = React.cloneElement(Element, {
-    'data-hook': dataHook
+    'data-hook': dataHook,
+    dataHook
   });
   const renderedElement = ReactTestUtils.renderIntoDocument(
     <div>{elementToRender}</div>


### PR DESCRIPTION
this PR fixes two issues:

1) fix `obj.wrapper.querySelector` `undefined is not a function` error for vanilla testkits. Fix is to reuse already existing `getElement`
2) vanilla and enzyme testkit assertion methods need to pass both `dataHook` and `data-hook`. due to different react versions, depending on whether stylable `...style` thing is used or not, if component extends `WixComponent` or if `dataHook` is set manually. Simple fix is to just always pass both kebab and pascal cases. This also fixes testkit-smoke for unidrivers