### PR TITLE
wix-ui-test-utils: UniDriver / vanilla: add body ad optional 2nd argument

### DIFF
--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -82,6 +82,6 @@
     ]
   },
   "dependencies": {
-    "unidriver": "^2.0.0"
+    "unidriver": "^2.0.1"
   }
 }

--- a/packages/wix-ui-test-utils/src/uni-driver-factory/createUniDriverFactory.tsx
+++ b/packages/wix-ui-test-utils/src/uni-driver-factory/createUniDriverFactory.tsx
@@ -4,7 +4,7 @@ import {BaseUniDriver} from '../base-driver';
 import {UniDriver} from 'unidriver';
 import {reactUniDriver} from 'unidriver/react';
 
-export type UniDriverFactory<TDriver extends BaseUniDriver> = (base: UniDriver) => TDriver;
+export type UniDriverFactory<TDriver extends BaseUniDriver> = (base: UniDriver, body?: UniDriver) => TDriver;
 
 function componentFactory(Component: React.ReactElement<any>): UniDriver {
   const wrapperDiv = document.createElement('div');

--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -47,7 +47,6 @@ export function uniTestkitFactoryCreator<T extends BaseUniDriver>(
   };
 }
 
-
 export function isTestkitExists<T extends BaseDriver>(
   Element: React.ReactElement<any>,
   testkitFactory: (obj: { wrapper: any; dataHook: string }) => T,

--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -6,6 +6,7 @@ import {DriverFactory, BaseDriver} from '../driver-factory';
 import {BaseUniDriver} from '../base-driver';
 import {UniDriver} from 'unidriver';
 import {reactUniDriver} from 'unidriver/react';
+import {UniDriverFactory} from '../uni-driver-factory';
 
 export interface TestkitArgs {
   wrapper: HTMLElement;
@@ -38,13 +39,14 @@ export function testkitFactoryCreator<T extends BaseDriver>(
 }
 
 export function uniTestkitFactoryCreator<T extends BaseUniDriver>(
-  driverFactory: (base: UniDriver) => T
+  driverFactory: UniDriverFactory<T>
 ) {
   return (testkitArgs: TestkitArgs) => {
     const element = getElement(testkitArgs) as Element;
-    return driverFactory(reactUniDriver(element));
+    return driverFactory(reactUniDriver(element), reactUniDriver(document.body));
   };
 }
+
 
 export function isTestkitExists<T extends BaseDriver>(
   Element: React.ReactElement<any>,


### PR DESCRIPTION
- Should should NOT break any types, since `body` is optional
- We can make is required later