### PR TITLE
<ButtonNext/> - use template strings instead of classnames dependency

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import classnames from 'classnames';
 
 import style from './button-next.st.css';
 
@@ -23,7 +22,7 @@ export interface ButtonProps
 const _addAffix = (Affix, styleClass) =>
   Affix &&
   React.cloneElement(Affix, {
-    className: classnames(style[styleClass], Affix.props.className),
+    className: `${style[styleClass]} ${Affix.props.className}`,
   });
 
 /**


### PR DESCRIPTION
This PR fixes the following error:

> Error: Uncaught [TypeError: classnames_1.default is not a function]

Resource: https://github.com/jedmao/tsx-react-postcss-webpack/issues/1