### PR TITLE
wix-storybook-utils: display imports in LiveCodeExample

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -53,13 +53,24 @@ export default class LiveCodeExample extends Component {
     };
   }
 
-  formatCode = code =>
-    prettier.format(code, {
+  formatCode = code => {
+    const filteredCode = code
+      .split('\n')
+      .filter(
+        line =>
+          !/\/(\*|\/)+.*((t|e)slint[-|:](dis|en)able|prettier-ignore)/.test(
+            line,
+          ),
+      )
+      .join('\n');
+
+    return prettier.format(filteredCode, {
       parser: 'babel',
       plugins: [babylonParser],
       singleQuote: true,
       trailingComma: 'all',
     });
+  };
 
   resetCode = () =>
     this.setState({
@@ -78,6 +89,20 @@ export default class LiveCodeExample extends Component {
     this.setState(state => ({
       isEditorOpened: !state.isEditorOpened,
     }));
+
+  transformCode = (code = '') =>
+    code
+      .split('\n')
+      .filter(
+        line =>
+          ![
+            // ignore import/export statements
+            /^[\s]*?(import|export)/,
+            // ignore require calls
+            /\S*?require\(['"]\S*?['"]\)/,
+          ].some(regex => regex.test(line)),
+      )
+      .join('\n');
 
   render() {
     const { compact, previewRow, previewProps, autoRender } = this.props;
@@ -120,6 +145,7 @@ export default class LiveCodeExample extends Component {
           scope={this.props.scope}
           mountStylesheet={false}
           noInline={!autoRender}
+          transformCode={this.transformCode}
         >
           <div className={styles.liveExampleWrapper}>
             <div

--- a/packages/wix-storybook-utils/src/Sections/section-with-siblings/index.test.tsx
+++ b/packages/wix-storybook-utils/src/Sections/section-with-siblings/index.test.tsx
@@ -2,22 +2,26 @@ import { mount } from 'enzyme';
 
 import { sectionWithSiblings } from '.';
 
-import { title } from '../';
+import * as sectionBuilders from '../';
 
 describe('sectionWithSiblings', () => {
-  it('should not render siblings for `title` section', () => {
-    const rendered = mount(
-      sectionWithSiblings(
-        title({
-          pretitle: 'i',
-          title: 'should',
-          subtitle: 'not',
-          description: 'show',
-        }),
-        'i should show',
-      ),
-    );
+  ['title', 'header'].map(section => {
+    it(`should not render siblings for ${section} section`, () => {
+      const expectation = `${section} without siblings`;
 
-    expect(rendered.text()).toEqual('i should show');
+      const rendered = mount(
+        sectionWithSiblings(
+          sectionBuilders[section]({
+            pretitle: 'i',
+            title: 'should',
+            subtitle: 'not',
+            description: 'show',
+          }),
+          expectation,
+        ),
+      );
+
+      expect(rendered.text()).toEqual(expectation);
+    });
   });
 });

--- a/packages/wix-storybook-utils/src/Sections/section-with-siblings/index.tsx
+++ b/packages/wix-storybook-utils/src/Sections/section-with-siblings/index.tsx
@@ -5,7 +5,7 @@ import { SectionType } from '../../typings/story-section';
 import styles from './styles.scss';
 
 const SIBLINGS = ['pretitle', 'title', 'subtitle', 'description'];
-const SECTIONS_WITHOUT_SIBLINGS = [SectionType.Title];
+const SECTIONS_WITHOUT_SIBLINGS = [SectionType.Title, SectionType.Header];
 
 const sectionPrepares = {
   [SectionType.ImportExample]: section => ({

--- a/packages/wix-storybook-utils/src/StoryPage/index.tsx
+++ b/packages/wix-storybook-utils/src/StoryPage/index.tsx
@@ -26,6 +26,7 @@ const makeSections: (a: StoryPageProps) => Section[] = props =>
       when: props.sections && props.componentPath,
       make: () => merge(createDefaultSections(props), props.sections),
     },
+
     {
       when: props.sections && !props.componentPath,
       make: () => props.sections,

--- a/packages/wix-storybook-utils/stories/examples/code-with-imports.js
+++ b/packages/wix-storybook-utils/stories/examples/code-with-imports.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-console */
+/* prettier-ignore */
+/*eslint-disable*/
+/* eslint-enable */
+/* eslint-disable hello-kitty */
+/** eslint-disable */
+/* eslint-disable hello-kitty */
+// eslint-disable-next-line
+/* prettier-ignore */
+
+import Something from 'some-library/Something';
+
+const SomethingElse = require('some-library/SomethingElse');
+
+/* tslint:enable:rule1 rule2 rule3... */
+// tslint:disable-next-line
+// prettier-ignore
+<div>Lorem nihil ea adipisci possimus?</div>;

--- a/packages/wix-storybook-utils/stories/index.js
+++ b/packages/wix-storybook-utils/stories/index.js
@@ -18,6 +18,7 @@ import './sections/single-component.story';
 import './sections/story-with-sections.story';
 import './sections/default-sections.story';
 import './sections/filled-sections.story';
+import './sections/code-examples.story';
 
 storiesOf('Components', module)
   .add('<CodeExample/>', () => (

--- a/packages/wix-storybook-utils/stories/sections/code-examples.story.js
+++ b/packages/wix-storybook-utils/stories/sections/code-examples.story.js
@@ -1,0 +1,9 @@
+import { header, code } from '../../Sections';
+
+import importsExample from '!raw-loader!../examples/code-with-imports';
+
+export default {
+  category: 'Sections',
+  storyName: 'Code Examples',
+  sections: [header({ title: 'yo' }), code(importsExample)]
+};


### PR DESCRIPTION
1. allow `LiveCodeExample` to get `source` with `import`, `export`
statements and `require` calls
1. hide linter comments from editor

this change:

1. allows writing code examples more naturally (just like any other js code),
1. examples can showcase what components are imported and how
1. no more headaches with `sterilizeCode` for specific examples