### PR TITLE
Remove requireindex, export eslint no-full-wsr-lib rule manually

### DIFF
--- a/packages/eslint-plugin-wix-style-react/lib/index.js
+++ b/packages/eslint-plugin-wix-style-react/lib/index.js
@@ -4,9 +4,9 @@
  */
 "use strict";
 
-var requireIndex = require("requireindex");
-
-module.exports.rules = requireIndex(__dirname + "/rules");
+module.exports.rules = {
+  'no-full-wsr-lib': require('./rules/no-full-wsr-lib')
+};
 
 module.exports.config = {
   recommended: {

--- a/packages/eslint-plugin-wix-style-react/package.json
+++ b/packages/eslint-plugin-wix-style-react/package.json
@@ -14,7 +14,6 @@
     "release": "wnpm-release --no-shrinkwrap"
   },
   "dependencies": {
-    "requireindex": "~1.1.0",
     "resolve": "^1.10.0",
     "semver": "^5.6.0"
   },


### PR DESCRIPTION
requireindex doesn't work with jest and we want to run tests on a package that contains this rule