### PR TITLE
[eslint-plugin-wix-style-react]: Disable `no-full-wsr-lib` for WSR greater than 5.9.0.

### DIFF
--- a/packages/eslint-plugin-wix-style-react/lib/rules/no-full-wsr-lib.js
+++ b/packages/eslint-plugin-wix-style-react/lib/rules/no-full-wsr-lib.js
@@ -3,9 +3,12 @@
  * @author YairH
  */
 
+const { matchesVersion, isVersionGreater } = require('../utils/version');
+
 const LIB_NAME = 'wix-style-react';
 const ERROR =
-  "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';`";
+  "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';` or update WSR to at least 5.9.0 version";
+const MAX_VERSION = '5.8.1';
 
 module.exports = {
   meta: {
@@ -19,9 +22,11 @@ module.exports = {
   },
 
   create(context) {
+    const shouldIgnoreNamedImports = isVersionGreater(LIB_NAME, MAX_VERSION);
+
     return {
       ImportDeclaration(node) {
-        if (isDestructuredImportStatement(node)) {
+        if (!shouldIgnoreNamedImports && isDestructuredImportStatement(node)) {
           context.report({
             node,
             message: ERROR,

--- a/packages/eslint-plugin-wix-style-react/lib/utils/version.js
+++ b/packages/eslint-plugin-wix-style-react/lib/utils/version.js
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Utility functions for wix-style-react version configuration.
+ * @author Artem Yavorsky
+ */
+
+const resolve = require('resolve');
+const semver = require('semver');
+
+function detectVersion(packageName) {
+  try {
+    const pkgPath = resolve.sync(`${packageName}/package.json`, {basedir: process.cwd()});
+    const pkg = require(pkgPath);
+    return pkg.version;
+  } catch (e) {
+    return null;
+  }
+}
+
+function isVersionGreater(packageName, version) {
+  const currentVersion = detectVersion(packageName);
+  if (!currentVersion) return false;
+  return semver.gt(currentVersion, version);
+};
+
+module.exports = {
+  detectVersion,
+  isVersionGreater,
+};

--- a/packages/eslint-plugin-wix-style-react/package.json
+++ b/packages/eslint-plugin-wix-style-react/package.json
@@ -10,14 +10,18 @@
   "author": "yairhaimo",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha tests --recursive",
+    "test": "mocha './tests/{,!(fixtures)/**}/*.js' --recursive",
     "release": "wnpm-release --no-shrinkwrap"
   },
   "dependencies": {
-    "requireindex": "~1.1.0"
+    "requireindex": "~1.1.0",
+    "resolve": "^1.9.0",
+    "semver": "^5.6.0"
   },
   "devDependencies": {
+    "assert": "^1.4.1",
     "eslint": "~3.9.1",
+    "execa": "^1.0.0",
     "mocha": "^3.1.2",
     "wnpm-ci": "latest"
   },

--- a/packages/eslint-plugin-wix-style-react/tests/fixtures/disable-no-full-wsr-lib/no-full-wsr-lib.js
+++ b/packages/eslint-plugin-wix-style-react/tests/fixtures/disable-no-full-wsr-lib/no-full-wsr-lib.js
@@ -1,6 +1,5 @@
 /**
- * @fileoverview Fail if importing all of WSR
- * @author YairH
+ * @fileoverview Fails if importing all of WSR using commonjs. Works for named imports. Exists in >= 5.9 WSR environment.
  */
 'use strict';
 

--- a/packages/eslint-plugin-wix-style-react/tests/fixtures/disable-no-full-wsr-lib/no-full-wsr-lib.js
+++ b/packages/eslint-plugin-wix-style-react/tests/fixtures/disable-no-full-wsr-lib/no-full-wsr-lib.js
@@ -23,19 +23,9 @@ RuleTester.setDefaultConfig({
 //------------------------------------------------------------------------------
 const ruleTester = new RuleTester();
 ruleTester.run('no-full-wsr-lib', rule, {
-  valid: [`import Button from 'wix-style-react/Button';`],
+  valid: [`import {Button} from 'wix-style-react';`],
 
   invalid: [
-    {
-      code: "import {Button, Panel} from 'wix-style-react';",
-      errors: [
-        {
-          message:
-            "Wix-Style-React is imported in a way that does not support tree shaking. Use a direct import, for example: `import Button from 'wix-style-react/Button';` or update WSR to at least 5.9.0 version",
-          type: 'ImportDeclaration'
-        }
-      ]
-    },
     {
       code: "const Button = require('wix-style-react').Button;",
       errors: [

--- a/packages/eslint-plugin-wix-style-react/tests/lib/rules/disable-no-full-wsr-lib-runner.js
+++ b/packages/eslint-plugin-wix-style-react/tests/lib/rules/disable-no-full-wsr-lib-runner.js
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview Fail if importing all of WSR
+ * @author YairH
+ */
+'use strict';
+
+const path = require('path');
+const execa = require('execa');
+
+try {
+  const test = execa.shellSync('mocha --recursive --colors .', {
+    stderr: 'inherit',
+    cwd: path.resolve(__dirname, '../../fixtures/disable-no-full-wsr-lib')
+  });
+  console.log('Fixtures passing: ', test.stdout);
+} catch(e) {
+  throw e.stdout;
+}

--- a/packages/eslint-plugin-wix-style-react/tests/lib/rules/disable-no-full-wsr-lib-runner.js
+++ b/packages/eslint-plugin-wix-style-react/tests/lib/rules/disable-no-full-wsr-lib-runner.js
@@ -1,6 +1,5 @@
 /**
- * @fileoverview Fail if importing all of WSR
- * @author YairH
+ * @fileoverview Runs tests on fixtures for specific project environment.
  */
 'use strict';
 

--- a/packages/eslint-plugin-wix-style-react/tests/lib/utils/version.js
+++ b/packages/eslint-plugin-wix-style-react/tests/lib/utils/version.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const assert = require('assert');
+const { detectVersion, isVersionGreater } = require('../../../lib/utils/version');
+
+describe('Version', () => {
+  const base = path.resolve(__dirname, '..', '..', 'fixtures', 'version');
+  const pkgName = 'wix-style-react'; // 5.1.2;
+  const uninstalledPkgName = 'some-uninstalled-package'; // null
+  let cwd;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    process.chdir(base);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+  });
+
+  describe('detect', () => {
+    it('matches wsr version', () => {
+      assert.equal(detectVersion(pkgName), '5.1.2');
+    });
+
+    it('returns null for uninstalled version', () => {
+      assert.equal(detectVersion(uninstalledPkgName), null);
+    });
+  });
+
+  describe('is greater check', () => {
+    it('works for lower version', () => {
+      assert.equal(isVersionGreater(pkgName, '5.1.0'), true);
+    });
+
+    it('works for greater version', () => {
+      assert.equal(isVersionGreater(pkgName, '7.0.0'), false);
+    });
+
+    it('works for same version', () => {
+      assert.equal(isVersionGreater(pkgName, '5.1.2'), false);
+    });
+
+    it('works for uninstalled package', () => {
+      assert.equal(isVersionGreater(uninstalledPkgName, '2.0.0'), false);
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/wix/wix-style-react/issues/2450.

The main idea - disable `no-full-wsr-lib` rule if WSR ^5.9.0 found (the version that supports Tree shaking).

Will add more description a bit later...