### PR TITLE
chore(AutoTestkit/fields-documentation): do not fail upon undefined unit type

### DIFF
--- a/packages/wix-storybook-utils/src/AutoTestkit/fields-documentation.test.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/fields-documentation.test.tsx
@@ -75,10 +75,7 @@ describe('FieldsDocumentation', () => {
     });
   });
 
-  it('fails when invalid unit type is given', () => {
-    const consoleError = console.error;
-    console.error = jest.fn();
-
+  it('should not fail given invalid unit type', () => {
     const units = [
       {
         type: 'notFittingType',
@@ -89,9 +86,7 @@ describe('FieldsDocumentation', () => {
 
     driver.create({ units }, spy);
 
-    expect(spy).toHaveBeenCalled();
-
-    console.error = consoleError;
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it('has a property header', () => {

--- a/packages/wix-storybook-utils/src/AutoTestkit/fields-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/fields-documentation.tsx
@@ -18,10 +18,12 @@ export const FieldsDocumentation = ({ units }) => {
         </tr>
       </thead>
       <tbody>
-        {units.map((unit, i) => {
-          const Documentation = typeComponents[unit.type];
-          return <Documentation key={i} unit={unit} />;
-        })}
+        {units
+          .filter(({ type }) => typeComponents[type])
+          .map((unit, i) => {
+            const Documentation = typeComponents[unit.type];
+            return <Documentation key={i} unit={unit} />;
+          })}
       </tbody>
     </table>
   ) : (


### PR DESCRIPTION
otherwise entire story page fails. ErrorBoundary is not yet an option,
because consumers of AutoTestkit might be with React15

closes https://github.com/wix/wix-style-react/issues/2685