### PR TITLE
<Tooltip/> - missing use case with onClickoutside

### DIFF
--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
@@ -125,5 +125,16 @@ describe('Tooltip', () => {
       await driver.clickOutside();
       expect(await driver.tooltipExists()).toBe(false);
     });
+
+    it('should not close tooltip on mouse out when given shouldCloseOnClickOutside', async () => {
+      const onClickOutside = jest.fn();
+      const { driver } = render(
+        tooltip({ onClickOutside, shouldCloseOnClickOutside: true }),
+      );
+      expect(await driver.tooltipExists()).toBe(false);
+      await driver.mouseEnter();
+      await driver.mouseLeave();
+      expect(await driver.tooltipExists()).toBe(true);
+    });
   });
 });

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -58,14 +58,15 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
   _handleClickOutside = () => {
     const { onClickOutside, shouldCloseOnClickOutside } = this.props;
     if (shouldCloseOnClickOutside) {
-      this.close();
+      this.props.onHide();
+      this.setState({ isOpen: false });
     }
     return onClickOutside ? onClickOutside() : null;
   };
 
   _renderElement = () => {
     const { children } = this.props;
-    if (typeof children === 'string') {
+    if (typeof children === 'string' || !children) {
       return children;
     }
     return React.cloneElement(children as any, {
@@ -80,8 +81,11 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
   };
 
   close = () => {
-    this.props.onHide();
-    this.setState({ isOpen: false });
+    const { shouldCloseOnClickOutside } = this.props;
+    if(!shouldCloseOnClickOutside) {
+      this.props.onHide();
+      this.setState({ isOpen: false });
+    }
   };
 
   _onFocus = (event, handlers) => {

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -67,7 +67,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
   _renderElement = () => {
     const { children } = this.props;
     if (typeof children === 'string' || !children) {
-      return children;
+      return children || '';
     }
     return React.cloneElement(children as any, {
       onFocus: this._onFocus,


### PR DESCRIPTION
This PR fixes and issue where wix-ui-backoffice expects the tooltip to not close when shouldCloseOnClickOutside is defined.