### PR TITLE
Update parent for wix-ui-lint utils.

### DIFF
--- a/packages/wix-ui-lint-utils/pom.xml
+++ b/packages/wix-ui-lint-utils/pom.xml
@@ -10,7 +10,7 @@
 
     <parent>
         <groupId>com.wixpress.common</groupId>
-        <artifactId>wix-master-parent</artifactId>
+        <artifactId>wix-statics-parent</artifactId>
         <version>100.0.0-SNAPSHOT</version>
     </parent>
 


### PR DESCRIPTION
I'm trying to make wix-ui-lint-utils visible for CI stuff and according to https://jira.wixpress.com/browse/CI-13550
and 
https://ci-kb.wixanswers.com/en/article/adding-a-new-build-to-the-build-system
we should at least update `parent.artifactId`.