### PR TITLE
<Tooltip/> & <Popover/> - make sure that popover gets data-hook. Add data-hook to Tooltip

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -469,6 +469,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
         >
           <div
             style={inlineStyles}
+            data-hook={this.props['data-hook']}
             {...style('root', {}, this.props)}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -131,6 +131,9 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     return (
       <Popover
         {...style('root', {}, this.props)}
+        {...(this.props['data-hook']
+          ? { 'data-hook': this.props['data-hook'] }
+          : {})}
         placement={placement}
         shown={disabled ? false : this.state.isOpen}
         showArrow={showArrow}


### PR DESCRIPTION
This PR add data-hook attribute for popover instead of relying on stylable spread. Also this will add data-hook attribute support for Tooltip component.