### PR TITLE
wix-ui-core - (UniDriver) ReactBase - remove irrelevant workarounds

### DIFF
--- a/packages/wix-ui-core/src/components/deprecated/label/Label.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/deprecated/label/Label.uni.driver.ts
@@ -5,7 +5,6 @@ import {
 import { UniDriver } from 'wix-ui-test-utils/unidriver';
 import { StylableUnidriverUtil } from '../../../../test/StylableUnidriverUtil';
 import styles from './Label.st.css';
-import { ReactBase } from '../../../../test/utils/unidriver';
 
 export interface LabelDriver extends BaseUniDriver {
   /** get the label's text */
@@ -24,7 +23,6 @@ export interface LabelDriver extends BaseUniDriver {
 
 export const labelUniDriverFactory = (base: UniDriver): LabelDriver => {
   const stylableUnidriverUtil = new StylableUnidriverUtil(styles);
-  const unidriverReactDOMExtension = ReactBase(base);
 
   return {
     ...baseUniDriverFactory(base),
@@ -33,6 +31,6 @@ export const labelUniDriverFactory = (base: UniDriver): LabelDriver => {
     getForAttribute: () => base.attr('for'),
     hasEllipsis: () => stylableUnidriverUtil.hasStyleState(base, 'ellipsis'),
     isDisabled: () => stylableUnidriverUtil.hasStyleState(base, 'disabled'),
-    keyDown: key => unidriverReactDOMExtension.pressKey(key),
+    keyDown: key => base.pressKey(key),
   };
 };

--- a/packages/wix-ui-core/src/components/file-picker-button/test/FilePickerButton.private.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/file-picker-button/test/FilePickerButton.private.uni.driver.ts
@@ -22,7 +22,6 @@ export const filePickerButtonPrivateUniDriverFactory = (
     byDataHook(DataHook.ChooseFileButton),
   );
 
-  const reactFileInputUniDriver = ReactBase(fileInputUniDriver);
   const reactChooseFileButtonUniDriver = ReactBase(chooseFileButtonUniDriver);
 
   return {
@@ -34,9 +33,8 @@ export const filePickerButtonPrivateUniDriverFactory = (
         return el;
       }
     },
-    getFileInputAttribute: (attr: string) =>
-      reactFileInputUniDriver.getAttribute(attr),
+    getFileInputAttribute: (attr: string) => fileInputUniDriver.attr(attr),
     getChooseFileButtonAttribute: (attr: string) =>
-      reactChooseFileButtonUniDriver.getAttribute(attr),
+      chooseFileButtonUniDriver.attr(attr),
   };
 };

--- a/packages/wix-ui-core/src/components/file-picker-button/test/FilePickerButton.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/file-picker-button/test/FilePickerButton.uni.driver.ts
@@ -37,10 +37,10 @@ export const filePickerButtonUniDriverFactory = (
     getText: () => chooseFileButtonUniDriver.text(),
     getAccept: () => fileInputUniDriver.attr('accept'),
     isRequired: async () =>
-      (await getReactFileInputUniDriver().hasAttribute('required')) &&
+      (await fileInputUniDriver.attr('required')) !== null &&
       stylableUniDriverUtil.hasStyleState(base, 'required'),
     isDisabled: async () =>
-      (await getReactFileInputUniDriver().hasAttribute('disabled')) &&
+      (await fileInputUniDriver.attr('disabled')) !== null &&
       stylableUniDriverUtil.hasStyleState(base, 'disabled'),
     selectFile: async (file: Partial<File>) => {
       if (base.type === 'protractor') {

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
@@ -12,7 +12,7 @@ type SubscribeCb = () => void;
 /**
  * Singleton for managing current input method (keyboard or mouse).
  */
-const inputMethod = new class {
+const inputMethod = new (class {
   // Default is keyboard in case an element is focused programmatically.
   method: 'mouse' | 'keyboard' = 'keyboard';
   subscribers: Map<any, SubscribeCb> = new Map();
@@ -43,7 +43,7 @@ const inputMethod = new class {
       this.subscribers.forEach(f => f());
     }
   }
-}();
+})();
 
 /*
  * TODO: Consider adding 'disabled' state to this HOC, since:

--- a/packages/wix-ui-core/src/utils/index.ts
+++ b/packages/wix-ui-core/src/utils/index.ts
@@ -9,11 +9,11 @@ export const buildChildrenObject = <T>(
       return acc;
     }
 
-    if (!child.type || !child.type['displayName']) {
+    if (!child.type || !(child.type as any).displayName) {
       return acc;
     }
 
-    const name = child.type['displayName'].split('.').pop();
+    const name = (child.type as any).displayName.split('.').pop();
     acc[name] = child;
     return acc;
   }, childrenObject || ({} as T));

--- a/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
+++ b/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
@@ -19,8 +19,6 @@ export function ReactBase(base: UniDriver) {
   };
 
   return {
-    pressKey: async (key: string) =>
-      Simulate.keyDown(await getNative(), { key }),
     mouseLeave: async () => Simulate.mouseLeave(await getNative()),
     hasAttribute: async (name: string) =>
       (await getNative()).hasAttribute(name),

--- a/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
+++ b/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
@@ -7,10 +7,6 @@ import { UniDriver } from 'wix-ui-test-utils/unidriver';
  * @param {UniDriver} base
  */
 export function ReactBase(base: UniDriver) {
-  if (base.type !== 'react') {
-    throw new Error('Supported only in React/DOM.');
-  }
-
   const getNative = (): Promise<HTMLElement> => {
     if (base.type !== 'react') {
       throw new Error('Supported only in React/DOM.');

--- a/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
+++ b/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
@@ -15,17 +15,14 @@ export function ReactBase(base: UniDriver) {
     if (base.type !== 'react') {
       throw new Error('Supported only in React/DOM.');
     }
-    return base.getNative()
+    return base.getNative();
   };
 
   return {
     mouseLeave: async () => Simulate.mouseLeave(await getNative()),
     hasAttribute: async (name: string) =>
       (await getNative()).hasAttribute(name),
-    getAttribute: async (name: string) =>
-      (await getNative()).getAttribute(name),
     focus: async () => (await getNative()).focus(),
-    getStyle: async () =>
-      (await getNative()).style,
+    getStyle: async () => (await getNative()).style,
   };
 }

--- a/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
+++ b/packages/wix-ui-core/test/utils/unidriver/ReactBase.ts
@@ -20,8 +20,6 @@ export function ReactBase(base: UniDriver) {
 
   return {
     mouseLeave: async () => Simulate.mouseLeave(await getNative()),
-    hasAttribute: async (name: string) =>
-      (await getNative()).hasAttribute(name),
     focus: async () => (await getNative()).focus(),
     getStyle: async () => (await getNative()).style,
   };


### PR DESCRIPTION
Now that UniDriver is upgraded. We can remove redundant workarounds.
- `getAttribute` and `hasAttribute` shouldn't have been in ReactrBase in the first place.
- `pressKey` is now available in UNiDriver (And it actually was not in use)