### PR TITLE
`<Label/>` (unidriver): Add Unidriver

### DIFF
--- a/packages/wix-ui-core/src/components/deprecated/label/Label.spec.tsx
+++ b/packages/wix-ui-core/src/components/deprecated/label/Label.spec.tsx
@@ -1,70 +1,88 @@
-import * as React from 'react';
-import {labelDriverFactory} from './Label.driver';
-import {ReactDOMTestContainer} from '../../../../test/dom-test-container';
-import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
-import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
-import {labelTestkitFactory} from '../../../testkit';
-import {labelTestkitFactory as enzymeLabelTestkitFactory} from '../../../testkit/enzyme';
-import {Label} from './Label';
-import {mount} from 'enzyme';
+import * as React from "react";
+import { labelDriverFactory } from "./Label.driver";
+import { labelUniDriverFactory } from "./Label.uni.driver";
+import { ReactDOMTestContainer } from "../../../../test/dom-test-container";
+import { isEnzymeTestkitExists } from "wix-ui-test-utils/enzyme";
+import { isTestkitExists, isUniTestkitExists } from "wix-ui-test-utils/vanilla";
+import { labelTestkitFactory } from "../../../testkit";
+import { labelTestkitFactory as enzymeLabelTestkitFactory } from "../../../testkit/enzyme";
+import { Label } from "./Label";
+import { mount } from "enzyme";
 
-describe('Label', () => {
-  const createDriver =
-    new ReactDOMTestContainer()
-    .unmountAfterEachTest()
-    .createLegacyRenderer(labelDriverFactory);
+describe("Label", () => {
+  const testContainer = new ReactDOMTestContainer().unmountAfterEachTest();
 
-  it('Renders children', async () => {
-    const label = createDriver(<Label>HELLO</Label>);
-
-    expect(label.getLabelText()).toBe('HELLO');
+  describe("[sync]", () => {
+    runTests(testContainer.createLegacyRenderer(labelDriverFactory));
   });
 
-  it('takes an id prop', async () => {
-    const label = createDriver(<Label id="hey" />);
-
-    expect(label.getId()).toBe('hey');
+  describe("[async]", () => {
+    runTests(testContainer.createUniRenderer(labelUniDriverFactory));
   });
 
-  it('takes an htmlFor prop', async () => {
-    const label = createDriver(<Label for="hey" />);
+  function runTests(createDriver) {
+    it("Renders children", async () => {
+      const driver = createDriver(<Label>HELLO</Label>);
 
-    expect(label.getForAttribute()).toBe('hey');
-  });
-
-  describe('ellipsis attribute', () => {
-    it('should not have ellipsis by default', () => {
-      const driver = createDriver(<Label>Hello World</Label>);
-      expect(driver.hasEllipsis()).toBeFalsy();
+      expect(await driver.getLabelText()).toBe("HELLO");
     });
 
-    it('should have ellipsis', () => {
-      const driver = createDriver(<Label ellipsis>Hello World</Label>);
-      expect(driver.hasEllipsis()).toBeTruthy();
+    it("takes an id prop", async () => {
+      const driver = createDriver(<Label id="hey" />);
+
+      expect(await driver.getId()).toBe("hey");
     });
-  });
 
-  it('takes a disabled prop', async () => {
-    const label = createDriver(<Label disabled />);
+    describe('for attribute', () => {
+      it("takes an htmlFor prop", async () => {
+        const driver = createDriver(<Label for="hey" />);
 
-    expect(label.isDisabled()).toBe(true);
-  });
+        expect(await driver.getForAttribute()).toBe("hey");
+      });
 
-  it('should not be disabled by default', async () => {
-    const label = createDriver(<Label />);
+      it("shouldclick on Label takes an htmlFor prop", async () => {
+        const driver = createDriver(<Label for="hey" />);
 
-    expect(label.isDisabled()).toBe(false);
-  });
+        expect(await driver.getForAttribute()).toBe("hey");
+      });
+    })  
 
-  describe('testkit', () => {
-    it('should exist', () => {
+    describe("ellipsis attribute", () => {
+      it("should not have ellipsis by default", async () => {
+        const driver = createDriver(<Label>Hello World</Label>);
+        expect(await driver.hasEllipsis()).toBeFalsy();
+      });
+
+      it("should have ellipsis", async () => {
+        const driver = createDriver(<Label ellipsis>Hello World</Label>);
+        expect(await driver.hasEllipsis()).toBeTruthy();
+      });
+    });
+
+    it("takes a disabled prop", async () => {
+      const driver = createDriver(<Label disabled />);
+
+      expect(await driver.isDisabled()).toBe(true);
+    });
+
+    it("should not be disabled by default", async () => {
+      const driver = createDriver(<Label />);
+
+      expect(await driver.isDisabled()).toBe(false);
+    });
+  }
+
+  describe("testkit", () => {
+    it("should exist", () => {
       expect(isTestkitExists(<Label />, labelTestkitFactory)).toBe(true);
     });
   });
 
-  describe('enzyme testkit', () => {
-    it('should exist', () => {
-      expect(isEnzymeTestkitExists(<Label />, enzymeLabelTestkitFactory, mount)).toBe(true);
+  describe("enzyme testkit", () => {
+    it("should exist", () => {
+      expect(
+        isEnzymeTestkitExists(<Label />, enzymeLabelTestkitFactory, mount)
+      ).toBe(true);
     });
   });
 });

--- a/packages/wix-ui-core/src/components/deprecated/label/Label.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/deprecated/label/Label.uni.driver.ts
@@ -1,0 +1,38 @@
+import {
+  BaseUniDriver,
+  baseUniDriverFactory
+} from 'wix-ui-test-utils/base-driver';
+import {UniDriver} from 'unidriver';
+import { StylableUnidriverUtil } from '../../../../test/StylableUnidriverUtil';
+import styles from './Label.st.css';
+import {UnidriverReactDOMExtension} from '../../../../test/utils/unidriver/UnidriverReactDOMExtension';
+
+export interface LabelDriver extends BaseUniDriver {
+  /** get the label's text */
+  getLabelText: ()=> Promise<string>;
+  /** get the id of the component */
+  getId: ()=> Promise<string>;
+  /** get the "for" attribute of the component */
+  getForAttribute: () => Promise<string>;
+  /** returns true if the label is in ellipsis state */
+  hasEllipsis: () => Promise<boolean>;
+   /** true if disabled */
+  isDisabled: () => Promise<boolean>;
+  /** send key down on the label */
+  keyDown: (key) => Promise<void>;
+}
+
+export const labelUniDriverFactory = (base: UniDriver): LabelDriver => {
+  const stylableUnidriverUtil = new StylableUnidriverUtil(styles);
+  const unidriverReactDOMExtension = UnidriverReactDOMExtension(base);
+
+  return {
+    ...baseUniDriverFactory(base),
+    getLabelText: () => base.text(),
+    getId: () => base.attr('id'),
+    getForAttribute: () => base.attr('for'),
+    hasEllipsis: () => stylableUnidriverUtil.hasStyleState(base, 'ellipsis'),
+    isDisabled: () => stylableUnidriverUtil.hasStyleState(base, 'disabled'),
+    keyDown: key => unidriverReactDOMExtension.pressKey(key),
+  }
+};

--- a/packages/wix-ui-core/test/utils/unidriver/UnidriverReactDOMExtension.ts
+++ b/packages/wix-ui-core/test/utils/unidriver/UnidriverReactDOMExtension.ts
@@ -1,0 +1,17 @@
+import { Simulate } from 'react-dom/test-utils';
+import { UniDriver } from 'unidriver';
+
+/**
+ *Temporary workaround for implementing missing Unidriver methods in React/DOM only.
+ *
+ * @export
+ * @param {UniDriver} base
+ */
+export function UnidriverReactDOMExtension(base: UniDriver) {
+  if (base.type !== 'react') {
+    throw new Error('Supported only in React/DOM.')
+  } 
+  return {
+    pressKey: async key => Simulate.keyDown(await base.getNative(), {key}),
+  }
+}


### PR DESCRIPTION
- Added also a temp workaround for non-existing Unidriver methods. The workaround implements only react platform.