### PR TITLE
<ButtonNext/> - render affix with its provided class name

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.driver.private.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.driver.private.ts
@@ -6,15 +6,22 @@ import {
 
 export interface ButtonNextPrivateDriver extends ButtonNextDriver {
   suffixExists(): Promise<boolean>;
+  hasSuffixClass(string): Promise<boolean>;
   prefixExists(): Promise<boolean>;
+  hasPrefixClass(string): Promise<boolean>;
 }
 
 export const buttonNextPrivateDriverFactory = (
   base: UniDriver,
 ): ButtonNextPrivateDriver => {
+  const getSuffix = () => base.$('[data-hook="suffix"]');
+  const getPrefix = () => base.$('[data-hook="prefix"]');
+
   return {
     ...publicButtonDriver(base),
-    suffixExists: async () => base.$('[data-hook="suffix"]').exists(),
-    prefixExists: async () => base.$('[data-hook="prefix"]').exists(),
+    suffixExists: async () => getSuffix().exists(),
+    hasSuffixClass: async className => getSuffix().hasClass(className),
+    prefixExists: async () => getPrefix().exists(),
+    hasPrefixClass: async className => getPrefix().hasClass(className),
   };
 };

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -45,19 +45,33 @@ describe('ButtonNext', () => {
   });
 
   describe(`'suffixIcon' and 'prefixIcon' props`, () => {
-    const suffix = <div data-hook="suffix">suffix</div>;
-    const prefix = <div data-hook="prefix">prefix</div>;
+    const suffixInternalClass = 'suffix-internal-class';
+    const suffix = (
+      <div data-hook="suffix" className={suffixInternalClass}>
+        suffix
+      </div>
+    );
+    const prefixInternalClass = 'prefix-internal-class';
+    const prefix = (
+      <div data-hook="prefix" className={prefixInternalClass}>
+        prefix
+      </div>
+    );
 
-    it(`should render 'suffix' when given`, async () => {
+    it(`should render 'suffix' with its class name when given`, async () => {
       const driver = await createDriver(<ButtonNext suffixIcon={suffix} />);
-      expect(await driver.suffixExists()).toBeTruthy();
+
       expect(await driver.prefixExists()).toBeFalsy();
+      expect(await driver.suffixExists()).toBeTruthy();
+      expect(await driver.hasSuffixClass(suffixInternalClass)).toBe(true);
     });
 
-    it(`should render 'prefix' when given`, async () => {
+    it(`should render 'prefix' with its class name when given`, async () => {
       const driver = await createDriver(<ButtonNext prefixIcon={prefix} />);
-      expect(await driver.prefixExists()).toBeTruthy();
+
       expect(await driver.suffixExists()).toBeFalsy();
+      expect(await driver.prefixExists()).toBeTruthy();
+      expect(await driver.hasPrefixClass(prefixInternalClass)).toBe(true);
     });
   });
 

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import classnames from 'classnames';
+
 import style from './button-next.st.css';
 
 export interface ButtonProps
@@ -21,7 +23,7 @@ export interface ButtonProps
 const _addAffix = (Affix, styleClass) =>
   Affix &&
   React.cloneElement(Affix, {
-    className: style[styleClass],
+    className: classnames(style[styleClass], Affix.props.className),
   });
 
 /**


### PR DESCRIPTION
## The Issue
When providing a className for the affix element (through `suffixIcon` and `prefixIcon` either) - this class isn't actually appended to the child's class list. 

## The Solution
This PR fixes that by appending the class to the affix child.