### PR TITLE
wix-ui-core: Bump Major version to 3.x - Upgrade Unidriver 

### DIFF
--- a/packages/wix-ui-core/README.md
+++ b/packages/wix-ui-core/README.md
@@ -1,3 +1,7 @@
 # wix-ui-core
 
 ## [Using Icons](https://github.com/wix/wix-ui/blob/master/docs/icons.md)
+
+## Migration (Major Version)
+
+See [`docs/migration`](./docs/migration/index.md)

--- a/packages/wix-ui-core/docs/migration/index.md
+++ b/packages/wix-ui-core/docs/migration/index.md
@@ -1,0 +1,4 @@
+# Migration (Major Versions)
+
+- [v2-v3](./v2-v3.md)
+

--- a/packages/wix-ui-core/docs/migration/v2-v3.md
+++ b/packages/wix-ui-core/docs/migration/v2-v3.md
@@ -1,0 +1,5 @@
+# Migration v2-v3
+
+## Unidriver
+
+- In version 3.x we use `@unidriver/core` in which the `attr` method returns `null` when attribute does not exists (and not an empty string)

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -71,9 +71,8 @@
     "shallowequal": "1.1.0",
     "tslib": "^1.9.3",
     "type-zoo": "3.1.1",
-    "unidriver": "^2.0.1",
     "wix-eventually": "^2.2.0",
-    "wix-ui-test-utils": "^1.0.0"
+    "wix-ui-test-utils": "^2.0.0"
   },
   "devDependencies": {
     "@storybook/react": "^5.0.0",
@@ -90,6 +89,7 @@
     "@ui-autotools/registry": "^4.0.0",
     "@ui-autotools/sanity": "^2.5.0",
     "@ui-autotools/snap": "^3.0.0",
+    "@unidriver/core": "^1.1.2",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "enzyme": "^3.0.0",
@@ -106,11 +106,11 @@
     "ts-jest": "^22.0.3",
     "typescript": "~3.0.3",
     "wait-for-cond": "^1.5.1",
+    "webpack-dev-middleware": "3.6.0",
     "wix-storybook-utils": "^2.0.45",
     "wix-ui-icons-common": "^1.0.0",
     "wix-ui-mocha-runner": "^0.1.6",
     "yoshi": "^3.28.0",
-    "webpack-dev-middleware": "3.6.0",
     "yoshi-style-dependencies": "^3.16.0"
   },
   "license": "MIT",

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "name": "wix-ui-core",
   "description": "wix-ui-core",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "module": "./dist/es/src",
   "sideEffects": [
     "./.storybook/**/*.*",

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -90,6 +90,7 @@
     "@ui-autotools/sanity": "^2.5.0",
     "@ui-autotools/snap": "^3.0.0",
     "@unidriver/core": "^1.1.2",
+    "@unidriver/jsdom-react": "^1.2.1",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "enzyme": "^3.0.0",

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -72,7 +72,7 @@
     "tslib": "^1.9.3",
     "type-zoo": "3.1.1",
     "wix-eventually": "^2.2.0",
-    "wix-ui-test-utils": "^2.0.0"
+    "wix-ui-test-utils": "^1.0.0"
   },
   "devDependencies": {
     "@storybook/react": "^5.0.0",

--- a/packages/wix-ui-core/src/base-driver.ts
+++ b/packages/wix-ui-core/src/base-driver.ts
@@ -1,4 +1,4 @@
-import {UniDriver} from 'unidriver';
+import {UniDriver} from '@unidriver/core';
 
 export interface BaseUniDriver {
   /** returns true if component exists */

--- a/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
+++ b/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
@@ -1,4 +1,4 @@
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 import {
   BaseUniDriver,
   baseUniDriverFactory

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {StylableDOMUtil} from '@stylable/dom-test-kit';
 import * as eventually from 'wix-eventually';
-import { reactUniDriver } from 'unidriver';
+import { jsdomReactUniDriver } from '@unidriver/jsdom-react';
 import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { Avatar , AvatarProps} from '.';
 import { nameToInitials } from './util';
@@ -20,7 +20,7 @@ describe('Avatar', () => {
   const createDriver = testContainer.createUniRendererAsync(avatarDriverFactory);
 
   const createDriverFromContainer = () => {
-    const base = reactUniDriver(testContainer.componentNode);
+    const base = jsdomReactUniDriver(testContainer.componentNode);
     return avatarDriverFactory(base);
   }
     
@@ -303,7 +303,7 @@ describe('Avatar', () => {
     it('should pass className prop onto root elemenet', async () => {
         const className = 'foo';
         await testContainer.render(<Avatar className={className}/>);
-      const driver = reactUniDriver(testContainer.componentNode);
+      const driver = jsdomReactUniDriver(testContainer.componentNode);
       expect(await driver.attr('class')).toContain(className);
     });
   })
@@ -312,14 +312,14 @@ describe('Avatar', () => {
     it('should pass title prop onto root elemenet', async () => {
       const title = 'Avatar for John Doe';
       const driver = createDriver(<Avatar title={title}/>);
-      const unDriver = reactUniDriver(testContainer.componentNode);
+      const unDriver = jsdomReactUniDriver(testContainer.componentNode);
       expect(await unDriver.attr('title')).toBe(title);
     });
 
     it('should have default value for title if name is provided', async () => {
       const name = 'John Doe';
       const driver = createDriver(<Avatar name={name}/>);
-      const unDriver = reactUniDriver(testContainer.componentNode);
+      const unDriver = jsdomReactUniDriver(testContainer.componentNode);
       expect(await unDriver.attr('title')).toBe(name);
     });
   })
@@ -328,14 +328,14 @@ describe('Avatar', () => {
     it('should pass aria-label prop onto root elemenet', async () => {
       const ariaLabel = 'Avatar for John Doe';
       const driver = createDriver(<Avatar ariaLabel={ariaLabel}/>);
-      const unDriver = reactUniDriver(testContainer.componentNode);
+      const unDriver = jsdomReactUniDriver(testContainer.componentNode);
       expect(await unDriver.attr('aria-label')).toBe(ariaLabel);
     });
 
     it('should have default value for aria-label if name is provided', async () => {
       const name = 'John Doe';
       const driver = createDriver(<Avatar name={name}/>);
-      const unDriver = reactUniDriver(testContainer.componentNode);
+      const unDriver = jsdomReactUniDriver(testContainer.componentNode);
       expect(await unDriver.attr('aria-label')).toBe(name);
     });
   })

--- a/packages/wix-ui-core/src/components/button-next/button-next.driver.private.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.driver.private.ts
@@ -1,4 +1,4 @@
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 import {
   buttonNextDriverFactory as publicButtonDriver,
   ButtonNextDriver

--- a/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
@@ -2,7 +2,7 @@ import {
   BaseUniDriver,
   baseUniDriverFactory
 } from 'wix-ui-test-utils/base-driver';
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 import {StylableUnidriverUtil} from '../../../test/StylableUnidriverUtil';
 import styles from './button-next.st.css';
 

--- a/packages/wix-ui-core/src/components/captcha/Captcha.driver.ts
+++ b/packages/wix-ui-core/src/components/captcha/Captcha.driver.ts
@@ -2,7 +2,7 @@ import {
   BaseUniDriver,
   baseUniDriverFactory
 } from 'wix-ui-test-utils/base-driver';
-import {UniDriver} from 'unidriver';
+import {UniDriver} from '@unidriver/core';
 
 export interface CaptchaDriver extends BaseUniDriver {
   /** clicks on the captcha checkbox challenge */

--- a/packages/wix-ui-core/src/components/captcha/test-assets/CaptchaTestComponent.testDriver.ts
+++ b/packages/wix-ui-core/src/components/captcha/test-assets/CaptchaTestComponent.testDriver.ts
@@ -6,7 +6,7 @@ import {
   BaseUniDriver,
   baseUniDriverFactory
 } from 'wix-ui-test-utils/base-driver';
-import {UniDriver} from 'unidriver';
+import {UniDriver} from '@unidriver/core';
 
 async function isCaptchaVerified() {
   await waitForVisibilityOf($(`[data-hook=${constants.verifiedTokenDataHook}`));

--- a/packages/wix-ui-core/src/components/deprecated/label/Label.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/deprecated/label/Label.uni.driver.ts
@@ -2,7 +2,7 @@ import {
   BaseUniDriver,
   baseUniDriverFactory
 } from 'wix-ui-test-utils/base-driver';
-import {UniDriver} from 'unidriver';
+import {UniDriver} from '@unidriver/core';
 import { StylableUnidriverUtil } from '../../../../test/StylableUnidriverUtil';
 import styles from './Label.st.css';
 import {ReactBase} from '../../../../test/utils/unidriver';

--- a/packages/wix-ui-core/src/components/image/image.driver.private.ts
+++ b/packages/wix-ui-core/src/components/image/image.driver.private.ts
@@ -1,4 +1,4 @@
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 import {
   BaseUniDriver,
   baseUniDriverFactory,

--- a/packages/wix-ui-core/src/components/image/image.driver.ts
+++ b/packages/wix-ui-core/src/components/image/image.driver.ts
@@ -1,4 +1,4 @@
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 import {
   BaseUniDriver,
   baseUniDriverFactory,

--- a/packages/wix-ui-core/src/components/menu-item/menu-item.driver.ts
+++ b/packages/wix-ui-core/src/components/menu-item/menu-item.driver.ts
@@ -6,7 +6,7 @@ import {
   baseUniDriverFactory
 } from 'wix-ui-test-utils/base-driver';
 
-import {UniDriver} from 'unidriver';
+import {UniDriver} from '@unidriver/core';
 
 export interface MenuItemDriver extends BaseUniDriver {
   /** checks if the item is selected */

--- a/packages/wix-ui-core/src/components/popover/Popover.common.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.common.uni.driver.ts
@@ -1,4 +1,4 @@
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 
 export const CommonDriver = (base: UniDriver, body: UniDriver ) => {
   const queryDocumentOrElement= async (query: string) => {

--- a/packages/wix-ui-core/src/components/popover/Popover.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.uni.driver.ts
@@ -1,7 +1,7 @@
 import { CommonDriver } from './Popover.common.uni.driver';
 import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
 import { Simulate } from 'react-dom/test-utils';
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 import { ReactBase, safeGetNative } from '../../../test/utils/unidriver';
 
 export const testkit = (base: UniDriver, body: UniDriver) => {

--- a/packages/wix-ui-core/src/components/video/Video.driver.private.ts
+++ b/packages/wix-ui-core/src/components/video/Video.driver.private.ts
@@ -1,4 +1,4 @@
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 import {
   videoDriverFactory as publicVideoDriver,
   IVideoDriver

--- a/packages/wix-ui-core/src/components/video/Video.driver.ts
+++ b/packages/wix-ui-core/src/components/video/Video.driver.ts
@@ -2,7 +2,7 @@ import {
   BaseUniDriver,
   baseUniDriverFactory
 } from 'wix-ui-test-utils/base-driver';
-import {UniDriver} from 'unidriver';
+import {UniDriver} from '@unidriver/core';
 
 export interface IVideoDriver extends BaseUniDriver {
   /** returns player name */

--- a/packages/wix-ui-core/test/StylableUnidriverUtil.ts
+++ b/packages/wix-ui-core/test/StylableUnidriverUtil.ts
@@ -1,4 +1,4 @@
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 import { RuntimeStylesheet, StateValue } from '@stylable/runtime';
 
 /**

--- a/packages/wix-ui-core/test/dom-test-container.ts
+++ b/packages/wix-ui-core/test/dom-test-container.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Simulate } from 'react-dom/test-utils';
-import { reactUniDriver, UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
+import { jsdomReactUniDriver } from '@unidriver/jsdom-react';
 
 // At the moment our tests support both Jsdom and browser environment.
 // The browser test runner provides #root element to render into, and
@@ -95,8 +96,8 @@ export class ReactDOMTestContainer {
   public createUniRenderer<T>(driverFactory: (base: UniDriver, body?: UniDriver) => T): (element: JSX.Element) => T {
     return (jsx: JSX.Element) => {
       this.renderSync(jsx);
-      const base = reactUniDriver(this.componentNode);
-      const body = reactUniDriver(document.body);
+      const base = jsdomReactUniDriver(this.componentNode);
+      const body = jsdomReactUniDriver(document.body);
       return driverFactory(base, body);
     };
   }
@@ -104,8 +105,8 @@ export class ReactDOMTestContainer {
   public createUniRendererAsync<T>(driverFactory: (base: UniDriver, body?: UniDriver) => T): (element: JSX.Element) => Promise<T> {
     return async (jsx: JSX.Element) => {
       await this.render(jsx);
-      const base = reactUniDriver(this.componentNode);
-      const body = reactUniDriver(document.body);
+      const base = jsdomReactUniDriver(this.componentNode);
+      const body = jsdomReactUniDriver(document.body);
       return driverFactory(base, body);
     };
   }

--- a/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
+++ b/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
@@ -1,5 +1,5 @@
 import { Simulate } from 'react-dom/test-utils';
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 
 /**
  *Temporary workaround for implementing missing Unidriver methods in React/DOM only.

--- a/packages/wix-ui-core/test/utils/unidriver/Utils.ts
+++ b/packages/wix-ui-core/test/utils/unidriver/Utils.ts
@@ -1,4 +1,4 @@
-import { UniDriver } from 'unidriver';
+import { UniDriver } from '@unidriver/core';
 
 /**
  * Safe getNative that returns `null` if the element doesn't exist.


### PR DESCRIPTION
### The Unidriver Breaking Change 
Unidriver upgrade introduces a small change in API, but it could  "slightly" break consumer's tests.
Unidriver `attr()` was fixed so that in case the attribute does not exist, it will return `null` and not an empty string.

This could break tests like this:
```js
it('should be disabled', ()=> {
   ...
   expect(driver.attr('data-disabled')).toBe('');
}
it('should NOT be disabled', ()=> {
   ...
   expect(driver.attr('data-disabled')).toBe('true');
}
```

We decided not to consider this as a breaking change. The chance of tests breaking is small.