### PR TITLE
<Tooltip/> - add proper support for a11y

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -211,6 +211,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       fixed,
       customArrow,
       role,
+      id,
     } = this.props;
     const shouldAnimate = shouldAnimatePopover(this.props);
 
@@ -256,7 +257,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                 )}
               <div
                 key="popover-content"
-                id={this.props['aria-describedby']}
+                id={id}
                 role={role}
                 className={showArrow ? style.popoverContent : ''}
               >
@@ -505,9 +506,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                   onClick={onClick}
                   onKeyDown={onKeyDown}
                 >
-                  {React.cloneElement(childrenObject.Element, {
-                    'aria-describedby': this.props['aria-describedby'],
-                  })}
+                  {childrenObject.Element}
                 </div>
               )}
             </Reference>

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -247,32 +247,21 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                 [style.popoverContent]: !showArrow,
               })}
             >
-              {showArrow ? (
-                [
-                  this.renderArrow(
-                    arrowProps,
-                    moveArrowTo,
-                    popperPlacement || placement,
-                    customArrow,
-                  ),
-                  <div
-                    key="popover-content"
-                    id={this.props['aria-describedby']}
-                    role={role}
-                    className={style.popoverContent}
-                  >
-                    {childrenObject.Content}
-                  </div>,
-                ]
-              ) : (
-                <div
-                  key="popover-content"
-                  id={this.props['aria-describedby']}
-                  role={role}
-                >
-                  {childrenObject.Content}
-                </div>
-              )}
+              {showArrow &&
+                this.renderArrow(
+                  arrowProps,
+                  moveArrowTo,
+                  popperPlacement || placement,
+                  customArrow,
+                )}
+              <div
+                key="popover-content"
+                id={this.props['aria-describedby']}
+                role={role}
+                className={showArrow ? style.popoverContent : ''}
+              >
+                {childrenObject.Content}
+              </div>
             </div>
           );
         }}

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -88,6 +88,8 @@ export interface PopoverProps {
   id?: string;
   /** Custom arrow element */
   customArrow?(placement: Placement, arrowProps: object): React.ReactNode;
+  /** target element role value */
+  role?: string;
 }
 
 export interface PopoverState {
@@ -208,6 +210,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       flip,
       fixed,
       customArrow,
+      role,
     } = this.props;
     const shouldAnimate = shouldAnimatePopover(this.props);
 
@@ -252,12 +255,23 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                     popperPlacement || placement,
                     customArrow,
                   ),
-                  <div key="popover-content" className={style.popoverContent}>
+                  <div
+                    key="popover-content"
+                    id={this.props['aria-describedby']}
+                    role={role}
+                    className={style.popoverContent}
+                  >
                     {childrenObject.Content}
                   </div>,
                 ]
               ) : (
-                <div key="popover-content">{childrenObject.Content}</div>
+                <div
+                  key="popover-content"
+                  id={this.props['aria-describedby']}
+                  role={role}
+                >
+                  {childrenObject.Content}
+                </div>
               )}
             </div>
           );
@@ -502,7 +516,9 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                   onClick={onClick}
                   onKeyDown={onKeyDown}
                 >
-                  {childrenObject.Element}
+                  {React.cloneElement(childrenObject.Element, {
+                    'aria-describedby': this.props['aria-describedby'],
+                  })}
                 </div>
               )}
             </Reference>

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -44,6 +44,8 @@ export interface TooltipProps {
   showArrow?: boolean;
   /** Custom arrow element */
   customArrow?(placement: Placement, arrowProps: object): React.ReactNode;
+  /** unique identifier to map target element and content element for screen readers */
+  'aria-describedby': string;
 }
 
 export interface TooltipState {
@@ -79,13 +81,14 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
   };
 
   _renderElement = () => {
-    const { children } = this.props;
+    const { children, 'aria-describedby': ariaDescribedBy } = this.props;
     if (typeof children === 'string' || !children) {
       return children || '';
     }
     return React.cloneElement(children as any, {
       onFocus: this._onFocus,
       onBlur: this._onBlur,
+      'aria-describedby': ariaDescribedBy,
     });
   };
 
@@ -129,6 +132,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
       showDelay,
       disabled,
       customArrow,
+      'aria-describedby': ariaDescribedBy,
     } = this.props;
 
     return (
@@ -152,7 +156,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
         fixed={fixed}
         onClickOutside={this._handleClickOutside}
         customArrow={customArrow}
-        aria-describedby={this.props['aria-describedby']}
+        id={ariaDescribedBy}
         role="tooltip"
       >
         <Popover.Element>{this._renderElement()}</Popover.Element>

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -152,6 +152,8 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
         fixed={fixed}
         onClickOutside={this._handleClickOutside}
         customArrow={customArrow}
+        aria-describedby={this.props['aria-describedby']}
+        role="tooltip"
       >
         <Popover.Element>{this._renderElement()}</Popover.Element>
         <Popover.Content>{content}</Popover.Content>

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -45,7 +45,7 @@ export interface TooltipProps {
   /** Custom arrow element */
   customArrow?(placement: Placement, arrowProps: object): React.ReactNode;
   /** unique identifier to map target element and content element for screen readers */
-  'aria-describedby': string;
+  'aria-describedby'?: string;
 }
 
 export interface TooltipState {

--- a/packages/wix-ui-core/stories/Tooltip/examples.ts
+++ b/packages/wix-ui-core/stories/Tooltip/examples.ts
@@ -219,8 +219,8 @@ class TooltipFixed extends React.Component {
 
 export const a11y = `
 <div style={{ display: 'flex', justifyContent: 'space-around'}}>
-  <Tooltip content="i am tooltip"><button>native</button></Tooltip>
-  <Tooltip content="i am tooltip"><ButtonNext>focusableHOC</ButtonNext></Tooltip>
+  <Tooltip aria-describedby="tooltip:1" content="i am tooltip"><button>native</button></Tooltip>
+  <Tooltip aria-describedby="tooltip:2" content="i am tooltip"><ButtonNext>focusableHOC</ButtonNext></Tooltip>
 </div>
 `;
 


### PR DESCRIPTION
This PR adds `role` and `aria-describedby` props for Tooltip and makes sure that Popover passes it to the right places.