### PR TITLE
fix(StoryPage): prevent double title

### DIFF
--- a/packages/wix-storybook-utils/src/StoryPage/index.test.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/index.test.tsx
@@ -25,6 +25,14 @@ describe('StoryPage', () => {
       testkit.when.created({ metadata: { description, readme } });
       expect(testkit.get.readme()).toMatch(readme);
     });
+
+    it('should render displayName only once', () => {
+      const displayName = 'batman';
+      const readme = '# `<batman/>`';
+      const description = '# `<batman/>`';
+      testkit.when.created({ metadata: { displayName, readme, description } });
+      expect(testkit.get.readme()).toEqual('# `<batman/>`');
+    });
   });
 
   describe('given `exampleImport`', () => {

--- a/packages/wix-storybook-utils/src/StoryPage/single-component-layout.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/single-component-layout.tsx
@@ -30,10 +30,14 @@ interface SingleComponentLayoutProps extends StoryConfig {
   activeTabId?: string;
 }
 
+const hasTitle = (string = '') => string.startsWith('# ');
+
 const readme = metadata => {
   const description = metadata.readme || metadata.description;
-  const title = `# \`<${metadata.displayName}/>\``;
-  const content = description ? `${title}\n${description}` : title;
+  const title = hasTitle(description)
+    ? ''
+    : `# \`<${metadata.displayName}/>\`\n`;
+  const content = description ? `${title}${description}` : title;
 
   return <Markdown dataHook="metadata-readme" source={content} />;
 };


### PR DESCRIPTION
small fix to prevent double title to appear in StoryPage

for example, StoryPage could render this:
![2019-03-15-162820_screenshot](https://user-images.githubusercontent.com/4284659/54438481-5ff64e80-473f-11e9-9c1f-d2ca4877a10d.png)
