### PR TITLE
<ButtonNext /> - fixing ButtonNext render as something else bugs

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -4,7 +4,7 @@ import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { ButtonNext } from './';
 import { buttonNextPrivateDriverFactory } from './button-next.driver.private';
 
-describe.only('ButtonNext', () => {
+describe('ButtonNext', () => {
   const createDriver = new ReactDOMTestContainer()
     .unmountAfterEachTest()
     .createUniRenderer(buttonNextPrivateDriverFactory);

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -107,34 +107,4 @@ describe('ButtonNext', () => {
       });
     });
   });
-
-  describe('should receive button html attribute type', async () => {
-    it('when rendered component is custom react component', async () => {
-      const CustomComponent = props => <button {...props}>Hello</button>;
-      testContainer.renderSync(
-        <ButtonNext as={CustomComponent} type="submit" />
-      );
-      await eventually(() => {
-        const htmlTag = testContainer.componentNode.getAttribute('type');
-        expect(htmlTag).toBe('submit');
-      });
-    });
-    it('when rendered component is html button(default)', async () => {
-      testContainer.renderSync(<ButtonNext type="submit" />);
-      await eventually(() => {
-        const htmlTag = testContainer.componentNode.getAttribute('type');
-        expect(htmlTag).toBe('submit');
-      });
-    });
-  });
-
-  describe('should not receive html attribute type', async () => {
-    it('when rendered component is html anchor', async () => {
-      testContainer.renderSync(<ButtonNext as="a" />);
-      await eventually(() => {
-        const htmlTag = testContainer.componentNode.getAttribute('type');
-        expect(!!htmlTag).toBe(false);
-      });
-    });
-  });
 });

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -4,7 +4,7 @@ import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { ButtonNext } from './';
 import { buttonNextPrivateDriverFactory } from './button-next.driver.private';
 
-describe('ButtonNext', () => {
+describe.only('ButtonNext', () => {
   const createDriver = new ReactDOMTestContainer()
     .unmountAfterEachTest()
     .createUniRenderer(buttonNextPrivateDriverFactory);

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -126,13 +126,6 @@ describe('ButtonNext', () => {
         expect(htmlTag).toBe('submit');
       });
     });
-    it('when rendered component is defined by user', async () => {
-      testContainer.renderSync(<ButtonNext as="button" />);
-      await eventually(() => {
-        const htmlTag = testContainer.componentNode.getAttribute('type');
-        expect(htmlTag).toBe('button');
-      });
-    });
   });
 
   describe('should not receive html attribute type', async () => {

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -56,7 +56,6 @@ describe('ButtonNext', () => {
     const Test = props => <span {...props} />;
     it('should render by default as html button', async () => {
       testContainer.renderSync(<ButtonNext />);
-
       await eventually(() => {
         const htmlTag = testContainer.componentNode.tagName;
         expect(htmlTag).toBe('BUTTON');
@@ -64,7 +63,6 @@ describe('ButtonNext', () => {
     });
     it('should render custom html tag', async () => {
       testContainer.renderSync(<ButtonNext as="a" />);
-
       await eventually(() => {
         const htmlTag = testContainer.componentNode.tagName;
         expect(htmlTag).toBe('A');
@@ -72,7 +70,6 @@ describe('ButtonNext', () => {
     });
     it('should render custom react component', async () => {
       testContainer.renderSync(<ButtonNext as={Test} />);
-
       await eventually(() => {
         const htmlTag = testContainer.componentNode.tagName;
         expect(htmlTag).toBe('SPAN');
@@ -102,27 +99,36 @@ describe('ButtonNext', () => {
     });
   });
 
-  describe(`'type' prop`, () => {
-    it('should render value `button` when props `as` and `type` are undefined', async () => {
-      testContainer.renderSync(<ButtonNext />);
-
-      await eventually(() => {
-        const htmlTag = testContainer.componentNode.getAttribute('type');
-        expect(htmlTag).toBe('button');
-      });
-    });
-    it('should render value `submit` when prop `type="submit"` and `as` is undefined', async () => {
-      testContainer.renderSync(<ButtonNext type="submit" />);
-
+  describe('should receive button html attribute type', async () => {
+    it('when rendered component is custom react component', async () => {
+      const CustomComponent = props => <button {...props}>Hello</button>;
+      testContainer.renderSync(
+        <ButtonNext as={CustomComponent} type="submit" />
+      );
       await eventually(() => {
         const htmlTag = testContainer.componentNode.getAttribute('type');
         expect(htmlTag).toBe('submit');
       });
     });
+    it('when rendered component is html button(default)', async () => {
+      testContainer.renderSync(<ButtonNext type="submit" />);
+      await eventually(() => {
+        const htmlTag = testContainer.componentNode.getAttribute('type');
+        expect(htmlTag).toBe('submit');
+      });
+    });
+    it('when rendered component is defined by user', async () => {
+      testContainer.renderSync(<ButtonNext as="button" />);
+      await eventually(() => {
+        const htmlTag = testContainer.componentNode.getAttribute('type');
+        expect(htmlTag).toBe('button');
+      });
+    });
+  });
 
-    it('should render prop `type` undefined if as prop is `a`', async () => {
+  describe('should not receive html attribute type', async () => {
+    it('when rendered component is html anchor', async () => {
       testContainer.renderSync(<ButtonNext as="a" />);
-
       await eventually(() => {
         const htmlTag = testContainer.componentNode.getAttribute('type');
         expect(!!htmlTag).toBe(false);

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -97,6 +97,15 @@ describe('ButtonNext', () => {
         expect(htmlTag).toBe('true');
       });
     });
+
+    it('when given should render href as undefined', async () => {
+      testContainer.renderSync(<ButtonNext as="a" disabled href="wix" />);
+
+      await eventually(() => {
+        const htmlTag = testContainer.componentNode.getAttribute('href');
+        expect(!!htmlTag).toBe(false);
+      });
+    });
   });
 
   describe('should receive button html attribute type', async () => {

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -6,7 +6,7 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** an element type to render as (string or function).  */
   as?: string | React.ComponentType<any>;
-  /** anchor attribute */
+  /** URL of the page that link goes to */
   href?: string;
   /** accepts prefix icon */
   prefixIcon?: React.ReactElement<any>;

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -1,30 +1,24 @@
 import * as React from 'react';
 import { withFocusable } from '../../hocs/Focusable/FocusableHOC';
-import classnames from 'classnames';
 import style from './button-next.st.css';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** an element type to render as (string or function).  */
-  as?: any;
+  as?: string | React.ComponentType<any>;
+  /** anchor attribute */
+  href?: string;
   /** accepts prefix icon */
   prefixIcon?: React.ReactElement<any>;
   /** accepts suffix icon  */
   suffixIcon?: React.ReactElement<any>;
-  /** callback need to be applied for onFocus event */
-  focusableOnFocus?: React.FocusEventHandler<HTMLButtonElement>;
-  /** callback need to be applied for onBlur event */
-  focusableOnBlur?: React.FocusEventHandler<HTMLButtonElement>;
   /** apply disabled styles */
   disabled?: boolean;
 }
 
-export type NativeButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
-  ButtonProps;
-
-const _addAffix = (AffixComp, styleClass) =>
-  AffixComp &&
-  React.cloneElement(AffixComp, {
+const _addAffix = (Affix, styleClass) =>
+  Affix &&
+  React.cloneElement(Affix, {
     className: style[styleClass],
   });
 
@@ -32,33 +26,32 @@ const _addAffix = (AffixComp, styleClass) =>
  * ButtonNext
  */
 
-const ButtonNextComponent: React.SFC<NativeButtonProps> = props => {
+const ButtonNextComponent: React.SFC<
+  ButtonProps & { focusableOnFocus: () => void; focusableOnBlur: () => void }
+> = props => {
   const {
     as: Component,
     suffixIcon,
     prefixIcon,
     children,
+    disabled,
     focusableOnFocus,
     focusableOnBlur,
-    disabled,
+    href,
     ...rest
   } = props;
-  const isButton = Component === 'button';
-  const restProps = isButton ? rest : (rest as any);
-  const htmlType = isButton ? restProps.type || 'button' : restProps.type;
-  const htmlTabIndex = disabled ? -1 : restProps.tabIndex || 0;
-  const htmlHref = disabled ? undefined : restProps.href;
+  const htmlTabIndex = disabled ? -1 : rest.tabIndex || 0;
+  const htmlHref = disabled ? undefined : href;
   return (
     <Component
       {...rest}
       onFocus={focusableOnFocus}
       onBlur={focusableOnBlur}
-      disabled={disabled}
-      type={htmlType}
+      disabled={href ? undefined : disabled}
       href={htmlHref}
       tabIndex={htmlTabIndex}
       aria-disabled={disabled}
-      {...style('root', { disabled }, restProps)}
+      {...style('root', { disabled }, rest)}
     >
       {_addAffix(prefixIcon, 'prefix')}
       <span className={style.content}>{children}</span>

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -46,7 +46,7 @@ const ButtonNextComponent: React.SFC<NativeButtonProps> = props => {
   const restProps = isButton ? rest : (rest as any);
   const htmlType = isButton ? restProps.type || 'button' : restProps.type;
   const htmlTabIndex = disabled ? -1 : restProps.tabIndex || 0;
-  const htmlRef = disabled ? undefined : restProps.href;
+  const htmlHref = disabled ? undefined : restProps.href;
   const ariaDisabled = disabled ? true : restProps['aria-disabled'];
   return (
     <Component
@@ -55,7 +55,7 @@ const ButtonNextComponent: React.SFC<NativeButtonProps> = props => {
       onBlur={focusableOnBlur}
       disabled={disabled}
       type={htmlType}
-      href={htmlRef}
+      href={htmlHref}
       tabIndex={htmlTabIndex}
       aria-disabled={ariaDisabled}
       {...style('root', { disabled }, restProps)}

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -22,10 +22,10 @@ export interface ButtonProps
 export type NativeButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
   ButtonProps;
 
-const _addAffix = (AffixComp, styleClass, className) =>
+const _addAffix = (AffixComp, styleClass) =>
   AffixComp &&
   React.cloneElement(AffixComp, {
-    className: classnames(style[styleClass], className),
+    className: style[styleClass],
   });
 
 /**
@@ -60,9 +60,9 @@ const ButtonNextComponent: React.SFC<NativeButtonProps> = props => {
       aria-disabled={disabled}
       {...style('root', { disabled }, restProps)}
     >
-      {_addAffix(prefixIcon, 'prefix', restProps.className)}
+      {_addAffix(prefixIcon, 'prefix')}
       <span className={style.content}>{children}</span>
-      {_addAffix(suffixIcon, 'suffix', restProps.className)}
+      {_addAffix(suffixIcon, 'suffix')}
     </Component>
   );
 };

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { withFocusable } from '../../hocs/Focusable/FocusableHOC';
 import style from './button-next.st.css';
 
-export interface ButtonProps {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** an element type to render as (string or function).  */
   as?: any;
   /** accepts prefix icon */
@@ -17,8 +18,8 @@ export interface ButtonProps {
   disabled?: boolean;
 }
 
-export type NativeButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & ButtonProps;
-
+export type NativeButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  ButtonProps;
 
 const _addAffix = (Affix, classname) =>
   Affix &&
@@ -30,9 +31,9 @@ const _addAffix = (Affix, classname) =>
  * ButtonNext
  */
 
-const ButtonNextComponent: React.SFC<ButtonProps> = props => {
+const ButtonNextComponent: React.SFC<NativeButtonProps> = props => {
   const {
-    as,
+    as: Component,
     suffixIcon,
     prefixIcon,
     children,
@@ -41,17 +42,22 @@ const ButtonNextComponent: React.SFC<ButtonProps> = props => {
     disabled,
     ...rest
   } = props;
-  const Component = as;
-  const restProps = as === 'button'? rest as NativeButtonProps: rest as any;
+  const isButton = Component === 'button';
+  const restProps = isButton ? rest : (rest as any);
+  const htmlType = isButton ? restProps.type || 'button' : restProps.type;
+  const htmlTabIndex = disabled ? -1 : restProps.tabIndex || 0;
+  const htmlRef = disabled ? undefined : restProps.href;
+  const ariaDisabled = disabled ? true : restProps['aria-disabled'];
   return (
     <Component
       {...rest}
       onFocus={focusableOnFocus}
       onBlur={focusableOnBlur}
       disabled={disabled}
-      type={as === 'button' ? restProps.type || 'button' : undefined}
-      tabIndex={disabled ? -1 : restProps.tabIndex || 0}
-      aria-disabled={disabled ? true : rest['aria-disabled']}
+      type={htmlType}
+      href={htmlRef}
+      tabIndex={htmlTabIndex}
+      aria-disabled={ariaDisabled}
       {...style('root', { disabled }, restProps)}
     >
       {_addAffix(prefixIcon, 'prefix')}

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -47,7 +47,6 @@ const ButtonNextComponent: React.SFC<NativeButtonProps> = props => {
   const htmlType = isButton ? restProps.type || 'button' : restProps.type;
   const htmlTabIndex = disabled ? -1 : restProps.tabIndex || 0;
   const htmlHref = disabled ? undefined : restProps.href;
-  const ariaDisabled = disabled ? true : restProps['aria-disabled'];
   return (
     <Component
       {...rest}
@@ -57,7 +56,7 @@ const ButtonNextComponent: React.SFC<NativeButtonProps> = props => {
       type={htmlType}
       href={htmlHref}
       tabIndex={htmlTabIndex}
-      aria-disabled={ariaDisabled}
+      aria-disabled={disabled}
       {...style('root', { disabled }, restProps)}
     >
       {_addAffix(prefixIcon, 'prefix')}

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { withFocusable } from '../../hocs/Focusable/FocusableHOC';
+import classnames from 'classnames';
 import style from './button-next.st.css';
 
 export interface ButtonProps
@@ -21,10 +22,10 @@ export interface ButtonProps
 export type NativeButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
   ButtonProps;
 
-const _addAffix = (Affix, classname) =>
-  Affix &&
-  React.cloneElement(Affix, {
-    className: style[classname],
+const _addAffix = (AffixComp, styleClass, className) =>
+  AffixComp &&
+  React.cloneElement(AffixComp, {
+    className: classnames(style[styleClass], className),
   });
 
 /**
@@ -59,9 +60,9 @@ const ButtonNextComponent: React.SFC<NativeButtonProps> = props => {
       aria-disabled={disabled}
       {...style('root', { disabled }, restProps)}
     >
-      {_addAffix(prefixIcon, 'prefix')}
+      {_addAffix(prefixIcon, 'prefix', restProps.className)}
       <span className={style.content}>{children}</span>
-      {_addAffix(suffixIcon, 'suffix')}
+      {_addAffix(suffixIcon, 'suffix', restProps.className)}
     </Component>
   );
 };


### PR DESCRIPTION
Fixes:
- Let users pass `type` at any time.
- Defined `href` attribute   as undefined when `disabled` is passed.
- Additional refactors and unit tests for use cases.