### PR TITLE
OptionFactory.createHighlighted - Supporting spaces in search term

### DIFF
--- a/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
@@ -799,36 +799,6 @@ describe('AddressInput', () => {
         });
     });
 
-    describe('Highlight', () => {
-        it('should highlight text in dropdown', async () => {
-            init({value: 'ne'});
-            GoogleMapsClientStub.setAddresses([helper.ADDRESS_1, helper.ADDRESS_2]);
-            driver.click();
-            driver.setValue('ne');
-            driver.keyDown('e');
-            await waitForCond(() => driver.isContentElementExists());
-            const highlightedStrings = driver.optionAt(0).getHighlightedStrings();
-            expect(highlightedStrings).toEqual({
-                highlighted: ['Ne'],
-                nonHighlighted: ['1 East Broadway, ', 'w York, NY, USA']
-            });
-        });
-
-        it('should highlight text in dropdown, even if it is not continuous', async () => {
-            init({value: 'ne yo'});
-            GoogleMapsClientStub.setAddresses([helper.ADDRESS_1, helper.ADDRESS_2]);
-            driver.click();
-            driver.setValue('ne yo');
-            driver.keyDown('o');
-            await waitForCond(() => driver.isContentElementExists());
-            const highlightedStrings = driver.optionAt(0).getHighlightedStrings();
-            expect(highlightedStrings).toEqual({
-                highlighted: ['Ne', 'Yo'],
-                nonHighlighted: ['1 East Broadway, ', 'w ', 'rk, NY, USA']
-            });
-        });
-    });
-
     describe('testkit', () => {
         it('should exist', () => {
             expect(isTestkitExists(

--- a/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
@@ -120,7 +120,7 @@ describe('AddressInput', () => {
         await waitForCond(() => driver.isContentElementExists());
         expect(helper.getOptionsText(driver)).toEqual([helper.ADDRESS_DESC_1, helper.ADDRESS_DESC_2]);
     });
-    
+
     it('Should display all result from maps client', async () => {
         init();
         GoogleMapsClientStub.setAddresses([helper.ADDRESS_1, helper.ADDRESS_2]);
@@ -796,6 +796,36 @@ describe('AddressInput', () => {
             init({onMouseLeave});
             driver.mouseLeaveInput();
             expect(onMouseLeave).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Highlight', () => {
+        it('should highlight text in dropdown', async () => {
+            init({value: 'ne'});
+            GoogleMapsClientStub.setAddresses([helper.ADDRESS_1, helper.ADDRESS_2]);
+            driver.click();
+            driver.setValue('ne');
+            driver.keyDown('e');
+            await waitForCond(() => driver.isContentElementExists());
+            const highlightedStrings = driver.optionAt(0).getHighlightedStrings();
+            expect(highlightedStrings).toEqual({
+                highlighted: ['Ne'],
+                nonHighlighted: ['1 East Broadway, ', 'w York, NY, USA']
+            });
+        });
+
+        it('should highlight text in dropdown, even if it is not continuous', async () => {
+            init({value: 'ne yo'});
+            GoogleMapsClientStub.setAddresses([helper.ADDRESS_1, helper.ADDRESS_2]);
+            driver.click();
+            driver.setValue('ne yo');
+            driver.keyDown('o');
+            await waitForCond(() => driver.isContentElementExists());
+            const highlightedStrings = driver.optionAt(0).getHighlightedStrings();
+            expect(highlightedStrings).toEqual({
+                highlighted: ['Ne', 'Yo'],
+                nonHighlighted: ['1 East Broadway, ', 'w ', 'rk, NY, USA']
+            });
         });
     });
 

--- a/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.driver.ts
+++ b/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.driver.ts
@@ -13,5 +13,14 @@ export const dropdownOptionDriverFactory = ({element, eventTrigger}) => {
     isDisabled: () => element && domUtils.hasStyleState(element, 'disabled'),
     getText: () => element && element.textContent,
     getElement: () => element,
+    getHighlightedStrings: () => {
+        const highlightedElements: Array<HTMLElement> = Array.from(element.querySelectorAll(`.${styles.highlight}`));
+        const highlighted = highlightedElements.map((el: HTMLElement) => el.innerHTML);
+
+        const nonHighlightedElements: Array<HTMLElement> = Array.from(element.querySelectorAll(`.${styles.nonHighlight}`));
+        const nonHighlighted = nonHighlightedElements.map((el: HTMLElement) => el.innerHTML);
+
+        return {highlighted, nonHighlighted};
+    }
   };
 };

--- a/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.driver.ts
+++ b/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.driver.ts
@@ -15,12 +15,7 @@ export const dropdownOptionDriverFactory = ({element, eventTrigger}) => {
     getElement: () => element,
     getHighlightedStrings: () => {
         const highlightedElements: Array<HTMLElement> = Array.from(element.querySelectorAll(`.${styles.highlight}`));
-        const highlighted = highlightedElements.map((el: HTMLElement) => el.innerHTML);
-
-        const nonHighlightedElements: Array<HTMLElement> = Array.from(element.querySelectorAll(`.${styles.nonHighlight}`));
-        const nonHighlighted = nonHighlightedElements.map((el: HTMLElement) => el.innerHTML);
-
-        return {highlighted, nonHighlighted};
+        return highlightedElements.map((el: HTMLElement) => el.innerHTML);
     }
   };
 };

--- a/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {DropdownOption, Option} from './';
 import {dropdownOptionDriverFactory} from './DropdownOption.driver';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
-import {sleep} from 'wix-ui-test-utils/react-helpers';
+import {OptionFactory} from './OptionFactory';
 
 describe('DropdownOption', () => {
   const createDriver =
@@ -13,12 +13,11 @@ describe('DropdownOption', () => {
   const onClickHandler = jest.fn();
   const onMouseEnterHandler = jest.fn();
 
-  const createOption = (isDisabled = false) => ({
+  const createOption = (isDisabled = false) => OptionFactory.create({
     id: 1,
     isDisabled,
     isSelectable: !isDisabled,
     value: 'value',
-    render: () => 'value'
   });
 
   const createDropdownOption = (option: Option) => (
@@ -68,4 +67,11 @@ describe('DropdownOption', () => {
     expect(driver.isSelected()).toBeFalsy();
     expect(driver.isDisabled()).toBeTruthy();
   });
+
+  it('should integrate with highlighting functionality of OptionFactory', () => {
+    const highlighted = 'lu';
+    const option = OptionFactory.createHighlighted(createOption(), highlighted);
+    const driver = createDriver(createDropdownOption(option));
+    expect(driver.getHighlightedStrings()).toEqual([highlighted]);
+  })
 });

--- a/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.spec.tsx
@@ -77,25 +77,63 @@ describe('OptionFactory', () => {
     expect(option.render(value)).toEqual(<Divider className={undefined}>value</Divider>);
   });
 
-  it('should create highlighted option', () => {
-    const existingOption = OptionFactory.create({value});
-    const option = OptionFactory.createHighlighted(existingOption, 'lu');
-    expect(option.id).toContain('Option');
-    expect(option.isDisabled).toBeFalsy();
-    expect(option.isSelectable).toBeTruthy();
-    expect(option.render(value)).toEqual([
-      <span className={style.nonHighlight} key={0}>va</span>,
-      <mark className={style.highlight} key={1}>lu</mark>,
-      <span className={style.nonHighlight} key={2}>e</span>
-    ]);
-  });
+  describe('Highlight', () => {
+    it('should create highlighted option', () => {
+      const existingOption = OptionFactory.create({value});
+      const option = OptionFactory.createHighlighted(existingOption, 'lu');
+      expect(option.id).toContain('Option');
+      expect(option.isDisabled).toBeFalsy();
+      expect(option.isSelectable).toBeTruthy();
+      expect(option.render(value)).toEqual([
+        <span className={style.nonHighlight} key={0}>va</span>,
+        <mark className={style.highlight} key={1}>lu</mark>,
+        <span className={style.nonHighlight} key={2}>e</span>
+      ]);
+    });
 
-  it('should create highlighted option with divider', () => {
-    const existingOption = OptionFactory.createDivider();
-    const option = OptionFactory.createHighlighted(existingOption, 'lu');
-    expect(option.id).toContain('Divider');
-    expect(option.isDisabled).toBeFalsy();
-    expect(option.isSelectable).toBeFalsy();
-    expect(option.render(value)).toEqual(<Divider className={undefined} />);
+    it('should support multiple highlight criteria, divided by space', () => {
+      const existingOption = OptionFactory.create({value: 'This is a sentence'});
+      const option = OptionFactory.createHighlighted(existingOption, 'his sen');
+      expect(option.render(value)).toEqual([
+        <span className={style.nonHighlight} key={0}>T</span>,
+        <mark className={style.highlight} key={1}>his</mark>,
+        <span className={style.nonHighlight} key={2}> is a </span>,
+        <mark className={style.highlight} key={3}>sen</mark>,
+        <span className={style.nonHighlight} key={4}>tence</span>,
+      ]);
+    });
+
+    it('should handle a case where the beginning of the string is matched', () => {
+      const existingOption = OptionFactory.create({value});
+      const option = OptionFactory.createHighlighted(existingOption, 'valu');
+      expect(option.id).toContain('Option');
+      expect(option.isDisabled).toBeFalsy();
+      expect(option.isSelectable).toBeTruthy();
+      expect(option.render(value)).toEqual([
+        <mark className={style.highlight} key={0}>valu</mark>,
+        <span className={style.nonHighlight} key={1}>e</span>
+      ]);
+    });
+
+    it('should handle a value ending with a white space', () => {
+      const existingOption = OptionFactory.create({value});
+      const option = OptionFactory.createHighlighted(existingOption, 'va ');
+      expect(option.id).toContain('Option');
+      expect(option.isDisabled).toBeFalsy();
+      expect(option.isSelectable).toBeTruthy();
+      expect(option.render(value)).toEqual([
+        <mark className={style.highlight} key={0}>va</mark>,
+        <span className={style.nonHighlight} key={1}>lue</span>
+      ]);
+    });
+
+    it('should create highlighted option with divider', () => {
+      const existingOption = OptionFactory.createDivider();
+      const option = OptionFactory.createHighlighted(existingOption, 'lu');
+      expect(option.id).toContain('Divider');
+      expect(option.isDisabled).toBeFalsy();
+      expect(option.isSelectable).toBeFalsy();
+      expect(option.render(value)).toEqual(<Divider className={undefined} />);
+    });
   });
 });

--- a/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {Divider} from '../../components/deprecated/divider';
 import style from './DropdownOption.st.css';
 const uniqueId = require('lodash/uniqueId');
+const compact = require('lodash/compact');
 
 export interface Option {
   id: number | string;
@@ -24,11 +25,16 @@ const createOption = (option: Partial<Option> = null): Option =>
   );
 
 const escapeRegExp = (s: string) => s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+const highlightRegExt = (s: string) => new RegExp(`(${s.replace(/ /g, '|')})`, 'gi');
+const isEven = i => i % 2 === 0;
+const isOdd = i => i % 2 === 1;
 
-const hightlightMatches = (option: Option, searchTerm: string): Option => {
-  const re = new RegExp(`(${escapeRegExp(searchTerm)})`, 'gi');
-  const parts = option.value.split(re).map((part, i) =>
-    i % 2 ? <mark className={style.highlight} key={i}>{part}</mark> : <span className={style.nonHighlight} key={i}>{part}</span>
+const highlightMatches = (option: Option, searchTerm: string): Option => {
+  const regExp = highlightRegExt(escapeRegExp(searchTerm.trim()));
+  const stringArray = option.value.split(regExp);
+  const f = stringArray[0] === '' ? isEven : isOdd;
+  const parts = compact(stringArray).map((part, i) =>
+    f(i) ? <mark className={style.highlight} key={i}>{part}</mark> : <span className={style.nonHighlight} key={i}>{part}</span>
   );
 
   return createOption({
@@ -55,7 +61,7 @@ export const OptionFactory = {
       render: value ? () => <Divider className={className}>{value}</Divider> : () => <Divider className={className}/>
     });
   },
-  createHighlighted(option: Option, hightlightValue: string): Option {
-    return option.value && hightlightValue ? hightlightMatches(option, hightlightValue) : option;
+  createHighlighted(option: Option, highlightValue: string): Option {
+    return option.value && highlightValue ? highlightMatches(option, highlightValue) : option;
   }
 };


### PR DESCRIPTION
This change allows us to highlight values, even if the search term contains spaces.

Having an option with the value of "New York" -
Before this change, if the user has typed "ne", the result would be "**Ne**w York" (which is perfectly fine), but if the user typed "Ne Y", the string will not be highlighted at all.
After this fix, for the "Ne Y" input, the result will be "**Ne**w **Y**ork"