### PR TITLE
Mark stories as a sideEffects. Use esnext module type.

### DIFF
--- a/packages/wix-ui-core/.storybook/webpack.config.js
+++ b/packages/wix-ui-core/.storybook/webpack.config.js
@@ -4,16 +4,13 @@ const path = require('path');
 module.exports = (config, env, defaultConfig) => {
   const newConfig = wixStorybookConfig(defaultConfig);
 
-  const tsLoaderOpts = newConfig.module.rules[0].use[1].options;
-  tsLoaderOpts.compilerOptions.module = 'commonjs';
-
   newConfig.module.rules.push({
     test: /\.story\.[j|t]sx?$/,
     loader: 'wix-storybook-utils/loader',
     resolve: {
       alias: {
-        'wix-ui-core': path.resolve(__dirname, '../src')
-      }
+        'wix-ui-core': path.resolve(__dirname, '../src'),
+      },
     },
     options: {
       storyConfig: {
@@ -21,9 +18,9 @@ module.exports = (config, env, defaultConfig) => {
         repoBaseURL:
           'https://github.com/wix/wix-ui/tree/master/packages/wix-ui-core/src/components/',
         importFormat:
-          "import {%componentName} from '%moduleName/%componentName'"
-      }
-    }
+          "import {%componentName} from '%moduleName/%componentName'",
+      },
+    },
   });
 
   return newConfig;

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -6,7 +6,8 @@
   "module": "./dist/es/src",
   "sideEffects": [
     "./.storybook/**/*.*",
-    "./stories/**/*.*"
+    "./stories/**/*.*",
+    "./src/**/*.story.tsx"
   ],
   "author": {
     "name": "Wix",

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -4,7 +4,10 @@
   "description": "wix-ui-core",
   "version": "2.0.0",
   "module": "./dist/es/src",
-  "sideEffects": false,
+  "sideEffects": [
+    "./.storybook/**/*.*",
+    "./stories/**/*.*"
+  ],
   "author": {
     "name": "Wix",
     "email": "fed-infra@wix.com"


### PR DESCRIPTION
With this update, we will have e2e checks with untrunspiled ES6 imports for webpack build generated by storybook.