### PR TITLE
<FocusableHOC/> - add onblur and onfocus props callbacks 

### DIFF
--- a/packages/wix-ui-core/src/components/toggle-switch/ToggleSwitch.tsx
+++ b/packages/wix-ui-core/src/components/toggle-switch/ToggleSwitch.tsx
@@ -15,7 +15,7 @@ export interface ToggleSwitchProps {
   checked?: boolean;
   disabled?: boolean;
   tabIndex?: number;
-  onChange?: () => void;
+  onChange?(): void;
   styles?: ToggleSwitchStyles;
   id?: string;
   checkedIcon?: React.ReactNode;
@@ -31,35 +31,42 @@ export interface ToggleSwitchState {
 /**
  * Toggle Switch
  */
-export class ToggleSwitch extends React.PureComponent<ToggleSwitchProps, ToggleSwitchState> {
+export class ToggleSwitch extends React.PureComponent<
+  ToggleSwitchProps,
+  ToggleSwitchState
+> {
   static displayName = 'ToggleSwitch';
 
   static defaultProps = {
     checked: false,
     styles: {},
     tabIndex: 0,
-    onChange: () => null
+    onChange: () => null,
   };
 
   public state = {
     focus: false,
-    focusVisible: false
+    focusVisible: false,
   };
 
   // We don't want to show outline when the component is focused by mouse.
   private focusedByMouse = false;
 
   render() {
-    const {checked, disabled, styles: inlineStyles} = this.props;
+    const { checked, disabled, styles: inlineStyles } = this.props;
 
     return (
       <div
-        {...style('root', {
-          checked,
-          disabled,
-          focus: this.state.focus,
-          'focus-visible': this.state.focusVisible
-        }, this.props)}
+        {...style(
+          'root',
+          {
+            checked,
+            disabled,
+            focus: this.state.focus,
+            'focus-visible': this.state.focusVisible,
+          },
+          this.props,
+        )}
         style={inlineStyles.root}
       >
         <div className={style.track} style={inlineStyles.track} />
@@ -89,22 +96,22 @@ export class ToggleSwitch extends React.PureComponent<ToggleSwitchProps, ToggleS
   private handleKeyDown: React.KeyboardEventHandler<HTMLElement> = e => {
     // Pressing any key should make the focus visible, even if the checkbox
     // was initially focused by mouse.
-    this.setState({focusVisible: true});
-  }
+    this.setState({ focusVisible: true });
+  };
 
   // Doesn't get invoked if the input is disabled.
   private handleMouseDown: React.MouseEventHandler<HTMLElement> = e => {
     if (e.button === 0) {
       this.focusedByMouse = true;
     }
-  }
+  };
 
   private handleFocus: React.FocusEventHandler<HTMLElement> = e => {
-    this.setState({focus: true, focusVisible: !this.focusedByMouse});
-  }
+    this.setState({ focus: true, focusVisible: !this.focusedByMouse });
+  };
 
   private handleBlur: React.FocusEventHandler<HTMLElement> = e => {
-    this.setState({focus: false, focusVisible: false});
+    this.setState({ focus: false, focusVisible: false });
     this.focusedByMouse = false;
-  }
+  };
 }

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.driver.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.driver.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
-import {mount} from 'enzyme';
-import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {StylableDOMUtil} from '@stylable/dom-test-kit';
+import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { StylableDOMUtil } from '@stylable/dom-test-kit';
 
-import {withFocusable} from './FocusableHOC';
+import { withFocusable } from './FocusableHOC';
 import style from './Focusable.st.css';
 
 declare global {
-  interface Window { Event: any; }
+  interface Window {
+    Event: any;
+  }
 }
 
 export interface IPureChildComponentProps {
@@ -19,9 +20,12 @@ export interface IPureChildComponentProps {
 const stylableUtil = new StylableDOMUtil(style);
 
 const hasFocusState = element => stylableUtil.hasStyleState(element, 'focus');
-const hasFocusVisibleState = element => stylableUtil.hasStyleState(element, 'focus-visible');
+const hasFocusVisibleState = element =>
+  stylableUtil.hasStyleState(element, 'focus-visible');
 
-export class PureChildComponent extends React.PureComponent<IPureChildComponentProps> {
+export class PureChildComponent extends React.PureComponent<
+  IPureChildComponentProps
+> {
   private id: string;
 
   constructor(props) {
@@ -33,7 +37,7 @@ export class PureChildComponent extends React.PureComponent<IPureChildComponentP
   static staticVariable = 'staticVariable';
   static staticMethod = () => 'staticMethod';
 
-  unboundMethod = () =>  'unboundMethod'
+  unboundMethod = () => 'unboundMethod';
 
   boundMethod = () => this.id;
 
@@ -56,7 +60,7 @@ const focusableDriverFactory = ({ element, eventTrigger }) => {
     focus: () => eventTrigger.focus(element),
     blur: () => eventTrigger.blur(element),
     hasFocusState: () => hasFocusState(element),
-    hasFocusVisibleState: () => hasFocusVisibleState(element)
+    hasFocusVisibleState: () => hasFocusVisibleState(element),
   };
 };
 
@@ -64,7 +68,8 @@ const driverFactory = createDriverFactory(focusableDriverFactory);
 
 export const createDriver = Component => {
   const driver = driverFactory(Component);
-  const fireMouseDown = () => window.dispatchEvent(new window.Event('mousedown'));
+  const fireMouseDown = () =>
+    window.dispatchEvent(new window.Event('mousedown'));
   const fireMouseUp = () => window.dispatchEvent(new window.Event('mouseup'));
   const fireKeyDown = () => window.dispatchEvent(new window.Event('keydown'));
   const fireKeyUp = () => window.dispatchEvent(new window.Event('keyup'));
@@ -91,7 +96,7 @@ export const createDriver = Component => {
     fireKeyUp,
     tabOut,
     tabIn,
-    click
+    click,
   };
 };
 

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.spec.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.spec.tsx
@@ -1,15 +1,20 @@
 import * as React from 'react';
-import {mount} from 'enzyme';
-import {createDriver, WithFocusableComp, PureChildComponent} from './FocusableHOC.driver';
+import { mount } from 'enzyme';
+import {
+  createDriver,
+  WithFocusableComp,
+  PureChildComponent,
+} from './FocusableHOC.driver';
 
-import {withFocusable} from './FocusableHOC';
+import { withFocusable } from './FocusableHOC';
 
 describe('FocusableHOC', () => {
-  const render = Comp => mount(Comp, {attachTo: document.createElement('div')});
+  const render = Comp =>
+    mount(Comp, { attachTo: document.createElement('div') });
 
   describe('Pure component HOC', () => {
     it('should render the wrapped component', () => {
-      const wrapper = render(<WithFocusableComp/>);
+      const wrapper = render(<WithFocusableComp />);
       expect(wrapper.children().instance()).toBeInstanceOf(PureChildComponent);
     });
 
@@ -63,13 +68,13 @@ describe('FocusableHOC', () => {
     });
 
     it('should not have focus nor focus-visible [given] initial render', () => {
-      const driver = createDriver(<WithFocusableComp2/>);
+      const driver = createDriver(<WithFocusableComp2 />);
 
       expectNotFocused(driver);
     });
 
     it('should have focus and focus-visible [when] focused programatically', () => {
-      const driver = createDriver(<WithFocusableComp2/>);
+      const driver = createDriver(<WithFocusableComp2 />);
 
       driver.focus();
       // Default input is keyboard
@@ -77,7 +82,7 @@ describe('FocusableHOC', () => {
     });
 
     it('should have focus and focus-visible [when] tabbed in', () => {
-      const driver = createDriver(<WithFocusableComp2/>);
+      const driver = createDriver(<WithFocusableComp2 />);
 
       driver.tabIn();
       expectKeyboardFocused(driver, 'after focus');
@@ -86,7 +91,7 @@ describe('FocusableHOC', () => {
     it('should have focus and focus-visible [when] tabbed in withot keyDown', () => {
       // This test case checks a scenario when the focus is on the browser's
       // url input, and we press tab. The keyDown is not fired.
-      const driver = createDriver(<WithFocusableComp2/>);
+      const driver = createDriver(<WithFocusableComp2 />);
 
       driver.focus();
       driver.fireKeyUp();
@@ -94,7 +99,7 @@ describe('FocusableHOC', () => {
     });
 
     it('should not have focus nor focus-visible [when] blured programatically [given] keyboard focused', () => {
-      const driver = createDriver(<WithFocusableComp2/>);
+      const driver = createDriver(<WithFocusableComp2 />);
 
       driver.tabIn();
       expectKeyboardFocused(driver, 'after focus');
@@ -103,8 +108,53 @@ describe('FocusableHOC', () => {
       expectNotFocused(driver, 'after blur');
     });
 
+    describe('Given `onFocus`', () => {
+      it('callback should not have focus nor focus-visible [when] keyboard focused', () => {
+        const onFocus = () => ({});
+
+        const driver = createDriver(<WithFocusableComp2 onFocus={onFocus} />);
+
+        driver.tabIn();
+        expectNotFocused(driver);
+      });
+      it('callback with focus method calling should have focus and focus-visible [when] keyboard focused', () => {
+        const onFocus = focus => focus();
+
+        const driver = createDriver(<WithFocusableComp2 onFocus={onFocus} />);
+
+        driver.tabIn();
+        expectKeyboardFocused(driver, 'after focus');
+      });
+    });
+
+    describe('Given `onBlur`', () => {
+      it('callback should not blur focused component [when] keyboard focused', () => {
+        const onBlur = () => ({});
+
+        const driver = createDriver(<WithFocusableComp2 onBlur={onBlur} />);
+
+        driver.tabIn();
+        expectKeyboardFocused(driver, 'after focus');
+
+        driver.blur();
+        expectKeyboardFocused(driver, 'after focus');
+      });
+
+      it('callback with blur method calling should blur focused component [when] keyboard focused', () => {
+        const onBlur = blur => blur();
+
+        const driver = createDriver(<WithFocusableComp2 onFocus={onBlur} />);
+
+        driver.tabIn();
+        expectKeyboardFocused(driver, 'after focus');
+
+        driver.blur();
+        expectNotFocused(driver);
+      });
+    });
+
     it('should have focus but not focus-visible [when] clicked', () => {
-      const driver = createDriver(<WithFocusableComp2/>);
+      const driver = createDriver(<WithFocusableComp2 />);
 
       driver.click();
       expectMouseFocused(driver, 'after click');
@@ -115,7 +165,7 @@ describe('FocusableHOC', () => {
      * is was set to `mouse`.
      */
     it('should have focus and focus-visible [when] focused [given] mouseDown and blur', () => {
-      const driver = createDriver(<WithFocusableComp2/>);
+      const driver = createDriver(<WithFocusableComp2 />);
 
       driver.click();
       expectMouseFocused(driver, 'after click');
@@ -128,7 +178,7 @@ describe('FocusableHOC', () => {
     });
 
     it('should not be focused [when] tabbed out [given] focused by mouse', () => {
-      const driver = createDriver(<WithFocusableComp/>);
+      const driver = createDriver(<WithFocusableComp />);
 
       driver.click();
       expectMouseFocused(driver, 'after click');
@@ -138,7 +188,7 @@ describe('FocusableHOC', () => {
     });
 
     it('should have focus and focus-visible, when: any keyboard key pressed [given] focused by mouse', () => {
-      const driver = createDriver(<WithFocusableComp/>);
+      const driver = createDriver(<WithFocusableComp />);
 
       driver.click();
       expectMouseFocused(driver, 'after click');

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.spec.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.spec.tsx
@@ -118,7 +118,7 @@ describe('FocusableHOC', () => {
         expectNotFocused(driver);
       });
       it('callback with focus method calling should have focus and focus-visible [when] keyboard focused', () => {
-        const onFocus = focus => focus();
+        const onFocus = (event, triggers) => triggers.focus();
 
         const driver = createDriver(<WithFocusableComp2 onFocus={onFocus} />);
 
@@ -141,9 +141,9 @@ describe('FocusableHOC', () => {
       });
 
       it('callback with blur method calling should blur focused component [when] keyboard focused', () => {
-        const onBlur = blur => blur();
+        const onBlur = (event, triggers) => triggers.blur();
 
-        const driver = createDriver(<WithFocusableComp2 onFocus={onBlur} />);
+        const driver = createDriver(<WithFocusableComp2 onBlur={onBlur} />);
 
         driver.tabIn();
         expectKeyboardFocused(driver, 'after focus');

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
@@ -84,7 +84,7 @@ export const withFocusable = Component => {
       const isFocused = this.state.focus || this.state.focusVisible;
       const isBecomeDisabled = !prevProps.disabled && this.props.disabled;
       if (isFocused && isBecomeDisabled) {
-        this.onBlur();
+        this.onBlur({});
       }
     }
 
@@ -102,14 +102,18 @@ export const withFocusable = Component => {
       this.setState({ focus: false, focusVisible: false });
     };
 
-    onFocus = () => {
+    onFocus = event => {
       const { onFocus } = this.props;
-      onFocus ? onFocus(this.focus) : this.focus();
+      onFocus
+        ? onFocus(event, { blur: this.blur, focus: this.focus })
+        : this.focus();
     };
 
-    onBlur = () => {
+    onBlur = event => {
       const { onBlur } = this.props;
-      onBlur ? onBlur(this.blur) : this.blur();
+      onBlur
+        ? onBlur(event, { blur: this.blur, focus: this.focus })
+        : this.blur();
     };
 
     render() {

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
@@ -68,7 +68,7 @@ export const withFocusable = Component => {
 
     state = {
       focus: false,
-      focusVisible: false
+      focusVisible: false,
     };
 
     componentWillUnmount() {
@@ -88,7 +88,7 @@ export const withFocusable = Component => {
       }
     }
 
-    onFocus = () => {
+    focus = () => {
       this.setState({ focus: true, focusVisible: inputMethod.isKeyboard() });
       inputMethod.subscribe(this, () => {
         if (inputMethod.isKeyboard()) {
@@ -97,9 +97,19 @@ export const withFocusable = Component => {
       });
     };
 
-    onBlur = () => {
+    blur = () => {
       inputMethod.unsubscribe(this);
       this.setState({ focus: false, focusVisible: false });
+    };
+
+    onFocus = () => {
+      const { onFocus } = this.props;
+      onFocus ? onFocus(this.focus) : this.focus();
+    };
+
+    onBlur = () => {
+      const { onBlur } = this.props;
+      onBlur ? onBlur(this.blur) : this.blur();
     };
 
     render() {
@@ -117,9 +127,9 @@ export const withFocusable = Component => {
             'root',
             {
               focus: this.state.focus,
-              'focus-visible': this.state.focusVisible
+              'focus-visible': this.state.focusVisible,
             },
-            this.props
+            this.props,
           )}
         />
       );
@@ -130,6 +140,6 @@ export const withFocusable = Component => {
     ? FocusableHOC
     : hoistNonReactMethods(FocusableHOC, Component, {
         delegateTo: c => c.wrappedComponentRef,
-        hoistStatics: true
+        hoistStatics: true,
       });
 };


### PR DESCRIPTION
This PR adds additional focus & blur control for consumer when using a component that uses FocusableHOC. There are cases when consumer wants to control focusable components focus and also add additional actions. This change will add onBlur and onFocus props on top and give control over the focusability.  