### PR TITLE
`<ButtonNext/>` - Fix `driver.isButtonDisabled`, fix tests, add missing tests.

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
@@ -3,18 +3,25 @@ import {
   baseUniDriverFactory
 } from 'wix-ui-test-utils/base-driver';
 import { UniDriver } from 'unidriver';
+import {StylableUnidriverUtil} from '../../../test/StylableUnidriverUtil';
+import styles from './button-next.st.css';
 
 export interface ButtonNextDriver extends BaseUniDriver {
   /** returns button text */
   getButtonTextContent: () => Promise<string>;
   /** returns true if button disabled */
-  isButtonDisabled: () => Promise<any>;
+  isButtonDisabled: () => Promise<boolean>;
 }
 
 export const buttonNextDriverFactory = (base: UniDriver): ButtonNextDriver => {
+  const stylableUtil = new StylableUnidriverUtil(styles);
+
   return {
     ...baseUniDriverFactory(base),
     getButtonTextContent: async () => await base.text(),
-    isButtonDisabled: async () => !!(await base.attr('disabled'))
+    isButtonDisabled: async () => {
+      // Using stylable state and not html 'disabled' attribute, since if 'href' exists, then we don't pu the 'disabled' attribute.
+      return await stylableUtil.hasStyleState(base, 'disabled');
+    }
   };
 };

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -77,8 +77,26 @@ describe('ButtonNext', () => {
     });
   });
 
-  describe(`'disabled' prop`, () => {
-    it('when given should render component with tabIndex -1', async () => {
+  describe(`Disabled`, () => {
+    describe('isButtonDisabled', () => {
+      it('should NOT be disabled by default', async() => {
+        const driver = createDriver(<ButtonNext />);
+        expect(await driver.isButtonDisabled()).toBeFalsy();
+      });
+      
+      it('should be disabled when disabled is passed', async() => {
+        const driver = createDriver(<ButtonNext disabled />);
+        
+        expect(await driver.isButtonDisabled()).toBeTruthy();
+      });
+      
+      it('should be disabled when href is provided', async() => {
+        const driver = createDriver(<ButtonNext as="a" disabled href="wix" />);
+        expect(await driver.isButtonDisabled()).toBeTruthy();
+      });
+    })
+
+    it('should render component with tabIndex -1 when disabled', async () => {
       testContainer.renderSync(<ButtonNext disabled />);
 
       await eventually(() => {
@@ -87,7 +105,7 @@ describe('ButtonNext', () => {
       });
     });
 
-    it('when given should render aria-disabled as true', async () => {
+    it('should render aria-disabled as true when disabled', async () => {
       testContainer.renderSync(<ButtonNext disabled />);
 
       await eventually(() => {
@@ -98,7 +116,7 @@ describe('ButtonNext', () => {
       });
     });
 
-    it('when given should render href as undefined', async () => {
+    it('should render href as undefined when disabled', async () => {
       testContainer.renderSync(<ButtonNext as="a" disabled href="wix" />);
 
       await eventually(() => {
@@ -106,5 +124,26 @@ describe('ButtonNext', () => {
         expect(!!htmlTag).toBe(false);
       });
     });
+
+    describe('disabled attribute', () => {
+      it(`should have 'disabled' attribute when disabled`, async () => {
+        testContainer.renderSync(<ButtonNext disabled />);
+        
+        await eventually(() => {
+          const disabledAttribute = testContainer.componentNode.getAttribute('disabled');
+          expect(disabledAttribute).not.toBeNull();
+        });
+      });
+      
+      it(`should NOT have 'disabled' attribute when disabled and 'href' is provided`, async () => {
+        testContainer.renderSync(<ButtonNext as="a" disabled href="wix" />);
+        
+        await eventually(() => {
+          const disabledAttribute = testContainer.componentNode.getAttribute('disabled');
+          expect(disabledAttribute).toBeNull();
+        });
+      });
+    })
+
   });
 });

--- a/packages/wix-ui-core/test/StylableUnidriverUtil.ts
+++ b/packages/wix-ui-core/test/StylableUnidriverUtil.ts
@@ -1,0 +1,22 @@
+import { UniDriver } from 'unidriver';
+import { RuntimeStylesheet, StateValue } from '@stylable/runtime';
+
+/**
+ * This is an implementation of StylableDOMUtil for Unidriver.
+ * 
+ * Work-In-Progress: Not all methods are implemented yet !
+ */
+export class StylableUnidriverUtil {
+  constructor(private style: RuntimeStylesheet) { }
+
+  public async hasStyleState(element: UniDriver, stateName: string, param: StateValue = true): Promise<boolean> {
+    const { stateKey, styleState } = this.getStateDataAttrKey(stateName, param);
+    const actual = await element.attr(stateKey);
+    return String(styleState[stateKey]) === actual;
+  }
+  
+  private getStateDataAttrKey(state: string, param: StateValue = true) {
+    const styleState = this.style.$cssStates({ [state]: param });
+    return { stateKey: Object.keys(styleState)[0], styleState };
+  }
+}


### PR DESCRIPTION
### isButtonDisabled
- It was broken, it never returned false. `base.attr('disabled')` always returns an empty string. See Unidriver [issue](https://github.com/wix-incubator/unidriver/issues/22)
- We should check the Stylable `disabled` state (not the native `disabled` attribute) since when `href` is provided then we don't put the `disabled` attribute.

### Tests
- isButtonDisabled was not tested at all.

### StylableUnidriverUtil

I added a partial implementation of StylableDOMUtil for use with Unidriver, trying to keep the same api.