### PR TITLE
wix-ui-test-utils: fix uniTestkit exists

### DIFF
--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -66,10 +66,17 @@ export function isTestkitExists<T extends BaseDriver>(
   return testkit.exists();
 }
 
-export async function isUniTestkitExists<T extends BaseUniDriver> (Element: React.ReactElement<any>, testkitFactory: (obj: {wrapper: any, dataHook: string}) => T) {
+export async function isUniTestkitExists<T extends BaseUniDriver> (
+  Element: React.ReactElement<any>,
+  testkitFactory: (obj: {wrapper: any, dataHook: string}) => T,
+  options?: { dataHookPropName?: string }) {
   const div = document.createElement('div');
   const dataHook = 'myDataHook';
-  const elementToRender = React.cloneElement(Element, {'data-hook': dataHook});
+  const dataHookPropName = options && options.dataHookPropName;
+  const extraProps = dataHookPropName
+    ? {[dataHookPropName]: dataHook}
+    : {'data-hook': dataHook, dataHook}; // For backward compatibility add dataHook which is used in Wix-Style-React
+  const elementToRender = React.cloneElement(Element, extraProps);
   const renderedElement = ReactTestUtils.renderIntoDocument(<div>{elementToRender}</div>);
   const wrapper = div.appendChild((renderedElement as any));
   const testkit = testkitFactory({wrapper, dataHook});

--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -72,11 +72,8 @@ export async function isUniTestkitExists<T extends BaseUniDriver> (
   options?: { dataHookPropName?: string }) {
   const div = document.createElement('div');
   const dataHook = 'myDataHook';
-  const dataHookPropName = options && options.dataHookPropName;
-  const extraProps = dataHookPropName
-    ? {[dataHookPropName]: dataHook}
-    : {'data-hook': dataHook, dataHook}; // For backward compatibility add dataHook which is used in Wix-Style-React
-  const elementToRender = React.cloneElement(Element, extraProps);
+  const dataHookPropName = (options && options.dataHookPropName) || 'data-hook';
+  const elementToRender = React.cloneElement(Element, {[dataHookPropName]: dataHook});
   const renderedElement = ReactTestUtils.renderIntoDocument(<div>{elementToRender}</div>);
   const wrapper = div.appendChild((renderedElement as any));
   const testkit = testkitFactory({wrapper, dataHook});


### PR DESCRIPTION
Support also `dataHook` prop (not only `data-hook`)