### PR TITLE
<Tooltip/> - add disabled prop support

### DIFF
--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
@@ -130,6 +130,16 @@ describe('Tooltip', () => {
     });
   });
 
+  describe('`disabled` prop', () => {
+    it('[when] given should not show tooltip on mouse enter', async () => {
+      const children = 'kido';
+      const { driver } = render(tooltip({ children, disabled: true }));
+      expect(await driver.tooltipExists()).toBe(false);
+      await driver.mouseEnter();
+      expect(await driver.tooltipExists()).toBe(false);
+    });
+  });
+
   describe('`onClickOutside` & `shouldCloseOnClickOutside` props', () => {
     it('should call onClickOutside when clicked outside', async () => {
       const onClickOutside = jest.fn();

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
@@ -138,6 +138,13 @@ describe('Tooltip', () => {
       await driver.mouseEnter();
       expect(await driver.tooltipExists()).toBe(false);
     });
+    it('[when] given should not show tooltip on focus', async () => {
+      const children = 'kido';
+      const { driver } = render(tooltip({ children, disabled: true }));
+      expect(await driver.tooltipExists()).toBe(false);
+      await driver.tabIn();
+      expect(await driver.tooltipExists()).toBe(false);
+    });
   });
 
   describe('`onClickOutside` & `shouldCloseOnClickOutside` props', () => {

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -22,6 +22,8 @@ export interface TooltipProps {
   onShow?: Function;
   /** callback to call when the tooltip is being hidden */
   onHide?: Function;
+  /** disabled tooltip showup on mouse enter */
+  disabled?: boolean;
   /** Enables calculations in relation to the parent element*/
   appendTo?: AppendTo;
   /** whether to enable the flip behaviour. This behaviour is used to flip the Tooltips placement when it starts to overlap the target element. */
@@ -123,13 +125,14 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
       fixed,
       hideDelay,
       showDelay,
+      disabled,
     } = this.props;
 
     return (
       <Popover
         {...style('root', {}, this.props)}
         placement={placement}
-        shown={this.state.isOpen}
+        shown={disabled ? false : this.state.isOpen}
         showArrow={showArrow}
         onMouseEnter={this.open}
         onMouseLeave={this.close}


### PR DESCRIPTION
This PR adds additional prop `disabled` which disables tooltip showup on mouse enter or focus event.