### PR TITLE
wix-storybook-utils: support class properties in code LiveCodeExample

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -47,6 +47,9 @@
     "react": "^15.4.0"
   },
   "dependencies": {
+    "@babel/core": "^7.4.3",
+    "@babel/plugin-proposal-class-properties": "^7.4.0",
+    "@babel/plugin-syntax-jsx": "^7.2.0",
     "babel-runtime": "^6.25.0",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { Collapse } from 'react-collapse';
 import prettier from 'prettier/standalone';
 import babylonParser from 'prettier/parser-babylon';
+import { transform } from '@babel/core';
 
 import { CopyButton } from '../CopyButton';
 import ToggleSwitch from '../ui/toggle-switch';
@@ -90,8 +91,8 @@ export default class LiveCodeExample extends Component {
       isEditorOpened: !state.isEditorOpened,
     }));
 
-  transformCode = (code = '') =>
-    code
+  transformCode = (code = '') => {
+    const withoutImports = code
       .split('\n')
       .filter(
         line =>
@@ -103,6 +104,16 @@ export default class LiveCodeExample extends Component {
           ].some(regex => regex.test(line)),
       )
       .join('\n');
+
+    const transformed = transform(withoutImports, {
+      plugins: [
+        require('@babel/plugin-syntax-jsx'),
+        [require('@babel/plugin-proposal-class-properties'), { loose: true }],
+      ],
+    }).code;
+
+    return transformed;
+  };
 
   render() {
     const { compact, previewRow, previewProps, autoRender } = this.props;

--- a/packages/wix-storybook-utils/stories/examples/class-with-arrows.js
+++ b/packages/wix-storybook-utils/stories/examples/class-with-arrows.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-undef */
+import React from 'react';
+
+class Component extends React.Component {
+  state = { value: 'test' };
+  onChange = event => this.setState({ value: event.target.value });
+
+  render() {
+    return (
+      <div>
+        <input value={this.state.value} onChange={this.onChange} />
+      </div>
+    );
+  }
+}
+
+render(
+  <div
+    style={{
+      background: 'teal',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: 300,
+      height: 300,
+    }}
+    children={<Component />}
+  />,
+);

--- a/packages/wix-storybook-utils/stories/sections/code-examples.story.js
+++ b/packages/wix-storybook-utils/stories/sections/code-examples.story.js
@@ -1,9 +1,17 @@
 import { header, code } from '../../Sections';
 
 import importsExample from '!raw-loader!../examples/code-with-imports';
+import classWithArrowsExample from '!raw-loader!../examples/class-with-arrows';
 
 export default {
   category: 'Sections',
   storyName: 'Code Examples',
-  sections: [header({ title: 'yo' }), code(importsExample)]
+  sections: [
+    header({ title: 'Code examples story' }),
+    code(importsExample),
+    code({
+      source: classWithArrowsExample,
+      autoRender: false,
+    }),
+  ],
 };


### PR DESCRIPTION
finalize https://github.com/wix/wix-ui/issues/1061
closes https://github.com/wix-private/wix-style-react-playground/issues/37

this is a really nice to have feature, but it might increase the bundle size, because `@babel/core` appears in runtime.

quick test on wsr shows a 500KB increase in built storybook, which is 7.5% increase which is not thaaat significant (from 6.1MB in vendors.js to 6.6MB) 

---

it's been decided, for now bundle increase is not too taxing. we should instead focus on making each `.story.js` a chunk