### PR TITLE
<LiveCodeExample/> - fix reset button in case of errors

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -36,6 +36,7 @@ export default class LiveCodeExample extends Component {
   resetCode = () => {
     this.setState({
       code: this.props.initialCode,
+      livePreviewKey: `live-preview-${Date.now()}`,
     });
   };
 
@@ -158,6 +159,7 @@ export default class LiveCodeExample extends Component {
               dir={isRtl ? 'rtl' : ''}
             >
               <LivePreview
+                key={this.state.livePreviewKey}
                 {...previewProps}
                 className={previewRow ? styles.previewRow : null}
               />


### PR DESCRIPTION
This PR makes the reset button to actually reload the component by generating a new `key` prop.

The issue:
https://github.com/wix/wix-ui/issues/1139