### PR TITLE
Unidriver - Move deprecation log to factory function

### DIFF
--- a/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
+++ b/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
@@ -1,3 +1,5 @@
-import { unidriverImportDepLog } from '../../utils/deprecationLog';
-unidriverImportDepLog('avatarDriverFactory');
 export * from './avatar.uni.driver';
+
+import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { avatarDriverFactory as original } from './avatar.uni.driver';
+export const avatarDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
+++ b/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
@@ -2,4 +2,7 @@ export * from './avatar.uni.driver';
 
 import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { avatarDriverFactory as original } from './avatar.uni.driver';
-export const avatarDriverFactory = unidriverDepLogWrapper(original);
+export const avatarDriverFactory = unidriverDepLogWrapper(
+  original,
+  'avatarDriverFactory',
+);

--- a/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
+++ b/packages/wix-ui-core/src/components/avatar/avatar.driver.ts
@@ -1,5 +1,5 @@
 export * from './avatar.uni.driver';
 
-import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { avatarDriverFactory as original } from './avatar.uni.driver';
 export const avatarDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -5,7 +5,7 @@ import { reactUniDriver } from 'wix-ui-test-utils/vanilla';
 import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { Avatar, AvatarProps } from '.';
 import { nameToInitials } from './util';
-import { avatarDriverFactory } from './avatar.uni.driver';
+import { avatarDriverFactory } from './avatar.driver';
 import styles from './avatar.st.css';
 
 /** jsdom simulates loading of the image regardless of the src URL */

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -5,7 +5,7 @@ import { reactUniDriver } from 'wix-ui-test-utils/vanilla';
 import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { Avatar, AvatarProps } from '.';
 import { nameToInitials } from './util';
-import { avatarDriverFactory } from './avatar.driver';
+import { avatarDriverFactory } from './avatar.uni.driver';
 import styles from './avatar.st.css';
 
 /** jsdom simulates loading of the image regardless of the src URL */

--- a/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
@@ -1,3 +1,5 @@
-import { unidriverImportDepLog } from '../../utils/deprecationLog';
-unidriverImportDepLog('buttonNextDriverFactory');
 export * from './button-next.uni.driver';
+
+import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { buttonNextDriverFactory as original } from './button-next.uni.driver';
+export const buttonNextDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
@@ -1,5 +1,5 @@
 export * from './button-next.uni.driver';
 
-import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { buttonNextDriverFactory as original } from './button-next.uni.driver';
 export const buttonNextDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.driver.ts
@@ -2,4 +2,7 @@ export * from './button-next.uni.driver';
 
 import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { buttonNextDriverFactory as original } from './button-next.uni.driver';
-export const buttonNextDriverFactory = unidriverDepLogWrapper(original);
+export const buttonNextDriverFactory = unidriverDepLogWrapper(
+  original,
+  'buttonNextDriverFactory',
+);

--- a/packages/wix-ui-core/src/components/captcha/Captcha.driver.ts
+++ b/packages/wix-ui-core/src/components/captcha/Captcha.driver.ts
@@ -1,5 +1,5 @@
 export * from './Captcha.uni.driver';
 
-import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { captchaDriverFactory as original } from './Captcha.uni.driver';
 export const captchaDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/captcha/Captcha.driver.ts
+++ b/packages/wix-ui-core/src/components/captcha/Captcha.driver.ts
@@ -1,3 +1,5 @@
-import { unidriverImportDepLog } from '../../utils/deprecationLog';
-unidriverImportDepLog('captchaDriverFactory');
 export * from './Captcha.uni.driver';
+
+import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { captchaDriverFactory as original } from './Captcha.uni.driver';
+export const captchaDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/captcha/Captcha.driver.ts
+++ b/packages/wix-ui-core/src/components/captcha/Captcha.driver.ts
@@ -2,4 +2,7 @@ export * from './Captcha.uni.driver';
 
 import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { captchaDriverFactory as original } from './Captcha.uni.driver';
-export const captchaDriverFactory = unidriverDepLogWrapper(original);
+export const captchaDriverFactory = unidriverDepLogWrapper(
+  original,
+  'captchaDriverFactory',
+);

--- a/packages/wix-ui-core/src/components/image/image.driver.ts
+++ b/packages/wix-ui-core/src/components/image/image.driver.ts
@@ -1,5 +1,5 @@
 export * from './image.uni.driver';
 
-import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { imageDriverFactory as original } from './image.uni.driver';
 export const imageDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/image/image.driver.ts
+++ b/packages/wix-ui-core/src/components/image/image.driver.ts
@@ -2,4 +2,7 @@ export * from './image.uni.driver';
 
 import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { imageDriverFactory as original } from './image.uni.driver';
-export const imageDriverFactory = unidriverDepLogWrapper(original);
+export const imageDriverFactory = unidriverDepLogWrapper(
+  original,
+  'imageDriverFactory',
+);

--- a/packages/wix-ui-core/src/components/image/image.driver.ts
+++ b/packages/wix-ui-core/src/components/image/image.driver.ts
@@ -1,3 +1,5 @@
-import { unidriverImportDepLog } from '../../utils/deprecationLog';
-unidriverImportDepLog('imageDriverFactory');
 export * from './image.uni.driver';
+
+import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { imageDriverFactory as original } from './image.uni.driver';
+export const imageDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/media-image/media-image.driver.ts
+++ b/packages/wix-ui-core/src/components/media-image/media-image.driver.ts
@@ -1,3 +1,5 @@
-import { unidriverImportDepLog } from '../../utils/deprecationLog';
-unidriverImportDepLog('mediaImageDriverFactory');
 export * from './media-image.uni.driver';
+
+import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { mediaImageDriverFactory as original } from './media-image.uni.driver';
+export const mediaImageDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/media-image/media-image.driver.ts
+++ b/packages/wix-ui-core/src/components/media-image/media-image.driver.ts
@@ -2,4 +2,7 @@ export * from './media-image.uni.driver';
 
 import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { mediaImageDriverFactory as original } from './media-image.uni.driver';
-export const mediaImageDriverFactory = unidriverDepLogWrapper(original);
+export const mediaImageDriverFactory = unidriverDepLogWrapper(
+  original,
+  'mediaImageDriverFactory',
+);

--- a/packages/wix-ui-core/src/components/media-image/media-image.driver.ts
+++ b/packages/wix-ui-core/src/components/media-image/media-image.driver.ts
@@ -1,5 +1,5 @@
 export * from './media-image.uni.driver';
 
-import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { mediaImageDriverFactory as original } from './media-image.uni.driver';
 export const mediaImageDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/menu-item/menu-item.driver.ts
+++ b/packages/wix-ui-core/src/components/menu-item/menu-item.driver.ts
@@ -2,4 +2,7 @@ export * from './menu-item.uni.driver';
 
 import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { menuItemDriverFactory as original } from './menu-item.uni.driver';
-export const menuItemDriverFactory = unidriverDepLogWrapper(original);
+export const menuItemDriverFactory = unidriverDepLogWrapper(
+  original,
+  'menuItemDriverFactory',
+);

--- a/packages/wix-ui-core/src/components/menu-item/menu-item.driver.ts
+++ b/packages/wix-ui-core/src/components/menu-item/menu-item.driver.ts
@@ -1,5 +1,5 @@
 export * from './menu-item.uni.driver';
 
-import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { menuItemDriverFactory as original } from './menu-item.uni.driver';
 export const menuItemDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/menu-item/menu-item.driver.ts
+++ b/packages/wix-ui-core/src/components/menu-item/menu-item.driver.ts
@@ -1,3 +1,5 @@
-import { unidriverImportDepLog } from '../../utils/deprecationLog';
-unidriverImportDepLog('menuItemDriverFactory');
 export * from './menu-item.uni.driver';
+
+import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { menuItemDriverFactory as original } from './menu-item.uni.driver';
+export const menuItemDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/video/Video.driver.ts
+++ b/packages/wix-ui-core/src/components/video/Video.driver.ts
@@ -2,4 +2,7 @@ export * from './Video.uni.driver';
 
 import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { videoDriverFactory as original } from './Video.uni.driver';
-export const videoDriverFactory = unidriverDepLogWrapper(original);
+export const videoDriverFactory = unidriverDepLogWrapper(
+  original,
+  'videoDriverFactory',
+);

--- a/packages/wix-ui-core/src/components/video/Video.driver.ts
+++ b/packages/wix-ui-core/src/components/video/Video.driver.ts
@@ -1,3 +1,5 @@
-import { unidriverImportDepLog } from '../../utils/deprecationLog';
-unidriverImportDepLog('videoDriverFactory');
 export * from './Video.uni.driver';
+
+import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { videoDriverFactory as original } from './Video.uni.driver';
+export const videoDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/components/video/Video.driver.ts
+++ b/packages/wix-ui-core/src/components/video/Video.driver.ts
@@ -1,5 +1,5 @@
 export * from './Video.uni.driver';
 
-import { unidriverDepLogWrapper } from '../../utils/deprecationLog';
+import { unidriverDepLogWrapper } from '../../utils/unidriver-dep-log-wrapper';
 import { videoDriverFactory as original } from './Video.uni.driver';
 export const videoDriverFactory = unidriverDepLogWrapper(original);

--- a/packages/wix-ui-core/src/utils/deprecation-logger.ts
+++ b/packages/wix-ui-core/src/utils/deprecation-logger.ts
@@ -1,0 +1,50 @@
+const noop = () => {};
+
+let depLogger: Logger = {
+  log: noop,
+};
+
+interface Logger {
+  log(msg: string): void;
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  class DeprecationLogger implements Logger {
+    constructor(private readonly prefix: string) {
+      this.log = this.log.bind(this);
+    }
+
+    reportedMessages = new Set<string>();
+
+    /**
+     * Log a warning message, once per key. (Calling `log` twice with same key would result in one log)
+     *
+     * @param {*} message
+     * @memberof DeprecationLogger
+     */
+    log(message: string) {
+      if (!this.reportedMessages.has(message)) {
+        this.reportedMessages.add(message);
+        this.printWarning(message);
+      }
+    }
+
+    printWarning = (msg: string) => {
+      const message = `${this.prefix}${msg}`;
+      if (console) {
+        console.warn(message); // eslint-disable-line
+      }
+      try {
+        // --- Welcome to debugging wix-style-react ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        throw new Error(message);
+      } catch (x) {}
+    };
+  }
+
+  depLogger = new DeprecationLogger('wix-ui-core: [WARNING] ');
+}
+
+export { depLogger };
+export default (msg: string) => depLogger.log(msg);

--- a/packages/wix-ui-core/src/utils/deprecationLog.ts
+++ b/packages/wix-ui-core/src/utils/deprecationLog.ts
@@ -1,7 +1,12 @@
-export function unidriverImportDepLog(driverName) {
-  deprecationLog(
-    `Deprecated import path: import {${driverName}} from 'wix-ui-core/drivers/vanilla'. ${driverName} is actually a UniDriver. Please import from 'wix-ui-core/drivers/unidriver'`,
-  );
+export function unidriverDepLogWrapper(originalDriverFactory) {
+  function driverFactory(base: any) {
+    const driverName = originalDriverFactory.name;
+    deprecationLog(
+      `Deprecated import path: import {${driverName}} from 'wix-ui-core/drivers/vanilla'. ${driverName} is actually a UniDriver. Please import from 'wix-ui-core/drivers/unidriver'`,
+    );
+    originalDriverFactory(base);
+  }
+  return driverFactory;
 }
 
 export function deprecationLog(msg) {

--- a/packages/wix-ui-core/src/utils/unidriver-dep-log-wrapper.ts
+++ b/packages/wix-ui-core/src/utils/unidriver-dep-log-wrapper.ts
@@ -3,12 +3,11 @@ import deprecationLog from './deprecation-logger';
 
 export function unidriverDepLogWrapper<T>(
   originalDriverFactory: (base: UniDriver) => T,
+  driverFactoryName: string,
 ) {
   function driverFactory(base: UniDriver) {
-    const driverName = originalDriverFactory.name;
-
     deprecationLog(
-      `Deprecated import path: import {${driverName}} from 'wix-ui-core/drivers/vanilla'. ${driverName} is actually a UniDriver. Please import from 'wix-ui-core/drivers/unidriver'`,
+      `Deprecated import path: import {${driverFactoryName}} from 'wix-ui-core/drivers/vanilla'. ${driverFactoryName} is actually a UniDriver. Please import from 'wix-ui-core/drivers/unidriver'`,
     );
     return originalDriverFactory(base);
   }

--- a/packages/wix-ui-core/src/utils/unidriver-dep-log-wrapper.ts
+++ b/packages/wix-ui-core/src/utils/unidriver-dep-log-wrapper.ts
@@ -1,14 +1,16 @@
-export function unidriverDepLogWrapper(originalDriverFactory) {
-  function driverFactory(base: any) {
+import { UniDriver } from 'wix-ui-test-utils/unidriver';
+import deprecationLog from './deprecation-logger';
+
+export function unidriverDepLogWrapper<T>(
+  originalDriverFactory: (base: UniDriver) => T,
+) {
+  function driverFactory(base: UniDriver) {
     const driverName = originalDriverFactory.name;
+
     deprecationLog(
       `Deprecated import path: import {${driverName}} from 'wix-ui-core/drivers/vanilla'. ${driverName} is actually a UniDriver. Please import from 'wix-ui-core/drivers/unidriver'`,
     );
-    originalDriverFactory(base);
+    return originalDriverFactory(base);
   }
   return driverFactory;
-}
-
-export function deprecationLog(msg) {
-  console.warn(`DEPRECATED wix-ui-core: ${msg}`);
 }


### PR DESCRIPTION
imports from `drivers/vanilla` of Unidrivers is wrong, hence I already added a deprecationLog (previous PR).

This PR moves the deprecation log to the `compDriverFactory` method, so we don't get false logs.
Meaning,
When someone imported:
`import {CheckboxDriver} from 'wix-ui-core/drivers/vannilla';`

They got the deprecation log for Avatar, although Avatar was not imported/used.
