### PR TITLE
Move wix-ui-test-utils to devDependencies

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -64,8 +64,7 @@
     "tslib": "^1.9.3",
     "type-zoo": "3.1.1",
     "unidriver": "^2.0.1",
-    "wix-eventually": "^2.2.0",
-    "wix-ui-test-utils": "^1.0.0"
+    "wix-eventually": "^2.2.0"
   },
   "devDependencies": {
     "@storybook/addon-options": "4.0.0-alpha.14",
@@ -102,6 +101,7 @@
     "wix-storybook-utils": "^2.0.45",
     "wix-ui-icons-common": "^1.0.0",
     "wix-ui-mocha-runner": "^0.1.6",
+    "wix-ui-test-utils": "^1.0.0",
     "yoshi": "^3.28.0",
     "yoshi-style-dependencies": "^3.16.0"
   },


### PR DESCRIPTION
Having wix-ui-test-utils as dependency creates a lot of warnings in our build.
Can we move it?