### PR TITLE
<Popover/> - use the `flip` prop regardless of `moveBy` if defined

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -580,9 +580,20 @@ describe('Popover', () => {
       const modifiers = createModifiers({
         ...defaultProps,
         moveBy: { x: 5, y: 10 },
+        flip: undefined,
       });
 
       expect(modifiers.flip.enabled).toEqual(false);
+    });
+
+    it('should enabled the flip modifier is set explicitly regardless of moveBy', () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        moveBy: { x: 5, y: 10 },
+        flip: true,
+      });
+
+      expect(modifiers.flip.enabled).toEqual(true);
     });
 
     it('should disable the flip modifier when set explicitly', () => {

--- a/packages/wix-ui-core/src/components/popover/modifiers.ts
+++ b/packages/wix-ui-core/src/components/popover/modifiers.ts
@@ -35,7 +35,7 @@ export const createModifiers = ({
       gpuAcceleration: !shouldAnimate
     },
     flip: {
-      enabled: typeof moveBy === 'undefined' ? flip : !moveBy
+      enabled: typeof flip !== 'undefined' ? flip : !moveBy
     },
     preventOverflow: {
       enabled: preventOverflow,


### PR DESCRIPTION
This PR makes the `<Popover/>` to use the `flip` if it was defined, regardless of the `moveBy` prop.

```jsx
<Popover />                          // flip: true,  previously true
<Popover moveBy={{}} />              // flip: false, previously false
<Popover moveBy={{}} flip />         // flip: true,  previously false
<Popover moveBy={{}} flip={false} /> // flip: false, previously false
```