### PR TITLE
Fix types for @types/react-onclickoutside.

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -77,7 +77,7 @@
     "@types/node": "^8.0.0",
     "@types/react": "16.8.4",
     "@types/react-dom": "^16.0.5",
-    "@types/react-onclickoutside": "^6.0.2",
+    "@types/react-onclickoutside": "^6.7.1",
     "@types/react-transition-group": "^2.0.6",
     "@ui-autotools/a11y": "^2.4.0",
     "@ui-autotools/registry": "^4.0.0",

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -252,4 +252,4 @@ export class DropdownComponent extends React.PureComponent<DropdownProps & Injec
   }
 }
 
-export const Dropdown = onClickOutside(DropdownComponent);
+export const Dropdown: React.ComponentClass<OnClickOutProps<DropdownProps & InjectedOnClickOutProps>> = onClickOutside(DropdownComponent);

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PopperJS from 'popper.js';
 import {getScrollParent} from 'popper.js/dist/umd/popper-utils';
-import onClickOutside from 'react-onclickoutside';
+import onClickOutside, { OnClickOutProps, InjectedOnClickOutProps } from 'react-onclickoutside';
 import {Manager, Reference, Popper} from 'react-popper';
 import {CSSTransition} from 'react-transition-group';
 import {Portal} from 'react-portal';
@@ -133,7 +133,7 @@ function getAppendToNode({appendTo, targetRef}) {
 
 // We're declaring a wrapper for the clickOutside machanism and not using the
 // HOC because of Typings errors.
-const ClickOutsideWrapper = onClickOutside(
+const ClickOutsideWrapper: React.ComponentClass<OnClickOutProps<InjectedOnClickOutProps>> = onClickOutside(
   class extends React.Component<any, any> {
     handleClickOutside() {
       this.props.handleClickOutside();

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import style from './Tooltip.st.css';
-import onClickOutside, {InjectedOnClickOutProps, OnClickOutProps, ClickOutComponentClass} from 'react-onclickoutside';
+import onClickOutside, {InjectedOnClickOutProps, OnClickOutProps} from 'react-onclickoutside';
 import {Popover, Placement, AppendTo} from '../popover';
 import {createComponentThatRendersItsChildren, ElementProps} from '../../utils';
 

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import style from './Tooltip.st.css';
-import onClickOutside, {InjectedOnClickOutProps, OnClickOutProps} from 'react-onclickoutside';
+import onClickOutside, {InjectedOnClickOutProps, OnClickOutProps, ClickOutComponentClass} from 'react-onclickoutside';
 import {Popover, Placement, AppendTo} from '../popover';
 import {createComponentThatRendersItsChildren, ElementProps} from '../../utils';
 
@@ -118,4 +118,4 @@ export class TooltipComponent extends React.PureComponent<TooltipProps & Injecte
   }
 }
 
-export const Tooltip = onClickOutside<any>(TooltipComponent);
+export const Tooltip: React.ComponentClass<OnClickOutProps<TooltipProps & InjectedOnClickOutProps>> = onClickOutside(TooltipComponent);


### PR DESCRIPTION
Follow-up for https://github.com/wix/wix-ui/pull/1185
We don't want to have a static version and rather update types