### PR TITLE
wix-ui-framework: generator fixes

### DIFF
--- a/packages/wix-ui-framework/package.json
+++ b/packages/wix-ui-framework/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "commander": "^2.20.0",
-    "jscodeshift": "^0.6.3",
+    "jscodeshift": "^0.6.4",
     "ora": "^3.4.0",
     "prompts": "^2.0.4",
     "simple-git": "^1.110.0"

--- a/packages/wix-ui-framework/src/generate/Answers.d.ts
+++ b/packages/wix-ui-framework/src/generate/Answers.d.ts
@@ -1,0 +1,4 @@
+export interface Answers {
+  description: string;
+  ComponentName: string;
+}

--- a/packages/wix-ui-framework/src/generate/Answers.d.ts
+++ b/packages/wix-ui-framework/src/generate/Answers.d.ts
@@ -1,4 +1,0 @@
-export interface Answers {
-  description: string;
-  ComponentName: string;
-}

--- a/packages/wix-ui-framework/src/generate/Options.d.ts
+++ b/packages/wix-ui-framework/src/generate/Options.d.ts
@@ -1,9 +1,0 @@
-export interface Options {
-  cwd: string;
-  ComponentName: string;
-  description: string;
-  templatesPath: string;
-  codemodsPath: string;
-  force: boolean;
-  skipCodemods: boolean;
-}

--- a/packages/wix-ui-framework/src/generate/__test__/__snapshots__/copy-templates.spec.ts.snap
+++ b/packages/wix-ui-framework/src/generate/__test__/__snapshots__/copy-templates.spec.ts.snap
@@ -9,7 +9,7 @@ import Text from '../Text';
 import Button from '../Button';
 import styles from './MyNewComponent.st.css';
 
-
+/** MyNewComponent */
 class MyNewComponent extends React.PureComponent {
   static displayName = 'MyNewComponent';
 
@@ -389,9 +389,7 @@ import Text from '../Text';
 import Button from '../Button';
 import styles from './MyNewComponent.st.css';
 
-/**
- * This is a very cool component, yall
- */
+/** This is a very cool component, yall */
 class MyNewComponent extends React.PureComponent {
   static displayName = 'MyNewComponent';
 

--- a/packages/wix-ui-framework/src/generate/__test__/copy-templates.spec.ts
+++ b/packages/wix-ui-framework/src/generate/__test__/copy-templates.spec.ts
@@ -47,7 +47,7 @@ describe('copyTemplates', () => {
     await copyTemplates({
       ComponentName: 'MyNewComponent',
       description: 'This is a very cool component, yall',
-      templatesPath: path.join(__dirname, 'templates'),
+      templates: path.join(__dirname, 'templates'),
       cwd: tempDir,
     });
 
@@ -58,7 +58,7 @@ describe('copyTemplates', () => {
     await copyTemplates({
       ComponentName: 'MyNewComponent',
       description: undefined,
-      templatesPath: path.join(__dirname, 'templates'),
+      templates: path.join(__dirname, 'templates'),
       cwd: tempDir,
     });
 

--- a/packages/wix-ui-framework/src/generate/__test__/create-values-map.spec.ts
+++ b/packages/wix-ui-framework/src/generate/__test__/create-values-map.spec.ts
@@ -24,4 +24,18 @@ describe('createValuesMap', () => {
       'component-name': 'my-component-name',
     });
   });
+
+  it('should use componentName as description, when description not provided', () => {
+    const ComponentName = 'MyComponentName';
+    expect(
+      createValuesMap({
+        ComponentName,
+        description: '',
+      }),
+    ).toMatchObject({
+      ComponentName,
+      'component-name': 'my-component-name',
+      description: ComponentName,
+    });
+  });
 });

--- a/packages/wix-ui-framework/src/generate/__test__/templates/test-generated/src/Component/Component.js
+++ b/packages/wix-ui-framework/src/generate/__test__/templates/test-generated/src/Component/Component.js
@@ -5,7 +5,7 @@ import Text from '../Text';
 import Button from '../Button';
 import styles from './{%ComponentName%}.st.css';
 
-{%description%}
+/** {%description%} */
 class {%ComponentName%} extends React.PureComponent {
   static displayName = '{%ComponentName%}';
 

--- a/packages/wix-ui-framework/src/generate/__test__/templates/test-generated/src/Component/Component.js
+++ b/packages/wix-ui-framework/src/generate/__test__/templates/test-generated/src/Component/Component.js
@@ -5,7 +5,7 @@ import Text from '../Text';
 import Button from '../Button';
 import styles from './{%ComponentName%}.st.css';
 
-{%descriptionJSDoc%}
+{%description%}
 class {%ComponentName%} extends React.PureComponent {
   static displayName = '{%ComponentName%}';
 

--- a/packages/wix-ui-framework/src/generate/create-values-map.ts
+++ b/packages/wix-ui-framework/src/generate/create-values-map.ts
@@ -11,5 +11,5 @@ export const createValuesMap = ({ ComponentName, description }) => ({
   ComponentName,
   componentName: pascalToCamel(ComponentName),
   'component-name': pascalToKebab(ComponentName),
-  description,
+  description: description || ComponentName,
 });

--- a/packages/wix-ui-framework/src/generate/create-values-map.ts
+++ b/packages/wix-ui-framework/src/generate/create-values-map.ts
@@ -1,19 +1,15 @@
 import { pascalToCamel, pascalToKebab } from './utils';
 
-export const createValuesMap = ({ ComponentName, description }) => {
-  const componentName = pascalToCamel(ComponentName);
-  const componentNameSnake = pascalToKebab(ComponentName);
+export interface CodemodValues {
+  ComponentName: string;
+  componentName: string;
+  'component-name': string;
+  description: string;
+}
 
-  return {
-    ComponentName,
-    description,
-    descriptionJSDoc:
-      description === undefined
-        ? ''
-        : `/**
- * ${description}
- */`,
-    componentName,
-    'component-name': componentNameSnake,
-  };
-};
+export const createValuesMap = ({ ComponentName, description }) => ({
+  ComponentName,
+  componentName: pascalToCamel(ComponentName),
+  'component-name': pascalToKebab(ComponentName),
+  description,
+});

--- a/packages/wix-ui-framework/src/generate/index.ts
+++ b/packages/wix-ui-framework/src/generate/index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { Options } from './Options';
+import { Options } from './typings';
 import { runTasks } from './run-tasks';
 import { runPrompts } from './tasks/run-prompts';
 
@@ -9,7 +9,7 @@ const cwd = process.cwd();
 const defaultTemplatesPath = 'generator/templates';
 const defaultCodemodsPath = 'generator/codemods';
 
-export const generate = ({
+export const generate: (a: Options) => Promise<void> = ({
   force,
   ComponentName,
   description,
@@ -28,8 +28,8 @@ export const generate = ({
     cwd,
     ComponentName,
     description,
-    templatesPath: path.join(cwd, templates || defaultTemplatesPath),
-    codemodsPath: path.join(cwd, codemods || defaultCodemodsPath),
+    templates: path.join(cwd, templates || defaultTemplatesPath),
+    codemods: path.join(cwd, codemods || defaultCodemodsPath),
     force,
     skipCodemods: false,
   };

--- a/packages/wix-ui-framework/src/generate/run-tasks.ts
+++ b/packages/wix-ui-framework/src/generate/run-tasks.ts
@@ -1,10 +1,16 @@
 import chalk from 'chalk';
 import * as logger from './logger';
 
-import { Options } from './Options';
+import { Options } from './typings';
+
+interface Task {
+  task(): (a: Options) => Promise<void>;
+  skipped?: boolean;
+  message: string;
+}
 
 export const runTasks: (a: Options) => Promise<void> = options => {
-  const tasks = [
+  const tasks: Task[] = [
     {
       // requires are put here for a reason, it is to delay code execution until needed. That's because one task
       // might change files that another task relies on. If all files are required beforehand, consecutive tasks will

--- a/packages/wix-ui-framework/src/generate/tasks/copy-templates.ts
+++ b/packages/wix-ui-framework/src/generate/tasks/copy-templates.ts
@@ -15,7 +15,7 @@ const pathExists = p =>
     });
   });
 
-export const copyTemplates: (a: Options) => void = async ({
+export const copyTemplates: (a: Options) => Promise<void> = async ({
   cwd,
   templates,
   ComponentName,

--- a/packages/wix-ui-framework/src/generate/tasks/copy-templates.ts
+++ b/packages/wix-ui-framework/src/generate/tasks/copy-templates.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { Options } from '../typings';
 import { replaceTemplates } from './replace-templates';
 
 import { createValuesMap } from '../create-values-map';
@@ -14,9 +15,9 @@ const pathExists = p =>
     });
   });
 
-export const copyTemplates = async ({
+export const copyTemplates: (a: Options) => void = async ({
   cwd,
-  templatesPath,
+  templates,
   ComponentName,
   description,
 }) => {
@@ -27,7 +28,7 @@ export const copyTemplates = async ({
   const readdir = entry =>
     fs.readdirSync(entry).map(dir => path.join(entry, dir));
 
-  const queue = readdir(templatesPath);
+  const queue = readdir(templates);
 
   while (queue.length) {
     const itemPath = queue.shift();
@@ -35,7 +36,7 @@ export const copyTemplates = async ({
     const isDir = fs.lstatSync(itemPath).isDirectory();
 
     const newDestPath = path
-      .join(cwd, itemPath.replace(templatesPath, ''))
+      .join(cwd, itemPath.replace(templates, ''))
       .replace(new RegExp(`${templateNamePlaceholder}`, 'g'), ComponentName);
 
     if (isDir) {

--- a/packages/wix-ui-framework/src/generate/tasks/run-codemods.ts
+++ b/packages/wix-ui-framework/src/generate/tasks/run-codemods.ts
@@ -15,10 +15,7 @@ const runCodemod: ({
     const codemodPath = path.join(options.codemods, codemodConfig.codemod);
 
     const pathToExecutable = path.join(
-      __dirname,
-      '..',
-      '..',
-      '..',
+      options.cwd,
       'node_modules',
       '.bin',
       'jscodeshift',

--- a/packages/wix-ui-framework/src/generate/tasks/run-codemods.ts
+++ b/packages/wix-ui-framework/src/generate/tasks/run-codemods.ts
@@ -3,19 +3,16 @@ import * as path from 'path';
 import { exec } from 'child_process';
 
 import * as logger from '../logger';
-import { createValuesMap } from '../create-values-map';
+import { Options, CodemodConfig } from '../typings.d';
+import { createValuesMap, CodemodValues } from '../create-values-map';
 
-const runCodemod = ({
-  codemodsPath,
-  codemod,
-  dist,
-  description,
-  cwd,
-  ComponentName,
-  componentName,
-}) => {
-  return new Promise((resolve, reject) => {
-    const codemodPath = path.join(codemodsPath, codemod);
+const runCodemod: ({
+  options: Options,
+  codemodValues: CodemodValues,
+  codemodConfig: CodemodConfig,
+}) => Promise<void> = ({ options, codemodValues, codemodConfig }) =>
+  new Promise((resolve, reject) => {
+    const codemodPath = path.join(options.codemods, codemodConfig.codemod);
 
     const pathToExecutable = path.join(
       __dirname,
@@ -27,54 +24,53 @@ const runCodemod = ({
       'jscodeshift',
     );
 
-    const inputPath = path.join(cwd, dist);
+    const inputPath = path.join(options.cwd, codemodConfig.dist);
 
     if (!fs.existsSync(inputPath)) {
-      reject(`Error in ${codemod}: ${inputPath} does not exist`);
+      reject(`Error in ${codemodConfig.codemod}: ${inputPath} does not exist`);
       return;
     }
 
     const command = `${pathToExecutable} \
-          ${inputPath} \
-          -t ${codemodPath} \
-          --ComponentName=${ComponentName} \
-          --componentName=${componentName} \
-          --verbose=2`;
+      ${inputPath} \
+      -t ${codemodPath} \
+      --ComponentName=${codemodValues.ComponentName} \
+      --componentName=${codemodValues.componentName} \
+      --verbose=2`;
 
     const execProc = exec(command);
 
     execProc.stderr.on('data', data => {
-      logger.error(`Error in ${codemod}: ${data.toString()}`);
+      logger.error(`Error in ${codemodConfig.codemod}: ${data.toString()}`);
       reject(data.toString());
     });
 
     execProc.on('exit', () => {
-      logger.success(description);
+      logger.success(codemodConfig.description);
       resolve();
     });
   });
-};
 
-export const runCodemods = ({
-  ComponentName,
-  description,
-  codemodsPath,
-  cwd,
-}) => {
-  try {
-    const codemods = require(path.join(codemodsPath, 'index.js'));
+export const runCodemods: (a: Options) => Promise<void[]> = options => {
+  const { ComponentName, description, codemods } = options;
 
-    return Promise.all(
-      codemods.map(codemod =>
-        runCodemod({
-          codemodsPath,
-          ...createValuesMap({ ComponentName, description }),
-          ...codemod,
-          cwd,
-        }),
-      ),
-    );
-  } catch (e) {
-    return Promise.reject(e);
-  }
+  const codemodsIndex: CodemodConfig[] = require(path.join(
+    codemods,
+    'index.js',
+  ));
+
+  const codemodValues: CodemodValues = createValuesMap({
+    ComponentName,
+    description,
+  });
+
+  return Promise.all(
+    codemodsIndex.map((codemodConfig: CodemodConfig) =>
+      runCodemod({
+        options,
+        codemodValues,
+        codemodConfig,
+      }),
+    ),
+  );
 };

--- a/packages/wix-ui-framework/src/generate/tasks/run-prompts.ts
+++ b/packages/wix-ui-framework/src/generate/tasks/run-prompts.ts
@@ -1,9 +1,11 @@
 import * as prompts from 'prompts';
 
-import { isPascalCase } from '../utils';
-const logger = require('../logger');
+import { Answers } from '../typings';
 
-export const runPrompts = async () => {
+import { isPascalCase } from '../utils';
+import * as logger from '../logger';
+
+export const runPrompts: () => Promise<Answers> = async () => {
   let promptAborted = false;
 
   const questions = [
@@ -30,11 +32,13 @@ export const runPrompts = async () => {
     },
   ];
 
-  const answers = await prompts(questions, {
+  const handlers = {
     onCancel: () => {
       promptAborted = true;
     },
-  });
+  };
+
+  const answers = await prompts(questions, handlers);
 
   if (promptAborted) {
     logger.divider();

--- a/packages/wix-ui-framework/src/generate/typings.d.ts
+++ b/packages/wix-ui-framework/src/generate/typings.d.ts
@@ -1,0 +1,20 @@
+export interface Options {
+  cwd: string;
+  ComponentName: string;
+  description: string;
+  force?: boolean;
+  skipCodemods?: boolean;
+  templates: string;
+  codemods?: string;
+}
+
+export interface Answers {
+  ComponentName: string;
+  description: string;
+}
+
+export interface CodemodConfig {
+  codemod: string;
+  dist: string;
+  description: string;
+}


### PR DESCRIPTION
* use `cwd`, not `__dirname` to find jscodeshift
* use `description: description || ComponentName` to prevent `undefined`s
* refactor data structures of `run-codemods` family, so that i get less confused