### PR TITLE
wix-storybook-utils: add remounting capability to playground

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/components/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/index.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { Cell } from '../../ui/Layout';
 import UIInput from '../../ui/input';
 import ToggleSwitch from '../../ui/toggle-switch';
+import TextButton from '../../TextButton';
 import Heading from '../../ui/heading';
 
 import ComponentSource from '../../ComponentSource';
@@ -19,12 +20,18 @@ const Preview = ({
   onToggleRtl,
   isDarkBackground,
   onToggleBackground,
+  onRemountComponent,
 }) => (
   <Cell span={6}>
     <div className={styles.title}>
       <Heading>Preview</Heading>
 
       <div className={styles.previewControls}>
+        <div className={styles.previewControl}>
+          <TextButton size="small" onClick={onRemountComponent}>
+            Remount Component
+          </TextButton>
+        </div>
         <div className={styles.previewControl}>
           Imitate RTL:&nbsp;
           <ToggleSwitch size="small" checked={isRtl} onChange={onToggleRtl} />
@@ -45,9 +52,9 @@ const Preview = ({
       {...{
         className: classnames(styles.preview, {
           rtl: isRtl,
-          [styles.darkPreview]: isDarkBackground,
+          [styles.darkPreview]: isDarkBackground
         }),
-        ...(isRtl ? { dir: 'rtl' } : {}),
+        ...(isRtl ? { dir: 'rtl' } : {})
       }}
     >
       {children}
@@ -61,6 +68,7 @@ Preview.propTypes = {
   isDarkBackground: PropTypes.bool,
   onToggleRtl: PropTypes.func,
   onToggleBackground: PropTypes.func,
+  onRemountComponent: PropTypes.func,
 };
 
 const Toggle = ({ value, onChange }) => (
@@ -69,7 +77,7 @@ const Toggle = ({ value, onChange }) => (
 
 Toggle.propTypes = {
   value: PropTypes.bool,
-  onChange: PropTypes.func,
+  onChange: PropTypes.func
 };
 
 const createInput = ({ type = 'string', property }) => ({
@@ -93,7 +101,7 @@ const NumberInput = createInput({ type: 'number', property: 'valueAsNumber' });
 Input.propTypes = NumberInput.propTypes = {
   value: PropTypes.string,
   defaultValue: PropTypes.string,
-  onChange: PropTypes.func,
+  onChange: PropTypes.func
 };
 
 const Code = ({ component }) => (
@@ -107,7 +115,7 @@ const Code = ({ component }) => (
 );
 
 Code.propTypes = {
-  component: PropTypes.node.isRequired,
+  component: PropTypes.node.isRequired
 };
 
 export { Option, Preview, Toggle, Input, NumberInput, List, Code };

--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -126,6 +126,7 @@ export default class extends Component {
       funcAnimate: {},
       isRtl: false,
       isDarkBackground: false,
+      forceRemount: 0,
     };
 
     this._initialPropsState = this.state.propsState;
@@ -143,6 +144,10 @@ export default class extends Component {
   }
 
   resetState = () => this.setState({ propsState: this._initialPropsState });
+
+  remountComponent = () => {
+    this.setState({ forceRemount: this.state.forceRemount + 1 });
+  };
 
   componentWillReceiveProps(nextProps) {
     this.setState({
@@ -377,12 +382,14 @@ export default class extends Component {
         </Cell>
 
         <Preview
+          key={this.state.forceRemount}
           isRtl={this.state.isRtl}
           isDarkBackground={this.state.isDarkBackground}
           onToggleRtl={isRtl => this.setState({ isRtl })}
           onToggleBackground={isDarkBackground =>
             this.setState({ isDarkBackground })
           }
+          onRemountComponent={this.remountComponent}
           children={componentToRender}
         />
 

--- a/packages/wix-storybook-utils/stories/component.js
+++ b/packages/wix-storybook-utils/stories/component.js
@@ -11,17 +11,33 @@ const disabledStyle = {
 };
 
 /** Description from source! */
-const Component = ({ enabled, children, onClick, number }) => (
-  <div style={enabled ? enabledStyle : disabledStyle} onClick={onClick}>
-    {children}
-    the number is {number}
-    <br />
-    and it's type is {typeof number}
-  </div>
-);
+class Component extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      valueSetOnMounting: this.props.valueSetOnMounting,
+    };
+  }
+  render() {
+    const { enabled, children, onClick, number } = this.props;
+    return (
+      <div style={enabled ? enabledStyle : disabledStyle} onClick={onClick}>
+        {children}
+        <br />
+        the number is {number}
+        <br />
+        and it's type is {typeof number}
+        <br />
+        this value is set only when mounted or remount:{' '}
+        {this.state.valueSetOnMounting}
+      </div>
+    );
+  }
+}
 
 Component.propTypes = {
   number: PropTypes.number,
+  valueSetOnMounting: PropTypes.number,
   children: PropTypes.node,
   enabled: PropTypes.bool.isRequired,
   onClick: PropTypes.func,

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -8,7 +8,7 @@ const showcase = `<button className={button.one}>one</button>
 <button className={button.three}>three</button>`;
 
 const exampleScope = {
-  Button: props => <button {...props} />,
+  Button: props => <button {...props} />
 };
 
 const ExampleShowcase = () => (
@@ -41,10 +41,11 @@ export default {
     },
 
     number: 4,
+    valueSetOnMounting: 17,
   },
 
   exampleProps: {
-    onClick: () => 'hai',
+    onClick: () => 'hai'
   },
 
   hiddenProps: ['propNotVisibleInStorybook'],
@@ -123,5 +124,5 @@ render(
         />
       </div>
     </div>
-  ),
+  )
 };


### PR DESCRIPTION
**What's in here**
This new feature will allow remounting the component on demand.

**Motivation**:
In cases where a prop has an effect on the component only mounted, this is a way to force a clean mounting with the given props.
For example, [Captcha](https://wix-wix-ui-core.surge.sh/?selectedKind=Components&selectedStory=Captcha&full=0&addons=0&stories=1&panelRight=0) component sets the theme only when loaded and script is loaded to page.

**How to play with it**
I create a new prop `valueSetOnMounting` for the test component which is copied to the state on initialization. Changing it's value will not have an effect until remounting
![image](https://user-images.githubusercontent.com/6093192/51943053-38625580-2421-11e9-99d2-7cd1da08997a.png)