### PR TITLE
wix-ui-test-utils: UniDriver: Migrate to `@unidriver`

### DIFF
--- a/packages/wix-ui-test-utils/README.md
+++ b/packages/wix-ui-test-utils/README.md
@@ -258,3 +258,7 @@ driver.click();
 driver.exists();
 // ...
 ```
+
+## Migration (Major versions)
+
+See [Migration.md](./docs/MIGRATION.md)

--- a/packages/wix-ui-test-utils/docs/MIGRATION.md
+++ b/packages/wix-ui-test-utils/docs/MIGRATION.md
@@ -1,0 +1,7 @@
+# Migration (Major Versions)
+
+## From 1.x to 2.x
+
+### Unidriver
+
+- In version 2.x Unidriver's `attr` method returns `null` when attribute does not exists (and not an empty string)

--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "wix-ui-test-utils",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Wix",
     "email": "fed-infra@wix.com"

--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -82,6 +82,9 @@
     ]
   },
   "dependencies": {
-    "unidriver": "^2.0.0"
+    "@unidriver/core": "^1.1.2",
+    "@unidriver/jsdom-react": "^1.2.1",
+    "@unidriver/protractor": "^1.1.2",
+    "@unidriver/puppeteer": "^1.1.2"
   }
 }

--- a/packages/wix-ui-test-utils/src/base-driver/index.ts
+++ b/packages/wix-ui-test-utils/src/base-driver/index.ts
@@ -1,4 +1,4 @@
-import {UniDriver} from 'unidriver';
+import {UniDriver} from '@unidriver/core';
 
 export interface BaseUniDriver {
   /** returns true if component exists */

--- a/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
+++ b/packages/wix-ui-test-utils/src/enzyme/enzyme.ts
@@ -3,8 +3,8 @@ import {reactEventTrigger} from '../react-helpers';
 import {BaseDriver} from '../driver-factory';
 import {BaseUniDriver} from '../base-driver';
 import {MountRendererProps, ReactWrapper} from 'enzyme';
-import {UniDriver} from 'unidriver';
-import {reactUniDriver} from 'unidriver/react';
+import {UniDriver} from '@unidriver/core';
+import {jsdomReactUniDriver} from '@unidriver/jsdom-react';
 
 export interface WrapperData {
   wrapper: ReactWrapper;
@@ -29,7 +29,7 @@ export function enzymeUniTestkitFactoryCreator<T extends BaseUniDriver> (driverF
     const regexp = new RegExp(`^<[^>]+data-hook="${obj.dataHook}"`);
     const component = obj.wrapper.findWhere(n => n.length > 0 && typeof n.type() === 'string' && (regexp).test(n.html()));
     const element = component.length > 0 ? component.first().getDOMNode() : undefined;
-    const base = reactUniDriver(element as Element);
+    const base = jsdomReactUniDriver(element as Element);
     return driverFactory(base);
   };
 }

--- a/packages/wix-ui-test-utils/src/protractor/protractor.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor.ts
@@ -1,6 +1,6 @@
 import {$, ElementFinder} from 'protractor';
-import {protractorUniDriver} from 'unidriver/protractor';
-import {UniDriver} from 'unidriver';
+import {protractorUniDriver} from '@unidriver/protractor';
+import {UniDriver} from '@unidriver/core';
 import {BaseUniDriver} from '../base-driver';
 
 export function protractorTestkitFactoryCreator<T>(

--- a/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
+++ b/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
@@ -1,7 +1,7 @@
 import {Page, ElementHandle} from 'puppeteer';
 import {BaseUniDriver} from '../base-driver';
-import {UniDriver} from 'unidriver';
-import {pupUniDriver} from 'unidriver/puppeteer';
+import {UniDriver} from '@unidriver/core';
+import {pupUniDriver} from '@unidriver/puppeteer';
 
 export function puppeteerTestkitFactoryCreator<T>(
   driverFactory: (e: ElementHandle | null, page: Page) => T
@@ -14,10 +14,8 @@ export function puppeteerUniTestkitFactoryCreator<T extends BaseUniDriver>(
   driverFactory: (base: UniDriver, body: UniDriver) => T
 ) {
   return async (obj: {dataHook: string; page: Page}) => {
-    const base = pupUniDriver(
-      async () => await obj.page.$(`[data-hook='${obj.dataHook}']`)
-    );
-    const body = pupUniDriver(async () => await obj.page.$(`body`));
+    const base = pupUniDriver({page: obj.page, selector: `[data-hook='${obj.dataHook}']`});
+    const body = pupUniDriver({page: obj.page, selector: 'body'});
     return driverFactory(base, body);
   };
 }

--- a/packages/wix-ui-test-utils/src/uni-driver-factory/createUniDriverFactory.tsx
+++ b/packages/wix-ui-test-utils/src/uni-driver-factory/createUniDriverFactory.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import {render} from 'react-dom';
 import {BaseUniDriver} from '../base-driver';
-import {UniDriver} from 'unidriver';
-import {reactUniDriver} from 'unidriver/react';
+import {UniDriver} from '@unidriver/core';
+import {jsdomReactUniDriver} from '@unidriver/jsdom-react';
 
 export type UniDriverFactory<TDriver extends BaseUniDriver> = (base: UniDriver) => TDriver;
 
 function componentFactory(Component: React.ReactElement<any>): UniDriver {
   const wrapperDiv = document.createElement('div');
   render(Component, wrapperDiv);
-  const base = reactUniDriver(wrapperDiv.childNodes[0] as Element);
+  const base = jsdomReactUniDriver(wrapperDiv.childNodes[0] as Element);
   return base;
 }
 

--- a/packages/wix-ui-test-utils/src/unidriver/stylable-unidriver-util.ts
+++ b/packages/wix-ui-test-utils/src/unidriver/stylable-unidriver-util.ts
@@ -1,4 +1,4 @@
-import {UniDriver} from 'unidriver';
+import {UniDriver} from '@unidriver/core';
 import {RuntimeStylesheet, StateValue} from '@stylable/runtime';
 
 /**

--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -4,8 +4,8 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 import {reactEventTrigger} from '../react-helpers';
 import {DriverFactory, BaseDriver} from '../driver-factory';
 import {BaseUniDriver} from '../base-driver';
-import {UniDriver} from 'unidriver';
-import {reactUniDriver} from 'unidriver/react';
+import {UniDriver} from '@unidriver/core';
+import {jsdomReactUniDriver} from '@unidriver/jsdom-react';
 
 export interface TestkitArgs {
   wrapper: HTMLElement;
@@ -42,7 +42,7 @@ export function uniTestkitFactoryCreator<T extends BaseUniDriver>(
 ) {
   return (testkitArgs: TestkitArgs) => {
     const element = getElement(testkitArgs) as Element;
-    return driverFactory(reactUniDriver(element));
+    return driverFactory(jsdomReactUniDriver(element));
   };
 }
 


### PR DESCRIPTION
- We used to use `unidriver@2`
- Now we'll use: 
  - `@unidriver/core@1`
  - `@unidriver/jsdom-react@1`
  - `@unidriver/protractor@1`
  - `@unidriver/puppeteer@1`

There shouldn't be any breaking changes in the `UniDriver` API.