### PR TITLE
fix(AutoExample): do not fail with `undefined` values in `componentProps`

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -249,24 +249,25 @@ export default class extends Component {
     );
   };
 
-  renderPropControllers = ({ props, allProps }) => {
-    return Object.entries(props).map(([key, prop]) => (
-      <Option
-        key={key}
-        {...{
-          label: key,
-          value: allProps[key],
-          defaultValue:
-            typeof this.props.componentProps === 'function'
-              ? undefined
-              : this.props.componentProps[key],
-          isRequired: prop.required || false,
-          onChange: value => this.setProp(key, value),
-          children: this.getPropControlComponent(key, prop.type),
-        }}
-      />
-    ));
-  };
+  renderPropControllers = ({ props, allProps }) =>
+    Object.entries(props)
+      .filter(([key, prop]) => prop)
+      .map(([key, prop]) => (
+        <Option
+          key={key}
+          {...{
+            label: key,
+            value: allProps[key],
+            defaultValue:
+              typeof this.props.componentProps === 'function'
+                ? undefined
+                : this.props.componentProps[key],
+            isRequired: prop.required || false,
+            onChange: value => this.setProp(key, value),
+            children: this.getPropControlComponent(key, prop.type),
+          }}
+        />
+      ));
 
   propsCategories = {
     primary: {

--- a/packages/wix-storybook-utils/src/AutoExample/index.test.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.test.js
@@ -48,6 +48,46 @@ describe('AutoExample', () => {
     });
   });
 
+  describe('compnentProps', () => {
+    it('should not fail with `undefined` values', () => {
+      const testkit = new Testkit(AutoExample);
+      const create = () =>
+        testkit.when.created({
+          parsedSource: {
+            displayName: 'TestComponent',
+            props: {
+              functionProp: { type: { name: 'func' } },
+            },
+          },
+          componentProps: {
+            undefinedProp: undefined,
+          },
+        });
+
+      expect(create).not.toThrow();
+    });
+
+    it('should display NodesList regardless of type in parsedSource', () => {
+      const testkit = new Testkit(AutoExample);
+      testkit.when.created({
+        parsedSource: {
+          displayName: 'TestComponent',
+          props: {
+            someProp: {
+              type: { name: 'unknown type name, something really obscure' },
+            },
+          },
+        },
+        exampleProps: {
+          someProp: [1, 2, 3, 4, 5],
+        },
+      });
+
+      const option = testkit.get.options().props();
+      expect(option.children).not.toBe(null);
+    });
+  });
+
   describe('exampleProps', () => {
     it('should display "Interaction preview" for function type', () => {
       const testkit = new Testkit(AutoExample);

--- a/packages/wix-storybook-utils/stories/component.js
+++ b/packages/wix-storybook-utils/stories/component.js
@@ -42,6 +42,7 @@ Component.propTypes = {
   enabled: PropTypes.bool.isRequired,
   onClick: PropTypes.func,
   propNotVisibleInStorybook: PropTypes.bool,
+  undefinedValueProp: PropTypes.string,
 };
 
 Component.defaultProps = {

--- a/packages/wix-storybook-utils/stories/index.story.js
+++ b/packages/wix-storybook-utils/stories/index.story.js
@@ -8,7 +8,7 @@ const showcase = `<button className={button.one}>one</button>
 <button className={button.three}>three</button>`;
 
 const exampleScope = {
-  Button: props => <button {...props} />
+  Button: props => <button {...props} />,
 };
 
 const ExampleShowcase = () => (
@@ -42,10 +42,12 @@ export default {
 
     number: 4,
     valueSetOnMounting: 17,
+
+    undefinedValueProp: undefined,
   },
 
   exampleProps: {
-    onClick: () => 'hai'
+    onClick: () => 'hai',
   },
 
   hiddenProps: ['propNotVisibleInStorybook'],
@@ -124,5 +126,5 @@ render(
         />
       </div>
     </div>
-  )
+  ),
 };


### PR DESCRIPTION
AutoExample used to crash given `componentProps: { someProp: undefined }`. This PR fixes that.

a small fix, one less red screen of death.