### PR TITLE
wix-storybook-utils: allow code section to have darkBackground initially

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -30,6 +30,7 @@ export default class LiveCodeExample extends Component {
     previewRow: PropTypes.bool,
     previewProps: PropTypes.object,
     autoRender: PropTypes.bool,
+    darkBackground: PropTypes.bool
   };
 
   static defaultProps = {
@@ -37,6 +38,7 @@ export default class LiveCodeExample extends Component {
     previewRow: false,
     previewProps: {},
     autoRender: true,
+    darkBackground: false
   };
 
   constructor(props) {
@@ -46,7 +48,7 @@ export default class LiveCodeExample extends Component {
       code: this.formatCode(props.initialCode),
       dirty: false,
       isRtl: false,
-      isDarkBackground: false,
+      isDarkBackground: props.darkBackground,
       isEditorOpened: !props.compact,
     };
   }
@@ -77,8 +79,6 @@ export default class LiveCodeExample extends Component {
       isEditorOpened: !state.isEditorOpened,
     }));
 
-  renderCopyButton = () => <CopyButton source={this.state.code} />;
-
   render() {
     const { compact, previewRow, previewProps, autoRender } = this.props;
     const { code, isRtl, isDarkBackground, isEditorOpened } = this.state;
@@ -91,7 +91,7 @@ export default class LiveCodeExample extends Component {
       >
         {!compact && (
           <div className={styles.header}>
-            {this.renderCopyButton()}
+            <CopyButton source={this.state.code} />
 
             <div className={styles.spacer} />
 
@@ -154,7 +154,7 @@ export default class LiveCodeExample extends Component {
 
         {compact && (
           <div className={styles.controlButtons}>
-            {this.renderCopyButton()}
+            <CopyButton source={this.state.code} />
 
             <div style={{ marginLeft: 'auto' }} />
 

--- a/packages/wix-storybook-utils/src/Sections/views/code.tsx
+++ b/packages/wix-storybook-utils/src/Sections/views/code.tsx
@@ -11,14 +11,18 @@ export const code: (a: CodeSection) => React.ReactNode = ({
   previewProps,
   interactive = true,
   autoRender,
+  darkBackground = false,
 }) =>
   interactive ? (
     <LiveCodeExample
-      previewProps={previewProps}
-      compact={compact}
-      scope={components}
-      initialCode={source.trim()}
-      autoRender={autoRender}
+      {...{
+        previewProps,
+        compact,
+        autoRender,
+        darkBackground,
+        scope: components,
+        initialCode: source.trim(),
+      }}
     />
   ) : (
     <CodeBlock source={source.trim()} />

--- a/packages/wix-storybook-utils/src/typings/story-section.ts
+++ b/packages/wix-storybook-utils/src/typings/story-section.ts
@@ -61,6 +61,7 @@ export interface CodeSection extends StorySection {
   compact?: boolean;
   interactive?: boolean;
   autoRender?: boolean;
+  darkBackground?: boolean;
 }
 
 export interface TabSection extends StorySection {


### PR DESCRIPTION
`code({ darkBackground: true })` and `<LiveCodeExample darkBackground/>`