### PR TITLE
Wix storybook utils/sections refactor

### DIFF
--- a/packages/wix-storybook-utils/src/Sections/index.test.ts
+++ b/packages/wix-storybook-utils/src/Sections/index.test.ts
@@ -79,9 +79,7 @@ describe('columns section', () => {
 describe('tabs section', () => {
   it('should work with array or config object', () => {
     const tabs = [1, 2, 3].map(c => builders.tab({ sections: [] }));
-
     expect(builders.tabs({ tabs })).toEqual(expect.objectContaining({ tabs }));
-
     expect(builders.tabs(tabs)).toEqual(expect.objectContaining({ tabs }));
   });
 });
@@ -93,5 +91,14 @@ describe('description section', () => {
 
     expect(builders.description({ text })).toEqual(expectation);
     expect(builders.description(text)).toEqual(expectation);
+  });
+});
+
+describe('table section', () => {
+  it('should work with array or config object', () => {
+    expect(builders.table({ rows: [] })).toEqual(
+      expect.objectContaining({ rows: [] }),
+    );
+    expect(builders.table([])).toEqual(expect.objectContaining({ rows: [] }));
   });
 });

--- a/packages/wix-storybook-utils/src/Sections/index.test.ts
+++ b/packages/wix-storybook-utils/src/Sections/index.test.ts
@@ -102,3 +102,15 @@ describe('table section', () => {
     expect(builders.table([])).toEqual(expect.objectContaining({ rows: [] }));
   });
 });
+
+describe('importExample section', () => {
+  it('should work with string or config object', () => {
+    const source = 'hello world';
+    expect(builders.importExample({ source })).toEqual(
+      expect.objectContaining({ source }),
+    );
+    expect(builders.importExample(source)).toEqual(
+      expect.objectContaining({ source }),
+    );
+  });
+});

--- a/packages/wix-storybook-utils/src/Sections/index.test.ts
+++ b/packages/wix-storybook-utils/src/Sections/index.test.ts
@@ -114,3 +114,13 @@ describe('importExample section', () => {
     );
   });
 });
+
+describe('code section', () => {
+  it('should work with string or config object', () => {
+    const source = 'hello world';
+    expect(builders.code({ source })).toEqual(
+      expect.objectContaining({ source }),
+    );
+    expect(builders.code(source)).toEqual(expect.objectContaining({ source }));
+  });
+});

--- a/packages/wix-storybook-utils/src/Sections/index.ts
+++ b/packages/wix-storybook-utils/src/Sections/index.ts
@@ -57,11 +57,11 @@ export const header: (object: Partial<HeaderSection>) => HeaderSection = rest =>
   });
 
 export const importExample: (
-  object: Partial<ImportExampleSection>,
+  object: string | Partial<ImportExampleSection>,
 ) => ImportExampleSection = rest =>
   baseSection({
     type: SectionType.ImportExample,
-    ...rest,
+    ...(typeof rest === 'string' ? { source: rest } : rest),
   });
 
 export const tab: (object: Partial<TabSection>) => TabSection = rest =>

--- a/packages/wix-storybook-utils/src/Sections/index.ts
+++ b/packages/wix-storybook-utils/src/Sections/index.ts
@@ -11,6 +11,7 @@ import {
   TestkitSection,
   ColumnsSection,
   TableSection,
+  Row as TableRow,
   HeaderSection,
   TabsSection,
   MDXSection,
@@ -108,10 +109,12 @@ export const tabs: (
     ...(Array.isArray(rest) ? { tabs: rest } : rest),
   });
 
-export const table: (object: Partial<TableSection>) => TableSection = rest =>
+export const table: (
+  object: TableRow[] | Partial<TableSection>,
+) => TableSection = rest =>
   baseSection({
     type: SectionType.Table,
-    ...rest,
+    ...(Array.isArray(rest) ? { rows: rest } : rest),
   });
 
 export const mdx: (object?: Partial<MDXSection>) => MDXSection = rest =>

--- a/packages/wix-storybook-utils/src/Sections/index.ts
+++ b/packages/wix-storybook-utils/src/Sections/index.ts
@@ -23,74 +23,78 @@ import {
 // abstractions for consumer, so that they don't need to write all details manually and can also leverage some
 // autocomplete
 
-export const baseSection = rest => ({
+export const baseSection = config => ({
   type: SectionType.Error,
   pretitle: '',
   title: '',
   subtitle: '',
   hidden: false,
-  ...rest,
+  ...config,
 });
 
 export const error: (
   object: Partial<ErrorSection>,
 ) => ErrorSection = baseSection;
 
-export const code: (object: Partial<CodeSection>) => CodeSection = rest =>
+export const code: (
+  object: string | Partial<CodeSection>,
+) => CodeSection = config =>
   baseSection({
     type: SectionType.Code,
-    ...rest,
+    ...(typeof config === 'string' ? { source: config } : config),
   });
 
 export const description: (
   object: string | Partial<DescriptionSection>,
-) => DescriptionSection = rest =>
+) => DescriptionSection = config =>
   baseSection({
     type: SectionType.Description,
-    ...(typeof rest === 'string' ? { text: rest } : rest),
+    ...(typeof config === 'string' ? { text: config } : config),
   });
 
-export const header: (object: Partial<HeaderSection>) => HeaderSection = rest =>
+export const header: (
+  object: Partial<HeaderSection>,
+) => HeaderSection = config =>
   baseSection({
     type: SectionType.Header,
-    ...rest,
+    ...config,
   });
 
 export const importExample: (
   object: string | Partial<ImportExampleSection>,
-) => ImportExampleSection = rest =>
+) => ImportExampleSection = config =>
   baseSection({
     type: SectionType.ImportExample,
-    ...(typeof rest === 'string' ? { source: rest } : rest),
+    ...(typeof config === 'string' ? { source: config } : config),
   });
 
-export const tab: (object: Partial<TabSection>) => TabSection = rest =>
+export const tab: (object: Partial<TabSection>) => TabSection = config =>
   baseSection({
     type: SectionType.Tab,
     sections: [],
-    ...rest,
+    ...config,
   });
 
-export const api: (object?: Partial<ApiSection>) => ApiSection = rest =>
+export const api: (object?: Partial<ApiSection>) => ApiSection = config =>
   baseSection({
     type: SectionType.Api,
-    ...rest,
+    ...config,
   });
 
 export const playground: (
   object?: Partial<PlaygroundSection>,
-) => PlaygroundSection = rest =>
+) => PlaygroundSection = config =>
   baseSection({
     type: SectionType.Playground,
-    ...rest,
+    ...config,
   });
 
 export const testkit: (
   object?: Partial<TestkitSection>,
-) => TestkitSection = rest =>
+) => TestkitSection = config =>
   baseSection({
     type: SectionType.Testkit,
-    ...rest,
+    ...config,
   });
 
 export const columns: (
@@ -103,32 +107,32 @@ export const columns: (
 
 export const tabs: (
   object: Section[] | Partial<TabsSection>,
-) => TabsSection = rest =>
+) => TabsSection = config =>
   baseSection({
     type: SectionType.Tabs,
-    ...(Array.isArray(rest) ? { tabs: rest } : rest),
+    ...(Array.isArray(config) ? { tabs: config } : config),
   });
 
 export const table: (
   object: TableRow[] | Partial<TableSection>,
-) => TableSection = rest =>
+) => TableSection = config =>
   baseSection({
     type: SectionType.Table,
-    ...(Array.isArray(rest) ? { rows: rest } : rest),
+    ...(Array.isArray(config) ? { rows: config } : config),
   });
 
-export const mdx: (object?: Partial<MDXSection>) => MDXSection = rest =>
+export const mdx: (object?: Partial<MDXSection>) => MDXSection = config =>
   baseSection({
     type: SectionType.MDX,
-    ...rest,
+    ...config,
   });
 
 export const divider: (
   object?: Partial<DividerSection>,
-) => DividerSection = rest =>
+) => DividerSection = config =>
   baseSection({
     type: SectionType.Divider,
-    ...rest,
+    ...config,
   });
 
 export const title: (

--- a/packages/wix-storybook-utils/src/Sections/section-with-siblings/index.tsx
+++ b/packages/wix-storybook-utils/src/Sections/section-with-siblings/index.tsx
@@ -5,6 +5,7 @@ import { SectionType } from '../../typings/story-section';
 import styles from './styles.scss';
 
 const SIBLINGS = ['pretitle', 'title', 'subtitle', 'description'];
+const SECTIONS_WITHOUT_SIBLINGS = [SectionType.Title];
 
 const sectionPrepares = {
   [SectionType.ImportExample]: section => ({
@@ -35,13 +36,11 @@ const prepareSection = section => {
   return { ...preparedSection, ...siblingsWithDiv };
 };
 
-const sectionsWithoutSiblings = [SectionType.Title];
-
 export const sectionWithSiblings = (section, children) => {
   const preparedSection = prepareSection(section);
   const siblings = SIBLINGS.filter(row => preparedSection[row]);
   const shouldShowSiblings =
-    siblings.length > 0 && !sectionsWithoutSiblings.includes(section.type);
+    siblings.length > 0 && !SECTIONS_WITHOUT_SIBLINGS.includes(section.type);
 
   return (
     <div>

--- a/packages/wix-storybook-utils/src/Sections/section-with-siblings/styles.scss
+++ b/packages/wix-storybook-utils/src/Sections/section-with-siblings/styles.scss
@@ -1,4 +1,5 @@
 @import '../../ui/typography.scss';
+@import '../../ui/colors.scss';
 
 .titles {
   margin-bottom: 24px;
@@ -14,13 +15,20 @@
   margin-bottom: 30px;
   margin-top: 5px;
   font-size: 14px;
-  color: #7a92a5;
+  color: $D40;
 }
 
 .pretitle {
   @include font(roman);
   font-size: 12px;
   font-weight: 500;
-  color: #7a92a5;
+  color: $D40;
 }
 
+.description {
+  @include font(roman);
+  font-size: 14px;
+  font-weight: 300;
+  line-height: 1.5;
+  color: $D10;
+}

--- a/packages/wix-storybook-utils/src/Sections/views/header/index.tsx
+++ b/packages/wix-storybook-utils/src/Sections/views/header/index.tsx
@@ -33,6 +33,10 @@ export const header: (a: HeaderSection, b: StoryConfig) => React.ReactNode = (
       </Cell>
     </Layout>
 
-    <div className={styles.component}>{component}</div>
+    {component && (
+      <div className={styles.componentWrapper}>
+        <div className={styles.component}>{component}</div>
+      </div>
+    )}
   </div>
 );

--- a/packages/wix-storybook-utils/src/Sections/views/header/styles.scss
+++ b/packages/wix-storybook-utils/src/Sections/views/header/styles.scss
@@ -4,18 +4,24 @@
 $header-height: 281px;
 
 .root {
+  position: relative;
   display: flex;
   flex-direction: column;
-  width: 100%;
   height: $header-height;
   margin-bottom: 30px;
 
   &:before {
     content: '';
     position: absolute;
+
+    /* TODO: the magic 8px tries to negate default margin: 8px on body in order to prevent horizontal
+     * scroll. eventually default body margin should be set to 0, then this `calc` can be removed */
+    width: calc(100vw - 8px);
+
     top: 0;
-    left: 0;
-    right: 0;
+    left: 50%;
+    right: 50%;
+    margin: 0 -50vw;
     height: $header-height;
 
     background-image: linear-gradient(256deg, #f6f6f6, #fefefe),
@@ -63,6 +69,17 @@ $header-height: 281px;
   }
 }
 
+.componentWrapper {
+  position: relative;
+  flex: 1 1 auto;
+}
+
 .component {
+  position: absolute;
+  padding: 10px;
+  top: -10px;
+  right: -10px;
+  bottom: -10px;
+  left: -10px;
   overflow-y: auto;
 }

--- a/packages/wix-storybook-utils/src/Sections/views/styles.scss
+++ b/packages/wix-storybook-utils/src/Sections/views/styles.scss
@@ -9,7 +9,7 @@
     font-size: 14px;
     font-weight: 300;
     line-height: 1.5;
-    color: #162d3d;
+    color: $D10;
   }
 }
 

--- a/packages/wix-storybook-utils/src/typings/story-section.ts
+++ b/packages/wix-storybook-utils/src/typings/story-section.ts
@@ -84,7 +84,7 @@ export interface TabsSection extends StorySection {
 }
 
 type Cell = string | React.ReactNode;
-type Row = Cell[];
+export type Row = Cell[];
 export interface TableSection extends StorySection {
   rows: Row[];
 }

--- a/packages/wix-storybook-utils/stories/story-with-sections.story.tsx
+++ b/packages/wix-storybook-utils/stories/story-with-sections.story.tsx
@@ -17,12 +17,6 @@ import {
   title,
 } from '../src/Sections';
 
-const LiveExampleComponent = ({ disabled }) => (
-  <div style={{ background: disabled ? 'red' : '#bada55' }}>
-    Oh hello there!
-  </div>
-);
-
 export default {
   category: 'Components',
   storyName: 'Component with section',
@@ -30,89 +24,91 @@ export default {
   componentPath: './component.js',
   sections: [
     header({
-      component: LiveExampleComponent({ disabled: false }),
+      component: (
+        <div style={{ background: '#bada55', boxShadow: '0 0 3px 0 blue' }}>
+          Oh hello there!
+        </div>
+      ),
       issueUrl: 'https://github.com/wix/wix-ui/issues/new',
       sourceUrl: 'https://github.com/wix/wix-ui/',
     }),
 
-    tabs({
-      tabs: [
-        tab({
-          title: 'Something something',
-          sections: [
-            title('Component Title'),
+    tabs([
+      tab({
+        title: 'Something something',
+        sections: [
+          title('Component Title'),
 
-            importExample({
-              source: `
+          importExample({
+            source: `
 import Button from 'wix-style-react/Button';
 import Button from 'wix-style-react/Button';`,
-            }),
-            columns({
-              title: 'Septyni astuoni keturiolika',
-              items: [description(`🔨 To trigger an operation.`)],
-            }),
+          }),
+          columns({
+            title: 'Septyni astuoni keturiolika',
+            items: [description(`🔨 To trigger an operation.`)],
+          }),
 
-            divider(),
-          ],
-        }),
+          divider(),
+        ],
+      }),
 
-        tab({
-          title: 'hello',
-          sections: [
-            description({
-              title: 'lol',
-              text: 'I should not be in a tab',
-            }),
+      tab({
+        title: 'hello',
+        sections: [
+          description({
+            title: 'lol',
+            text: 'I should not be in a tab',
+          }),
 
-            table({
-              title: 'Included Components',
-              rows: [
-                ['&lt;FormField/&gt;', 'Layout component for form elements'],
-                ['&lt;Input /&gt;', 'Component that receives data'],
-              ],
-            }),
+          table({
+            title: 'Included Components',
+            rows: [
+              ['&lt;FormField/&gt;', 'Layout component for form elements'],
+              ['&lt;Input /&gt;', 'Component that receives data'],
+            ],
+          }),
 
-            tabs({
-              title: 'title',
-              tabs: [
-                tab({
-                  title: 'inner tab',
-                  sections: [
-                    code({
-                      description: 'this is the best code',
-                      source: '"hello"',
-                    }),
-                    api(),
-                  ],
-                }),
-                tab({
-                  title: 'inner tab #2',
-                  sections: [description('# im inside another tab!')],
-                }),
-              ],
-            }),
-          ],
-        }),
+          tabs({
+            title: 'title',
+            tabs: [
+              tab({
+                title: 'inner tab',
+                sections: [
+                  code({
+                    description: 'this is the best code',
+                    source: '"hello"',
+                  }),
+                  api(),
+                ],
+              }),
+              tab({
+                title: 'inner tab #2',
+                sections: [description('# im inside another tab!')],
+              }),
+            ],
+          }),
+        ],
+      }),
 
-        tab({
-          title: 'how are you',
-          sections: [
-            importExample({
-              source: "import Component from 'your-library/Component';",
-            }),
-          ],
-        }),
+      tab({
+        title: 'how are you',
+        sections: [
+          importExample({
+            source: "import Component from 'your-library/Component';",
+          }),
+        ],
+      }),
 
-        tab({
-          title: 'Playground',
-          sections: [playground()],
-        }),
+      tab({
+        title: 'Playground',
+        sections: [playground()],
+      }),
 
-        tab({
-          title: 'Testkit',
-          sections: [testkit()],
-        }),
-      ],
-    }),
+      tab({
+        title: 'Testkit',
+        sections: [testkit()],
+      }),
+    ]),
   ],
 };

--- a/packages/wix-storybook-utils/stories/story-with-sections.story.tsx
+++ b/packages/wix-storybook-utils/stories/story-with-sections.story.tsx
@@ -39,11 +39,9 @@ export default {
         sections: [
           title('Component Title'),
 
-          importExample({
-            source: `
+          importExample(`
 import Button from 'wix-style-react/Button';
-import Button from 'wix-style-react/Button';`,
-          }),
+import Button from 'wix-style-react/Button';`),
           columns({
             title: 'Septyni astuoni keturiolika',
             items: [description(`🔨 To trigger an operation.`)],

--- a/packages/wix-storybook-utils/stories/story-with-sections.story.tsx
+++ b/packages/wix-storybook-utils/stories/story-with-sections.story.tsx
@@ -92,9 +92,7 @@ import Button from 'wix-style-react/Button';`),
       tab({
         title: 'how are you',
         sections: [
-          importExample({
-            source: "import Component from 'your-library/Component';",
-          }),
+          importExample("import Component from 'your-library/Component';"),
         ],
       }),
 


### PR DESCRIPTION
collection of small improvements to sections:

1. support `code('string')`, not only `code({ source: 'string' })`
1. support `importExample('string')`, not only `importExample({ source: 'string' })`
1. support `table([])`, not only `table({ rows: [] })`
1. update `header` to allow some space for `box-shadow` in component (focus style is no longer cut)