### PR TITLE
fix(package.json): pin @types/enzyme to 3.1.17

### DIFF
--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -38,7 +38,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@types/enzyme": "^3.1.7",
+    "@types/enzyme": "3.1.17",
     "@types/express": "^4.0.39",
     "@types/jest": "^22.1.1",
     "@types/node": "^8.0.0",


### PR DESCRIPTION
extinguish the fire, 3.1.18 fails build and the chain afterwards
```
node_modules/@types/enzyme/index.d.ts(60,20): error TS2314: Generic type 'ReactElement<P>' requires 1 type argument(s).
```