### PR TITLE
chore(ButtonNext): relocate `withFocusable` HOC

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.meta.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.meta.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ButtonNext } from './button-next';
+import { ButtonNext } from '.';
 import Add from 'wix-ui-icons-common/Add';
 import Registry from '@ui-autotools/registry';
 
@@ -9,16 +9,16 @@ buttonMetadata.addSim({
   title: 'Simulation with suffix icon',
   props: {
     suffixIcon: <Add />,
-    children: 'Button'
-  }
+    children: 'Button',
+  },
 });
 
 buttonMetadata.addSim({
   title: 'Simulation with prefix icon',
   props: {
     prefixIcon: <Add />,
-    children: 'Button'
-  }
+    children: 'Button',
+  },
 });
 
 buttonMetadata.addSim({
@@ -26,6 +26,6 @@ buttonMetadata.addSim({
   props: {
     prefixIcon: <Add />,
     suffixIcon: <Add />,
-    children: 'Button'
-  }
+    children: 'Button',
+  },
 });

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -13,6 +13,9 @@ export interface ButtonProps
   suffixIcon?: React.ReactElement<any>;
   /** apply disabled styles */
   disabled?: boolean;
+
+  focusableOnFocus?(): void;
+  focusableOnBlur?(): void;
 }
 
 const _addAffix = (Affix, styleClass) =>
@@ -25,9 +28,7 @@ const _addAffix = (Affix, styleClass) =>
  * ButtonNext
  */
 
-const ButtonNextComponent: React.SFC<
-  ButtonProps & { focusableOnFocus(): void; focusableOnBlur(): void }
-> = props => {
+const ButtonNextComponent: React.SFC<ButtonProps> = props => {
   const {
     as: Component,
     suffixIcon,

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { withFocusable } from '../../hocs/Focusable/FocusableHOC';
 import style from './button-next.st.css';
 
 export interface ButtonProps
@@ -27,7 +26,7 @@ const _addAffix = (Affix, styleClass) =>
  */
 
 const ButtonNextComponent: React.SFC<
-  ButtonProps & { focusableOnFocus: () => void; focusableOnBlur: () => void }
+  ButtonProps & { focusableOnFocus(): void; focusableOnBlur(): void }
 > = props => {
   const {
     as: Component,
@@ -63,4 +62,4 @@ const ButtonNextComponent: React.SFC<
 ButtonNextComponent.displayName = 'ButtonNext';
 ButtonNextComponent.defaultProps = { as: 'button', type: 'button' };
 
-export const ButtonNext = withFocusable(ButtonNextComponent);
+export const ButtonNext = ButtonNextComponent;

--- a/packages/wix-ui-core/src/components/button-next/index.ts
+++ b/packages/wix-ui-core/src/components/button-next/index.ts
@@ -1,1 +1,4 @@
-export { ButtonNext } from './button-next';
+import { withFocusable } from '../../hocs/Focusable/FocusableHOC';
+import { ButtonNext as Button } from './button-next';
+
+export const ButtonNext = withFocusable(Button);


### PR DESCRIPTION
easy fix to make docs parser work.