### PR TITLE
<Tooltip/> - fix getTooltipText to read content with popover native method

### DIFF
--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.uni.driver.ts
@@ -16,7 +16,7 @@ export const tooltipDriverFactory = (base, body) => {
     /** returns tooltips content value in string */
     getTooltipText: async () => {
       await testkit.mouseEnter();
-      const text = await body.$(`[data-hook="popover-content"]`).text();
+      const text = (await testkit.getContentElement()).textContent;
       // Clean yourself!
       await testkit.mouseLeave();
       return text;


### PR DESCRIPTION
This PR is a follow up fix after Popovers [issue](https://github.com/wix/wix-ui/issues/1264)  has been solved. Method in Tooltip called `getTooltipText` will use popovers `getContentElement` method to find the correct content in the dom.