### PR TITLE
<Popover/> - make sure that Attributes Map type interface comes from file

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -10,6 +10,7 @@ import { CSSTransition } from 'react-transition-group';
 import { Portal } from 'react-portal';
 import style from './Popover.st.css';
 import { createModifiers } from './modifiers';
+import { AttributeMap } from '../../utils/stylableUtils';
 
 import {
   buildChildrenObject,

--- a/packages/wix-ui-core/src/utils/stylableUtils.tsx
+++ b/packages/wix-ui-core/src/utils/stylableUtils.tsx
@@ -1,3 +1,10 @@
+type StateValue = boolean | number | string;
+
+export interface AttributeMap {
+  className?: string;
+  [attributeName: string]: StateValue | undefined;
+}
+
 export const attachStylesToNode = (
   node: HTMLElement,
   stylesObj: AttributeMap,


### PR DESCRIPTION
This PR fixes and issue with Popovers internal variable that uses interface from global.d.ts file. I have moved to file and imported manually.