### PR TITLE
<Popover/> - add support for `flip` and update `moveBy` properly

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
@@ -64,11 +64,11 @@ describe('Popover', () => {
       await createDriver('story-popover-fixed-behaviour');
     });
 
-    eyes.it('flip disabled (default)', async () => {
+    eyes.it('fixed disabled (default)', async () => {
       await scrollToBottom('story-popover-fixed-disabled');
     });
 
-    eyes.it('flip enabled', async () => {
+    eyes.it('fixed enabled', async () => {
       await scrollToBottom('story-popover-flip-enabled');
     });
   });

--- a/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
@@ -4,7 +4,9 @@ import {createStoryUrl, waitForVisibilityOf, scrollToElement} from 'wix-ui-test-
 import * as autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 import {popoverTestkitFactory} from '../../testkit/protractor';
 
-// Scroll to the bottom of a container
+// Scroll to the bottom of a scrollable container. We assume the container has a `100px` height.
+// This utility function is used for the `flip` and `fixed` props tests, as they depeneds on a
+// scrollable container in the <Popover/>'s story.
 const scrollToBottom = async dataHook => {
   await browser.executeScript(
     `document.querySelector('[data-hook="${dataHook}"]').scrollTop = 100`,
@@ -50,13 +52,19 @@ describe('Popover', () => {
       await createDriver('story-popover-flip-behaviour');
     });
 
-    eyes.it('flip enabled (default)', async () => {
-      await scrollToBottom('story-popover-flip-enabled');
-    });
+    eyes.it(
+      'should flip the popover\'s placements when it overlaps the target element (default)',
+      async () => {
+        await scrollToBottom('story-popover-flip-enabled');
+      }
+    );
 
-    eyes.it('flip disabled', async () => {
-      await scrollToBottom('story-popover-flip-disabled');
-    });
+    eyes.it(
+      'should not flip the popover\'s placement when it overlaps the target elements when flip is disabled',
+      async () => {
+        await scrollToBottom('story-popover-flip-disabled');
+      }
+    );
   });
 
   describe('Fixed behaviour', () => {
@@ -64,12 +72,15 @@ describe('Popover', () => {
       await createDriver('story-popover-fixed-behaviour');
     });
 
-    eyes.it('fixed disabled (default)', async () => {
+    eyes.it('should keep the popover\'s visible when it overflows the container', async () => {
       await scrollToBottom('story-popover-fixed-disabled');
     });
 
-    eyes.it('fixed enabled', async () => {
-      await scrollToBottom('story-popover-flip-enabled');
-    });
+    eyes.it(
+      'should not keep the popover\'s visible when it overflows the container when fixed is enabled',
+      async () => {
+        await scrollToBottom('story-popover-fixed-enabled');
+      }
+    );
   });
 });

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {Simulate} from 'react-dom/test-utils';
 import {queryHook} from 'wix-ui-test-utils/dom';
 import {Popover, PopoverProps} from './';
+import {createModifiers} from './modifiers';
 import {popoverDriverFactory} from './Popover.driver';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
 import * as eventually from 'wix-eventually';
@@ -498,6 +499,117 @@ describe('Popover', () => {
 
       expect(queryPopoverElement().childNodes[0].nodeName).toEqual('DIV');
       expect(queryPopoverContent().childNodes[0].nodeName).toEqual('DIV');
+    });
+  });
+
+  describe('createModifiers', () => {
+    const defaultProps = {
+      moveBy: undefined,
+      appendTo: undefined,
+      shouldAnimate: false,
+      flip: true,
+      fixed: false,
+      placement: 'bottom',
+      isTestEnv: false,
+    };
+
+    it('should match default modifiers', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+      });
+
+      expect(modifiers).toEqual({
+        offset: {
+          offset: '0px, 0px',
+        },
+        computeStyle: {
+          gpuAcceleration: true,
+        },
+        flip: {
+          enabled: true,
+        },
+        preventOverflow: {
+          enabled: true,
+        },
+        hide: {
+          enabled: true,
+        },
+      });
+    });
+
+    it('should calculate the offset properly using moveBy for the top placement', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        moveBy: { x: 5, y: 10 },
+        placement: 'top',
+      });
+
+      expect(modifiers.offset.offset).toEqual('5px, 10px');
+    });
+
+    it('should calculate the offset properly using moveBy for the right placement', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        moveBy: { x: 5, y: 10 },
+        placement: 'right',
+      });
+
+      expect(modifiers.offset.offset).toEqual('10px, 5px');
+    });
+
+    it('should disable gpuAcceleration when animation is enabled', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        shouldAnimate: true,
+      });
+
+      expect(modifiers.computeStyle.gpuAcceleration).toEqual(false);
+    });
+
+    it('should disable the flip modifier if moveBy was provided', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        moveBy: { x: 5, y: 10 },
+      });
+
+      expect(modifiers.flip.enabled).toEqual(false);
+    });
+
+    it('should disable the flip modifier when set explicitly', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        flip: false
+      });
+
+      expect(modifiers.flip.enabled).toEqual(false);
+    });
+
+    it('should disable `preventOverflow` and `hide` when fixed set to `true`', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        fixed: true
+      });
+
+      expect(modifiers.preventOverflow.enabled).toEqual(false);
+      expect(modifiers.hide.enabled).toEqual(false);
+    });
+
+    it('should disable computeStyle when isTestEnv is set to `true`', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        isTestEnv: true,
+      });
+
+      expect(modifiers.computeStyle.enabled).toEqual(false);
+    });
+
+    it('should set boundariesElement when appendTo is provided', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        appendTo: 'viewport',
+      });
+
+      expect(modifiers.preventOverflow.boundariesElement).toEqual('viewport');
     });
   });
 });

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -59,6 +59,11 @@ export interface PopoverProps {
    * when it starts to overlap the target element (`<Popover.Element/>`).
    */
   flip?: boolean;
+  /**
+   * Whether to enable the fixed behaviour. This behaviour used to keep the `<Popover/>` at it's
+   * original placement even when it's being positioned outside the boundary.
+   */
+  fixed?: boolean;
   /** Moves popover relative to the parent */
   moveBy?: { x: number, y: number };
   /** Hide Delay */
@@ -127,7 +132,7 @@ const calculateOffset = ({moveBy, placement}): string => {
   return `${moveBy ? moveBy.x : 0}px, ${moveBy ? moveBy.y : 0}px`;
 };
 
-const createModifiers = ({moveBy, appendTo, shouldAnimate, flip, placement}) => {
+const createModifiers = ({moveBy, appendTo, shouldAnimate, flip, fixed, placement}) => {
   const modifiers: PopperJS.Modifiers = {
     offset: {
       offset: calculateOffset({moveBy, placement}),
@@ -137,6 +142,9 @@ const createModifiers = ({moveBy, appendTo, shouldAnimate, flip, placement}) => 
     },
     flip: {
       enabled: typeof moveBy === 'undefined' ? flip : !moveBy
+    },
+    preventOverflow: {
+      enabled: !fixed,
     }
   };
 
@@ -146,6 +154,7 @@ const createModifiers = ({moveBy, appendTo, shouldAnimate, flip, placement}) => 
 
   if (appendTo) {
     modifiers.preventOverflow = {
+      ...modifiers.preventOverflow,
       boundariesElement: appendTo
     };
   }
@@ -189,6 +198,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
 
   static defaultProps = {
     flip: true,
+    fixed: false,
   };
 
   static Element = createComponentThatRendersItsChildren('Popover.Element');
@@ -217,10 +227,10 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
   }
 
   getPopperContentStructure(childrenObject) {
-    const {moveBy, appendTo, placement, showArrow, moveArrowTo, flip} = this.props;
+    const {moveBy, appendTo, placement, showArrow, moveArrowTo, flip, fixed} = this.props;
     const shouldAnimate = shouldAnimatePopover(this.props);
 
-    const modifiers = createModifiers({moveBy, appendTo, shouldAnimate, flip, placement});
+    const modifiers = createModifiers({moveBy, appendTo, shouldAnimate, flip, placement, fixed});
 
     const popper = (
       <Popper

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -145,6 +145,9 @@ const createModifiers = ({moveBy, appendTo, shouldAnimate, flip, fixed, placemen
     },
     preventOverflow: {
       enabled: !fixed,
+    },
+    hide: {
+      enabled: !fixed
     }
   };
 

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -60,7 +60,7 @@ export interface PopoverProps {
    */
   flip?: boolean;
   /**
-   * Whether to enable the fixed behaviour. This behaviour used to keep the `<Popover/>` at it's
+   * Whether to enable the fixed behaviour. This behaviour is used to keep the `<Popover/>` at it's
    * original placement even when it's being positioned outside the boundary.
    */
   fixed?: boolean;

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -55,7 +55,7 @@ export interface PopoverProps {
   /** Show show arrow from the content */
   showArrow?: boolean;
   /**
-   * Whether to enable the flip behaviour. This behaviour used to flip the `<Popover/>`'s placement
+   * Whether to enable the flip behaviour. This behaviour is used to flip the `<Popover/>`'s placement
    * when it starts to overlap the target element (`<Popover.Element/>`).
    */
   flip?: boolean;

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -442,7 +442,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     }
 
     // Update popover visibility
-    if (prevProps.shown !== undefined && prevProps.shown !== shown) {
+    if (prevProps.shown !== shown) {
       if (shown) {
         this.showPopover();
       } else {

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -6,6 +6,7 @@ import {Manager, Reference, Popper} from 'react-popper';
 import {CSSTransition} from 'react-transition-group';
 import {Portal} from 'react-portal';
 import style from './Popover.st.css';
+import {createModifiers} from './modifiers';
 
 import {
   buildChildrenObject,
@@ -116,55 +117,6 @@ const getArrowShift = (shift: number | undefined, direction: string) => {
   };
 };
 
-const calculateOffset = ({moveBy, placement}): string => {
-  /*
-   * For `right` and `left` placements, we need to flip the `x` and `y` values as Popper.JS will use
-   * the first value for the main axis. As per Popper.js docs:
-   *
-   *   if the placement is top or bottom, the length will be the width. In case of left or right, it
-   *   will be the height.
-   *
-   */
-  if (placement.includes('right') || placement.includes('left')) {
-    return `${moveBy ? moveBy.y : 0}px, ${moveBy ? moveBy.x : 0}px`;
-  }
-
-  return `${moveBy ? moveBy.x : 0}px, ${moveBy ? moveBy.y : 0}px`;
-};
-
-const createModifiers = ({moveBy, appendTo, shouldAnimate, flip, fixed, placement}) => {
-  const modifiers: PopperJS.Modifiers = {
-    offset: {
-      offset: calculateOffset({moveBy, placement}),
-    },
-    computeStyle: {
-      gpuAcceleration: !shouldAnimate
-    },
-    flip: {
-      enabled: typeof moveBy === 'undefined' ? flip : !moveBy
-    },
-    preventOverflow: {
-      enabled: !fixed,
-    },
-    hide: {
-      enabled: !fixed
-    }
-  };
-
-  if (isTestEnv) {
-    modifiers.computeStyle = {enabled: false};
-  }
-
-  if (appendTo) {
-    modifiers.preventOverflow = {
-      ...modifiers.preventOverflow,
-      boundariesElement: appendTo
-    };
-  }
-
-  return modifiers;
-};
-
 function getAppendToNode({appendTo, targetRef}) {
   let appendToNode;
   if (appendTo === 'window' || appendTo === 'viewport') {
@@ -233,7 +185,15 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     const {moveBy, appendTo, placement, showArrow, moveArrowTo, flip, fixed} = this.props;
     const shouldAnimate = shouldAnimatePopover(this.props);
 
-    const modifiers = createModifiers({moveBy, appendTo, shouldAnimate, flip, placement, fixed});
+    const modifiers = createModifiers({
+      moveBy,
+      appendTo,
+      shouldAnimate,
+      flip,
+      placement,
+      fixed,
+      isTestEnv
+    });
 
     const popper = (
       <Popper

--- a/packages/wix-ui-core/src/components/popover/modifiers.ts
+++ b/packages/wix-ui-core/src/components/popover/modifiers.ts
@@ -1,0 +1,60 @@
+import PopperJS from 'popper.js';
+
+const calculateOffset = ({moveBy, placement}): string => {
+  /*
+   * For `right` and `left` placements, we need to flip the `x` and `y` values as Popper.JS will use
+   * the first value for the main axis. As per Popper.js docs:
+   *
+   *   if the placement is top or bottom, the length will be the width. In case of left or right, it
+   *   will be the height.
+   *
+   */
+  if (placement.includes('right') || placement.includes('left')) {
+    return `${moveBy ? moveBy.y : 0}px, ${moveBy ? moveBy.x : 0}px`;
+  }
+
+  return `${moveBy ? moveBy.x : 0}px, ${moveBy ? moveBy.y : 0}px`;
+};
+
+export const createModifiers = ({
+  moveBy,
+  appendTo,
+  shouldAnimate,
+  flip,
+  fixed,
+  placement,
+  isTestEnv
+}) => {
+  const preventOverflow = !fixed;
+
+  const modifiers: PopperJS.Modifiers = {
+    offset: {
+      offset: calculateOffset({moveBy, placement}),
+    },
+    computeStyle: {
+      gpuAcceleration: !shouldAnimate
+    },
+    flip: {
+      enabled: typeof moveBy === 'undefined' ? flip : !moveBy
+    },
+    preventOverflow: {
+      enabled: preventOverflow,
+    },
+    hide: {
+      enabled: preventOverflow,
+    }
+  };
+
+  if (isTestEnv) {
+    modifiers.computeStyle = {enabled: false};
+  }
+
+  if (appendTo) {
+    modifiers.preventOverflow = {
+      ...modifiers.preventOverflow,
+      boundariesElement: appendTo
+    };
+  }
+
+  return modifiers;
+};

--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -159,7 +159,7 @@ export default {
           Content element (<code>{`<Popover.Content/>`}</code>) intentionally overlapping the Target
           element (<code>{`<Popover.Element/>`}</code>).
         </p>
-        <Popover placement="left" shown moveBy={{ x: 100, y: 50 }} showArrow>
+        <Popover placement="right" shown moveBy={{ x: 50, y: 100 }} showArrow>
           <Popover.Element>
             <div style={{ height: '80px' }}>The element</div>
           </Popover.Element>

--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -37,6 +37,7 @@ const ScrollableContainer = props => (
       width: 250,
       margin: 10
     }}
+    data-hook={props.dataHook}
   >
     <div
       style={{
@@ -44,7 +45,7 @@ const ScrollableContainer = props => (
         height: 120,
       }}
     >
-      <div style={{ padding: '25px 25px 150px' }}>
+      <div style={{ padding: '25px 25px 80px' }}>
         {props.children}
       </div>
     </div>
@@ -190,7 +191,7 @@ export default {
         <PopoverWithState showDelay={1000} hideDelay={1000} />
       </div>
 
-      <div>
+      <div data-hook="story-popover-flip-behaviour">
         <h2>Flip behaviour</h2>
         <p>
           This behaviour used to flip the <code>{`<Popover/>`}</code>'s placement
@@ -201,18 +202,18 @@ export default {
 
         <br/>
 
-        <ScrollableContainer>
+        <ScrollableContainer dataHook="story-popover-flip-enabled">
           With <code>flip</code> enabled (default):<br/><br/><br/>
           <PopoverWithState placement="top" />
         </ScrollableContainer>
 
-        <ScrollableContainer>
+        <ScrollableContainer dataHook="story-popover-flip-disabled">
           With <code>flip</code> disabled:<br/><br/><br/>
           <PopoverWithState placement="top" flip={false} />
         </ScrollableContainer>
       </div>
 
-      <div>
+      <div data-hook="story-popover-fixed-behaviour">
         <h2>Fixed behaviour</h2>
         <p>
           This behaviour used to keep the <code>{`<Popover/>`}</code> in it's original
@@ -224,12 +225,12 @@ export default {
 
         <br/>
 
-        <ScrollableContainer>
+        <ScrollableContainer dataHook="story-popover-fixed-disabled">
           With <code>fixed</code> disabled (default):<br/><br/><br/>
           <PopoverWithState placement="top" />
         </ScrollableContainer>
 
-        <ScrollableContainer>
+        <ScrollableContainer dataHook="story-popover-fixed-enabled">
           With <code>fixed</code> enabled:<br/><br/><br/>
           <PopoverWithState placement="top" fixed />
         </ScrollableContainer>

--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -8,11 +8,11 @@ class PopoverWithState extends React.Component<Partial<PopoverProps>,{shown: boo
 
   render() {
     const props: PopoverProps & {children?: any} = {
-      ...this.props,
       placement: 'right',
       showArrow: true,
       shown: this.state.shown,
-      onClick:()=> this.setState({shown: !this.state.shown})
+      onClick:()=> this.setState({shown: !this.state.shown}),
+      ...this.props
     }
     return (
       <Popover {...props}>
@@ -26,6 +26,30 @@ class PopoverWithState extends React.Component<Partial<PopoverProps>,{shown: boo
     )
   }
 }
+
+const ScrollableContainer = props => (
+  <div
+    style={{
+      textAlign: 'center',
+      overflow: 'hidden',
+      position: 'relative',
+      border: '1px solid black',
+      width: 250,
+      margin: 10
+    }}
+  >
+    <div
+      style={{
+        overflow: 'auto',
+        height: 120,
+      }}
+    >
+      <div style={{ padding: '25px 25px 150px' }}>
+        {props.children}
+      </div>
+    </div>
+  </div>
+);
 
 const children = [
   {label: 'Default example',
@@ -127,10 +151,15 @@ export default {
         <h2>moveBy={'{x:50, y:100}'}</h2>
         <p>
           <em>x</em> and <em>y</em> axis orientation is relative to the placement of the popover.<br/>
-          If the <em>placement</em> is <code>"top"</code> or <code>"bottom"</code>, <em>x</em> represents offset in the horizontal axis and <em>y</em> in the vertical axis.<br/>
-          If the <em>placement</em> is <code>"left"</code> or <code>"right"</code>, <em>x</em> represents offset in the vertical axis and <em>y</em> in the horizontal axis.
+
+          <br/>
+
+          The <code>flip</code> behaviour is disabled when this props is used, in order to support
+          negative values when making the<br/>
+          Content element (<code>{`<Popover.Content/>`}</code>) intentionally overlapping the Target
+          element (<code>{`<Popover.Element/>`}</code>).
         </p>
-        <Popover placement="left" shown moveBy={{ x: 50, y: 100 }} showArrow>
+        <Popover placement="left" shown moveBy={{ x: 100, y: 50 }} showArrow>
           <Popover.Element>
             <div style={{ height: '80px' }}>The element</div>
           </Popover.Element>
@@ -159,6 +188,28 @@ export default {
         <br/>
 
         <PopoverWithState showDelay={1000} hideDelay={1000} />
+      </div>
+
+      <div>
+        <h2>Flip behaviour</h2>
+        <p>
+          This behaviour used to flip the <code>{`<Popover/>`}</code>'s placement
+          when it starts to overlap the target element (<code>{`<Popover.Element/>`}</code>).
+          <br/>
+          It is enabled by default.
+        </p>
+
+        <br/>
+
+        <ScrollableContainer>
+          With flip enabled:<br/>
+          <PopoverWithState placement="top" />
+        </ScrollableContainer>
+
+        <ScrollableContainer>
+          With flip disabled:<br/>
+          <PopoverWithState placement="top" flip={false} />
+        </ScrollableContainer>
       </div>
     </div>
   )

--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -37,9 +37,9 @@ const ScrollableContainer = props => (
       width: 250,
       margin: 10
     }}
-    data-hook={props.dataHook}
   >
     <div
+      data-hook={props.dataHook}
       style={{
         overflow: 'auto',
         height: 120,

--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -202,13 +202,36 @@ export default {
         <br/>
 
         <ScrollableContainer>
-          With flip enabled:<br/>
+          With <code>flip</code> enabled (default):<br/><br/><br/>
           <PopoverWithState placement="top" />
         </ScrollableContainer>
 
         <ScrollableContainer>
-          With flip disabled:<br/>
+          With <code>flip</code> disabled:<br/><br/><br/>
           <PopoverWithState placement="top" flip={false} />
+        </ScrollableContainer>
+      </div>
+
+      <div>
+        <h2>Fixed behaviour</h2>
+        <p>
+          This behaviour used to keep the <code>{`<Popover/>`}</code> in it's original
+          placement.<br/> By default this behaviour is <b>disabled</b>, and the &nbsp;
+          <code>{`<Popover/>`}</code> will change it's position when it'll being positioned outside<br/>
+          the boundary (the boundry is the value of the <code>appendTo</code> prop).
+          <br/>
+        </p>
+
+        <br/>
+
+        <ScrollableContainer>
+          With <code>fixed</code> disabled (default):<br/><br/><br/>
+          <PopoverWithState placement="top" />
+        </ScrollableContainer>
+
+        <ScrollableContainer>
+          With <code>fixed</code> enabled:<br/><br/><br/>
+          <PopoverWithState placement="top" fixed />
         </ScrollableContainer>
       </div>
     </div>

--- a/packages/wix-ui-core/stories/Popover.story.tsx
+++ b/packages/wix-ui-core/stories/Popover.story.tsx
@@ -42,7 +42,7 @@ const ScrollableContainer = props => (
       data-hook={props.dataHook}
       style={{
         overflow: 'auto',
-        height: 120,
+        height: 100,
       }}
     >
       <div style={{ padding: '25px 25px 80px' }}>


### PR DESCRIPTION
This PR adds a `flip` prop in order to control Popper.JS's `flip` behaviour (more info can be found [here](https://popper.js.org/popper-documentation.html#modifiers..flip)).

In addition, the `moveBy` behaviour has been changed so when its enabled, the `flip` behaviour will be disabled in order to support passing negative values to the Content element will overlap the Target element.

Also, it fixes the misleading usage at per https://github.com/wix/wix-style-react/issues/2636.

----

**Update:** a new `fixed` prop was added. When set, it'll disable the `preventOverflow` modifier so the popover will stay at the same position at all times. Check the examples for more info.