### PR TITLE
wix-ui-core: (Tests Cleanup):  Use render async in tests that use Unidriver

### DIFF
--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -100,7 +100,7 @@ describe('Avatar', () => {
 
     it('should have a default \'alt\' value when image is displayed', async () => {
       const dataHook = 'avatar_test_image';
-      testContainer.renderSync(
+      await testContainer.render(
         <Avatar 
           name="John Doe" 
           imgProps={{src:TEST_IMG_URL, ['data-hook']: dataHook}} 
@@ -114,7 +114,7 @@ describe('Avatar', () => {
     it('should NOT override \'alt\' value when image is displayed', async () => {
       const alt = 'Profile photo of John Doe';
       const dataHook = 'avatar_test_image';
-      testContainer.renderSync(
+      await testContainer.render(
         <Avatar 
           name="John Doe" 
           imgProps={{
@@ -133,7 +133,7 @@ describe('Avatar', () => {
   describe(`'placeholder' prop`, () => {
     it('should render specified placeholder content', async () => {
       const dataHook = 'avatar_test_placeholder';
-      testContainer.renderSync(
+      await testContainer.render(
         <Avatar 
           placeholder={<span data-hook={dataHook}>XXXX</span>}
         />);
@@ -145,7 +145,7 @@ describe('Avatar', () => {
   describe(`'imgProps' prop`, () => {
     it('should render img tag with imgProps', async () => {
       const dataHook = 'avatar_test_image';
-      testContainer.renderSync(
+      await testContainer.render(
         <Avatar 
           imgProps={{
             src:TEST_IMG_URL,
@@ -183,7 +183,7 @@ describe('Avatar', () => {
       
       let wrapper: any;
 
-      testContainer.renderSync(
+      await testContainer.render(
         <AvatarWrapper 
           ref={inst => wrapper = inst}
           imgProps={{
@@ -288,7 +288,7 @@ describe('Avatar', () => {
   describe('className prop', () => {
     it('should pass className prop onto root elemenet', async () => {
         const className = 'foo';
-        testContainer.renderSync(<Avatar className={className}/>);
+        await testContainer.render(<Avatar className={className}/>);
       const driver = reactUniDriver(testContainer.componentNode);
       expect(await driver.attr('class')).toContain(className);
     });
@@ -329,19 +329,19 @@ describe('Avatar', () => {
   describe(`Styling`, () => {
     describe('content pseudo element', () => {
       it('should have content class when text displayed', async () => {
-        testContainer.renderSync(<Avatar text="JD"/>);
+        await testContainer.render(<Avatar text="JD"/>);
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
         expect(utils.select('.content').textContent).toBe('JD');
       });
       
       it('should have content class when placeholder displayed', async () => {
-        testContainer.renderSync(<Avatar placeholder={PLACEHOLDER_AS_TEXT}/>);
+        await testContainer.render(<Avatar placeholder={PLACEHOLDER_AS_TEXT}/>);
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
         expect(utils.select('.content').textContent).toBe('XXXXX');
       });
       
       it('should have content class when image displayed', async () => {
-        testContainer.renderSync(<Avatar imgProps={{ src:TEST_IMG_URL }}/>);
+        await testContainer.render(<Avatar imgProps={{ src:TEST_IMG_URL }}/>);
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
         await eventually(() => {
           expect(utils.select('.content').getAttribute('src')).toBe(TEST_IMG_URL);
@@ -351,7 +351,7 @@ describe('Avatar', () => {
       
     describe('imgLoaded state', () => {
       it('should have imgLoaded', async () => {
-        testContainer.renderSync(
+        await testContainer.render(
           <Avatar imgProps={{ src:TEST_IMG_URL }} />
         );
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
@@ -360,8 +360,8 @@ describe('Avatar', () => {
         });
       });
 
-      it('should NOT have imgLoaded when displaying text', () => {
-        testContainer.renderSync(
+      it('should NOT have imgLoaded when displaying text', async () => {
+        await testContainer.render(
           <Avatar name="John Doe" />
         );
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
@@ -371,7 +371,7 @@ describe('Avatar', () => {
       // This test is skipped because it either passes with jsdom and fails with browser (mocha-runner), or in it's current form
       // passes in browser and fails in jsdom. Until we decide which platform we are testing on, this needs to stay skipped.
       xit('should NOT have imgLoaded when img is not loaded yet', async () => {
-        testContainer.renderSync(
+        await testContainer.render(
           <Avatar imgProps={{ src:INVALID_TEST_IMG_URL }} />
         );
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
@@ -382,16 +382,16 @@ describe('Avatar', () => {
     });
 
     describe('contentType state', () => {
-      it('should be text', () => {
-        testContainer.renderSync(
+      it('should be text', async () => {
+        await testContainer.render(
           <Avatar text="JD" />
         );
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
         expect(utils.getStyleState(testContainer.componentNode, 'contentType')).toBe('text');
       });
 
-      it('should be placeholder', () => {
-        testContainer.renderSync(
+      it('should be placeholder', async () => {
+        await testContainer.render(
           <Avatar placeholder={PLACEHOLDER_AS_TEXT} />
         );
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);
@@ -399,7 +399,7 @@ describe('Avatar', () => {
       });
 
       it('should be image', async () => {
-        testContainer.renderSync(
+        await testContainer.render(
           <Avatar imgProps={{ src:TEST_IMG_URL }}  />
         );
         const utils = new StylableDOMUtil(styles, testContainer.componentNode);

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -17,7 +17,7 @@ describe('Avatar', () => {
   const testContainer = new ReactDOMTestContainer()
     .unmountAfterEachTest();
 
-  const createDriver = testContainer.createUniRenderer(avatarDriverFactory);
+  const createDriver = testContainer.createUniRendererAsync(avatarDriverFactory);
 
   const createDriverFromContainer = () => {
     const base = reactUniDriver(testContainer.componentNode);
@@ -29,34 +29,34 @@ describe('Avatar', () => {
   );
 
   it('should render an empty placeholder by default', async () => {
-    const driver = createDriver(<Avatar />);
+    const driver = await createDriver(<Avatar />);
     expect((await driver.getContentType()) === 'placeholder').toBe(true);
   });
   
   describe(`content type resolution`, () => {
 
     it('should render a text', async () => {
-      const driver = createDriver(<Avatar text="JD" />);
+      const driver = await createDriver(<Avatar text="JD" />);
       expect((await driver.getContentType()) === 'text').toBe(true);
     });
 
     it('should render a text when name given', async () => {
-      const driver = createDriver(<Avatar name="John Doe" />);
+      const driver = await createDriver(<Avatar name="John Doe" />);
       expect((await driver.getContentType()) === 'text').toBe(true);
     });
 
     it('should render an placeholder', async () => {
-      const driver = createDriver(<Avatar placeholder={PLACEHOLDER_AS_TEXT} />);
+      const driver = await createDriver(<Avatar placeholder={PLACEHOLDER_AS_TEXT} />);
       expect((await driver.getContentType()) === 'placeholder').toBe(true);
     });
     
     it('should render an image', async () => {
-      const driver = createDriver(<Avatar imgProps={{src:TEST_IMG_URL}} />);
+      const driver = await createDriver(<Avatar imgProps={{src:TEST_IMG_URL}} />);
       await expectImgEventuallyLoaded(driver);
     });
 
     it('should render a text when given placeholder and text', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Avatar 
           text="JD"
           placeholder={PLACEHOLDER_AS_TEXT} 
@@ -65,7 +65,7 @@ describe('Avatar', () => {
     });
 
     it('should render a text when given placeholder and name', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Avatar 
           name="John Doe"
           placeholder={PLACEHOLDER_AS_TEXT} 
@@ -74,7 +74,7 @@ describe('Avatar', () => {
     });
 
     it('should render an image when given placeholder and image', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Avatar 
           placeholder={PLACEHOLDER_AS_TEXT} 
           imgProps={{src:TEST_IMG_URL}}
@@ -85,12 +85,12 @@ describe('Avatar', () => {
 
   describe(`'name' prop`, () => {
     it('should provide generated initials as text content', async () => {
-      const driver = createDriver(<Avatar name="John Doe" />);
+      const driver = await createDriver(<Avatar name="John Doe" />);
       expect(await driver.getTextContent()).toBe('JD');
     });
 
     it('should NOT override text content', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Avatar 
           name="John Smith Junir Doe"
           text="JsD"
@@ -209,7 +209,7 @@ describe('Avatar', () => {
   describe('nameToInitials', () => {
     describe('limit = 3', () => { 
       it('should render Avatar with 3 letter initials', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Avatar 
             name="John Smith Junir Doe"
             initialsLimit={3}
@@ -248,7 +248,7 @@ describe('Avatar', () => {
 
     describe('limit = 2 (default)', () => { 
       it('should render Avatar with 2 letter initials', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Avatar 
             name="John Smith Junir Doe"
           />);

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -6,21 +6,21 @@ import { buttonNextPrivateDriverFactory } from './button-next.driver.private';
 describe('ButtonNext', () => {
   const createDriver = new ReactDOMTestContainer()
     .unmountAfterEachTest()
-    .createUniRenderer(buttonNextPrivateDriverFactory);
+    .createUniRendererAsync(buttonNextPrivateDriverFactory);
 
   const testContainer = new ReactDOMTestContainer().unmountAfterEachTest();
 
   describe(`'onClick' prop`, () => {
     it('should be called on click', async () => {
       const onClick = jest.fn();
-      const driver = createDriver(<ButtonNext onClick={onClick} />);
+      const driver = await createDriver(<ButtonNext onClick={onClick} />);
       await driver.click();
       expect(onClick).toBeCalled();
     });
 
     it(`should not call 'onClick' when 'disabled'`, async () => {
       const onClick = jest.fn();
-      const driver = createDriver(<ButtonNext onClick={onClick} disabled />);
+      const driver = await createDriver(<ButtonNext onClick={onClick} disabled />);
       await driver.click();
       expect(onClick).not.toBeCalled();
     });
@@ -29,7 +29,7 @@ describe('ButtonNext', () => {
   describe(`'children' prop`, () => {
     it('should render text', async () => {
       const text = 'button';
-      const driver = createDriver(<ButtonNext children={text} />);
+      const driver = await createDriver(<ButtonNext children={text} />);
       expect(await driver.getButtonTextContent()).toBe(text);
     });
   });
@@ -39,13 +39,13 @@ describe('ButtonNext', () => {
     const prefix = <div data-hook="prefix">prefix</div>;
 
     it(`should render 'suffix' when given`, async () => {
-      const driver = createDriver(<ButtonNext suffixIcon={suffix} />);
+      const driver = await createDriver(<ButtonNext suffixIcon={suffix} />);
       expect(await driver.suffixExists()).toBeTruthy();
       expect(await driver.prefixExists()).toBeFalsy();
     });
 
     it(`should render 'prefix' when given`, async () => {
-      const driver = createDriver(<ButtonNext prefixIcon={prefix} />);
+      const driver = await createDriver(<ButtonNext prefixIcon={prefix} />);
       expect(await driver.prefixExists()).toBeTruthy();
       expect(await driver.suffixExists()).toBeFalsy();
     });
@@ -76,18 +76,18 @@ describe('ButtonNext', () => {
   describe(`Disabled`, () => {
     describe('isButtonDisabled', () => {
       it('should NOT be disabled by default', async() => {
-        const driver = createDriver(<ButtonNext />);
+        const driver = await createDriver(<ButtonNext />);
         expect(await driver.isButtonDisabled()).toBeFalsy();
       });
       
       it('should be disabled when disabled is passed', async() => {
-        const driver = createDriver(<ButtonNext disabled />);
+        const driver = await createDriver(<ButtonNext disabled />);
         
         expect(await driver.isButtonDisabled()).toBeTruthy();
       });
       
       it('should be disabled when href is provided', async() => {
-        const driver = createDriver(<ButtonNext as="a" disabled href="wix" />);
+        const driver = await createDriver(<ButtonNext as="a" disabled href="wix" />);
         expect(await driver.isButtonDisabled()).toBeTruthy();
       });
     })

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -55,19 +55,19 @@ describe('ButtonNext', () => {
     const Test = props => <span {...props} />;
     
     it('should render by default as html button', async () => {
-      testContainer.renderSync(<ButtonNext />);
+      await testContainer.render(<ButtonNext />);
       const htmlTag = testContainer.componentNode.tagName;
       expect(htmlTag).toBe('BUTTON');
     });
 
     it('should render custom html tag', async () => {
-      testContainer.renderSync(<ButtonNext as="a" />);
+      await testContainer.render(<ButtonNext as="a" />);
       const htmlTag = testContainer.componentNode.tagName;
       expect(htmlTag).toBe('A');
     });
 
     it('should render custom react component', async () => {
-      testContainer.renderSync(<ButtonNext as={Test} />);
+      await testContainer.render(<ButtonNext as={Test} />);
       const htmlTag = testContainer.componentNode.tagName;
       expect(htmlTag).toBe('SPAN');
     });
@@ -93,14 +93,14 @@ describe('ButtonNext', () => {
     })
 
     it('should render component with tabIndex -1 when disabled', async () => {
-      testContainer.renderSync(<ButtonNext disabled />);
+      await testContainer.render(<ButtonNext disabled />);
 
       const htmlTag = testContainer.componentNode.getAttribute('tabindex');
       expect(htmlTag).toBe('-1');
     });
 
     it('should render aria-disabled as true when disabled', async () => {
-      testContainer.renderSync(<ButtonNext disabled />);
+      await testContainer.render(<ButtonNext disabled />);
 
       const htmlTag = testContainer.componentNode.getAttribute(
         'aria-disabled'
@@ -109,7 +109,7 @@ describe('ButtonNext', () => {
     });
 
     it('should render href as undefined when disabled', async () => {
-      testContainer.renderSync(<ButtonNext as="a" disabled href="wix" />);
+      await testContainer.render(<ButtonNext as="a" disabled href="wix" />);
 
       const htmlTag = testContainer.componentNode.getAttribute('href');
       expect(!!htmlTag).toBe(false);
@@ -117,14 +117,14 @@ describe('ButtonNext', () => {
 
     describe('disabled attribute', () => {
       it(`should have 'disabled' attribute when disabled`, async () => {
-        testContainer.renderSync(<ButtonNext disabled />);
+        await testContainer.render(<ButtonNext disabled />);
         
         const disabledAttribute = testContainer.componentNode.getAttribute('disabled');
         expect(disabledAttribute).not.toBeNull();
       });
       
       it(`should NOT have 'disabled' attribute when disabled and 'href' is provided`, async () => {
-        testContainer.renderSync(<ButtonNext as="a" disabled href="wix" />);
+        await testContainer.render(<ButtonNext as="a" disabled href="wix" />);
         
         const disabledAttribute = testContainer.componentNode.getAttribute('disabled');
         expect(disabledAttribute).toBeNull();

--- a/packages/wix-ui-core/src/components/menu-item/menu-item.spec.tsx
+++ b/packages/wix-ui-core/src/components/menu-item/menu-item.spec.tsx
@@ -3,14 +3,16 @@ import {MenuItem} from './menu-item';
 import {ReactDOMTestContainer} from '../../../test/dom-test-container';
 import {menuItemDriverFactory} from './menu-item.driver';
 
-const createDriver = new ReactDOMTestContainer()
-  .unmountAfterEachTest()
-  .createUniRenderer(menuItemDriverFactory);
 
 describe('MenuItem', () => {
+  
+  const createDriver = new ReactDOMTestContainer()
+    .unmountAfterEachTest()
+    .createUniRendererAsync(menuItemDriverFactory);
+
   describe('`children` prop', () => {
     it('should be rendered', async () => {
-      const driver = createDriver(<MenuItem>hello</MenuItem>);
+      const driver = await createDriver(<MenuItem>hello</MenuItem>);
       expect(await driver.getText()).toEqual('hello');
     });
   });
@@ -18,7 +20,7 @@ describe('MenuItem', () => {
   describe('`onSelect` prop', () => {
     it('should be invoked on click', async () => {
       const onSelect = jest.fn();
-      const driver = createDriver(
+      const driver = await createDriver(
         <MenuItem onSelect={onSelect}>hello</MenuItem>
       );
       await driver.click();
@@ -27,7 +29,7 @@ describe('MenuItem', () => {
 
     it('should not be invoked on click when disabled', async () => {
       const onSelect = jest.fn();
-      const driver = createDriver(
+      const driver = await createDriver(
         <MenuItem onSelect={onSelect} disabled>hello</MenuItem>
       );
       await driver.click();
@@ -42,12 +44,12 @@ describe('MenuItem', () => {
   ].map(([prop, method]) =>
     describe(`\`${prop}\` prop`, async () => {
       it('should be false by default', async () => {
-        const driver = createDriver(<MenuItem>hello</MenuItem>);
+        const driver = await createDriver(<MenuItem>hello</MenuItem>);
         expect(await driver[method]()).toBe(false);
       });
 
       it('should set state when true', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <MenuItem {...{[prop]: true}}>hello</MenuItem>
         );
         expect(await driver[method]()).toBe(true);

--- a/packages/wix-ui-core/test/dom-test-container.ts
+++ b/packages/wix-ui-core/test/dom-test-container.ts
@@ -88,10 +88,21 @@ export class ReactDOMTestContainer {
     };
   }
 
-  // Adapter for react based uni driver
+  /**
+   * Adapter for react based uni driver
+   * @deprecated use createUniRendererAsync instead
+   */
   public createUniRenderer<T>(driverFactory: (base: UniDriver) => T): (element: JSX.Element) => T {
     return (jsx: JSX.Element) => {
       this.renderSync(jsx);
+      const base = reactUniDriver(this.componentNode);
+      return driverFactory(base);
+    };
+  }
+
+  public createUniRendererAsync<T>(driverFactory: (base: UniDriver) => T): (element: JSX.Element) => Promise<T> {
+    return async (jsx: JSX.Element) => {
+      await this.render(jsx);
       const base = reactUniDriver(this.componentNode);
       return driverFactory(base);
     };


### PR DESCRIPTION
Minor switch to using `ReactDomTestContainer.render` (which is async) instead of `ReactDomTestContainer.renderSync`.

This makes the tests forward-compatible with future version of react where the render may be async (According to React docs)