### PR TITLE
Revert "lock react-popper version to 1.3.1 (#1058)"

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -57,7 +57,7 @@
     "playable": "2.4.5",
     "popper.js": "^1.14.5",
     "react-onclickoutside": "^6.7.0",
-    "react-popper": "1.3.1",
+    "react-popper": "^1.3.0",
     "react-portal": "^4.1.5",
     "react-transition-group": "^2.2.1",
     "shallowequal": "1.1.0",


### PR DESCRIPTION
This reverts commit dce5f783741cb2f2e1c82b403204be9bcf512cb7.