### PR TITLE
Applying `data-hook` prop directly on Popover

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -430,7 +430,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
           <div
             style={inlineStyles}
             {...style('root', {}, this.props)}
-            'data-hook'={this.props['data-hook']}
+            data-hook={this.props['data-hook']}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             id={id}

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -430,6 +430,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
           <div
             style={inlineStyles}
             {...style('root', {}, this.props)}
+            'data-hook'={this.props['data-hook']}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             id={id}


### PR DESCRIPTION
rather than using stylable's runtime stylesheet function (#1135 )