### PR TITLE
<LiveCodeExample/> - add prettier

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -6,6 +6,9 @@ import { Collapse } from 'react-collapse';
 import copy from 'copy-to-clipboard';
 import styles from './index.scss';
 
+import prettier from 'prettier/standalone';
+import babylonParser from 'prettier/parser-babylon';
+
 import ToggleSwitch from '../ui/toggle-switch';
 import Revert from 'wix-ui-icons-common/Revert';
 import Code from 'wix-ui-icons-common/Code';
@@ -56,8 +59,15 @@ export default class LiveCodeExample extends Component {
   constructor(props) {
     super(props);
 
+    const formattedCode = prettier.format(props.initialCode, {
+      parser: 'babel',
+      plugins: [babylonParser],
+      singleQuote: true,
+      trailingComma: 'all',
+    });
+
     this.state = {
-      code: props.initialCode,
+      code: formattedCode,
       isRtl: false,
       isDarkBackground: false,
       isEditorOpened: !props.compact,


### PR DESCRIPTION
This PR runs prettier in the browser on the `initialCode` being passed to the `<LiveCodeExample/>`.

### Why?

The `initialCode` being passed may be built dynamically. For example, consider the following example in WSR:

https://github.com/wix/wix-style-react/blob/master/stories/Popover/examples/ExampleAppendTo.js#L11-L48

A utility function called `createPropsArray` is used to create a string representing the props, and the result may not follow our coding style. A way to solve this is to add `prettier` to format that initial code.

Also, why not? 🙃