### PR TITLE
<LinearProgressBar> - add `min` & `max` properties

### DIFF
--- a/packages/wix-ui-core/src/components/linear-progress-bar/DataHooks.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/DataHooks.ts
@@ -1,0 +1,21 @@
+/**
+ * ProgressBar data-hook props used for testing.
+ */
+export enum ProgressBarDataHooks {
+  container = 'progressbar-container',
+  background = 'progressbar-background',
+  foreground = 'progressbar-foreground',
+  progressIndicator = 'progress-indicator',
+  successIcon = 'success-icon',
+  errorIcon = 'error-icon',
+  progressPercentage = 'progress-percentages',
+}
+
+/**
+ * ProgressBar attribute keys used to store internal data (current value, min, max etc...)
+ */
+export enum ProgressBarDataKeys {
+  value = 'data-progress-value',
+  min = 'data-progress-min-value',
+  max = 'data-progress-max-value',
+}

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.driver.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.driver.ts
@@ -26,6 +26,8 @@ export interface LinearProgressBarDriver extends BaseDriver {
   hasError(): boolean;
   /** Returns min value prop */
   getMinValue(): number;
+  /** Returns max value prop */
+  getMaxValue(): number;
 }
 
 export const linearProgressBarDriverFactory: DriverFactory<
@@ -41,12 +43,15 @@ export const linearProgressBarDriverFactory: DriverFactory<
       : getElement(ProgressBarDataHooks.progressPercentage).querySelector(
           'span'
         ).innerHTML;
-  const getNumericValue = () =>
-    !element ? null : +element.getAttribute(ProgressBarDataKeys.value);
-  const getMinValue = () =>
-    !element || !element.getAttribute(ProgressBarDataKeys.min)
-      ? null
-      : +element.getAttribute(ProgressBarDataKeys.min);
+  const getDataAttribute = (key: string, parsingFunction?: Function) => {
+    if (!element || !element.getAttribute(key)) {
+      return null;
+    }
+    const value = element.getAttribute(key);
+    return !!parsingFunction && parsingFunction instanceof Function
+      ? parsingFunction(value)
+      : value;
+  };
   const driver = {
     exists: () => !!element,
     getWidth: () => {
@@ -59,10 +64,11 @@ export const linearProgressBarDriverFactory: DriverFactory<
     isPercentagesProgressDisplayed: () =>
       !!getElement(ProgressBarDataHooks.progressPercentage),
     getValue: () => getValue(),
-    isCompleted: () => getValue() === '100',
+    isCompleted: () => getValue() >= getDataAttribute(ProgressBarDataKeys.max),
     hasError: () => stylableDOMUtil.hasStyleState(element, 'error'),
-    getNumericValue,
-    getMinValue,
+    getNumericValue: () => getDataAttribute(ProgressBarDataKeys.value, Number),
+    getMinValue: () => getDataAttribute(ProgressBarDataKeys.min, Number),
+    getMaxValue: () => getDataAttribute(ProgressBarDataKeys.max, Number),
   };
 
   return driver;

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.driver.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.driver.ts
@@ -3,8 +3,9 @@ import {
   ComponentFactory,
   DriverFactory,
 } from 'wix-ui-test-utils/driver-factory';
-import { StylableDOMUtil } from '@stylable/dom-test-kit';
+import {StylableDOMUtil} from '@stylable/dom-test-kit';
 import style from './LinearProgressBar.st.css';
+import {ProgressBarDataHooks, ProgressBarDataKeys} from './DataHooks';
 
 export interface LinearProgressBarDriver extends BaseDriver {
   /** Get the width of the foreground bar (the progress) */
@@ -19,34 +20,47 @@ export interface LinearProgressBarDriver extends BaseDriver {
   getValue(): string;
   /** Get the progress numeric value */
   getNumericValue(): number;
-  /** Returms true if has progress completed (value is 100) */
+  /** Returns true if has progress completed (value is 100) */
   isCompleted(): boolean;
-  /** Returms true if has error */
+  /** Returns true if has error */
   hasError(): boolean;
+  /** Returns min value prop */
+  getMinValue(): number;
 }
 
 export const linearProgressBarDriverFactory: DriverFactory<
   LinearProgressBarDriver
-> = ({ element }: ComponentFactory) => {
+> = ({element}: ComponentFactory) => {
   const stylableDOMUtil = new StylableDOMUtil(style);
 
-  const getElement = dataHook => element.querySelector(`[data-hook="${dataHook}"]`)
-  const getValue = () => !element ? null : getElement('progress-percentages').querySelector('span').innerHTML;
-  const getNumericValue = () => !element ? null : +(getElement('progressbar-foreground').getAttribute('data-progress-value'))
-
+  const getElement = dataHook =>
+    element.querySelector(`[data-hook="${dataHook}"]`);
+  const getValue = () =>
+    !element
+      ? null
+      : getElement(ProgressBarDataHooks.progressPercentage).querySelector(
+          'span'
+        ).innerHTML;
+  const getNumericValue = () =>
+    !element ? null : +element.getAttribute(ProgressBarDataKeys.value);
+  const getMinValue = () =>
+    !element ? null : +element.getAttribute(ProgressBarDataKeys.min);
   const driver = {
     exists: () => !!element,
     getWidth: () => {
-      const el = getElement('progressbar-foreground') as HTMLElement;
+      const el = getElement(ProgressBarDataHooks.foreground) as HTMLElement;
       return el ? el.style.width : '0';
     },
-    isSuccessIconDisplayed: () => !!getElement('success-icon'),
-    isErrorIconDisplayed: () => !!getElement('error-icon'),
-    isPercentagesProgressDisplayed: () => !!getElement('progress-percentages'),
+    isSuccessIconDisplayed: () =>
+      !!getElement(ProgressBarDataHooks.successIcon),
+    isErrorIconDisplayed: () => !!getElement(ProgressBarDataHooks.errorIcon),
+    isPercentagesProgressDisplayed: () =>
+      !!getElement(ProgressBarDataHooks.progressPercentage),
     getValue: () => getValue(),
-    getNumericValue: () => getNumericValue(),
     isCompleted: () => getValue() === '100',
     hasError: () => stylableDOMUtil.hasStyleState(element, 'error'),
+    getNumericValue,
+    getMinValue,
   };
 
   return driver;

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.driver.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.driver.ts
@@ -44,7 +44,9 @@ export const linearProgressBarDriverFactory: DriverFactory<
   const getNumericValue = () =>
     !element ? null : +element.getAttribute(ProgressBarDataKeys.value);
   const getMinValue = () =>
-    !element ? null : +element.getAttribute(ProgressBarDataKeys.min);
+    !element || !element.getAttribute(ProgressBarDataKeys.min)
+      ? null
+      : +element.getAttribute(ProgressBarDataKeys.min);
   const driver = {
     exists: () => !!element,
     getWidth: () => {

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.spec.tsx
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.spec.tsx
@@ -138,6 +138,14 @@ describe('ProgressBar', () => {
         expect(await driver.getValue()).toBe('0%');
       });
 
+      it('should show percentages value of 0 when not passing a value and min is lesser than 0', async () => {
+        const min = -8;
+        driver = createDriver(
+          <LinearProgressBar {...{showProgressIndication: true, min}} />
+        );
+        expect(await driver.getValue()).toBe('0%');
+      });
+
       it('should show value in percentages rounded down', async () => {
         const floatValue = 3.9;
         const floatValueRoundDown = Math.floor(floatValue);
@@ -149,7 +157,7 @@ describe('ProgressBar', () => {
       });
     });
 
-    describe('`min` property', () => {
+    describe('`min` & `max` properties', () => {
       it('should allow setting `min` prop', async () => {
         const min = -5;
         const driver = createDriver(
@@ -158,9 +166,50 @@ describe('ProgressBar', () => {
         expect(await driver.getMinValue()).toBe(min);
       });
 
-      fit('should have default value of 0', async () => {
+      it('should have default `min` prop value of 0', async () => {
         const driver = createDriver(<LinearProgressBar {...defaultProps} />);
         expect(await driver.getMinValue()).toBe(0);
+      });
+
+      it('should visually set progress to minimum if given `value` < `min`', async () => {
+        const min = -5;
+        const value = -35;
+        const driver = createDriver(
+          <LinearProgressBar {...{...defaultProps, min, value}} />
+        );
+        expect(await driver.getWidth()).toBe(`0%`);
+      });
+
+      it('should allow setting `max` prop', async () => {
+        const max = 50;
+        const driver = createDriver(
+          <LinearProgressBar {...{...defaultProps, max}} />
+        );
+        expect(await driver.getMaxValue()).toBe(max);
+      });
+
+      it('should have default `max` prop value of 100', async () => {
+        const driver = createDriver(<LinearProgressBar {...defaultProps} />);
+        expect(await driver.getMaxValue()).toBe(100);
+      });
+
+      it('should visually set progress to max if given `value` > `max`', async () => {
+        const max = 50;
+        const value = 112;
+        const driver = createDriver(
+          <LinearProgressBar {...{...defaultProps, max, value}} />
+        );
+        expect(await driver.getWidth()).toBe(`100%`);
+      });
+
+      it('should visually set progress relative to `min` & `max`', async () => {
+        const max = 200;
+        const min = -200;
+        const value = 0;
+        const driver = createDriver(
+          <LinearProgressBar {...{...defaultProps, max, min, value}} />
+        );
+        expect(await driver.getWidth()).toBe(`50%`);
       });
     });
   }

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.spec.tsx
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.spec.tsx
@@ -150,12 +150,17 @@ describe('ProgressBar', () => {
     });
 
     describe('`min` property', () => {
-      it('should allow setting `min` props', async () => {
+      it('should allow setting `min` prop', async () => {
         const min = -5;
         const driver = createDriver(
           <LinearProgressBar {...{...defaultProps, min}} />
         );
         expect(await driver.getMinValue()).toBe(min);
+      });
+
+      fit('should have default value of 0', async () => {
+        const driver = createDriver(<LinearProgressBar {...defaultProps} />);
+        expect(await driver.getMinValue()).toBe(0);
       });
     });
   }

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.spec.tsx
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.spec.tsx
@@ -1,123 +1,164 @@
 import * as React from 'react';
-import { linearProgressBarDriverFactory } from './LinearProgressBar.driver';
-import { ReactDOMTestContainer } from '../../../test/dom-test-container';
-import { LinearProgressBar } from './';
-import { LinearProgressBarProps } from './LinearProgressBar';
-import { runTestkitExistsSuite } from '../../common/testkitTests';
-import { linearProgressBarTestkitFactory } from '../../testkit';
-import { linearProgressBarTestkitFactory as enzymeLinearProgressBarTestkitFactory } from '../../testkit/enzyme';
-import { linearProgressBarUniDriverFactory } from './LinearProgressBar.uni.driver';
+import {linearProgressBarDriverFactory} from './LinearProgressBar.driver';
+import {ReactDOMTestContainer} from '../../../test/dom-test-container';
+import {LinearProgressBar} from './';
+import {LinearProgressBarProps} from './LinearProgressBar';
+import {runTestkitExistsSuite} from '../../common/testkitTests';
+import {linearProgressBarTestkitFactory} from '../../testkit';
+import {linearProgressBarTestkitFactory as enzymeLinearProgressBarTestkitFactory} from '../../testkit/enzyme';
+import {linearProgressBarUniDriverFactory} from './LinearProgressBar.uni.driver';
 
 describe('ProgressBar', () => {
-
   const testContainer = new ReactDOMTestContainer().unmountAfterEachTest();
 
   const defaultProps = {
     value: 40,
   };
 
-  describe("[sync]", () => {
-    runTests(testContainer.createLegacyRenderer(linearProgressBarDriverFactory));
+  describe('[sync]', () => {
+    runTests(
+      testContainer.createLegacyRenderer(linearProgressBarDriverFactory)
+    );
   });
 
-  describe("[async]", () => {
-    runTests(testContainer.createUniRenderer(linearProgressBarUniDriverFactory));
+  describe('[async]', () => {
+    runTests(
+      testContainer.createUniRenderer(linearProgressBarUniDriverFactory)
+    );
   });
 
   function runTests(createDriver) {
     it('should exist', async () => {
       const driver = createDriver(<LinearProgressBar {...defaultProps} />);
       expect(await driver.exists()).toBe(true);
-    })
+    });
 
-    it(`should set the foreground progress bar layer to ${defaultProps.value}%`, async () => {
+    it(`should set the foreground progress bar layer to ${
+      defaultProps.value
+    }%`, async () => {
       const driver = createDriver(<LinearProgressBar {...defaultProps} />);
       expect(await driver.getWidth()).toBe(`${defaultProps.value}%`);
-    })
+    });
 
     it('should not show success icon when reaching 100%', async () => {
-      const driver = createDriver(<LinearProgressBar {...{ ...defaultProps, value: 100 }} />);
+      const driver = createDriver(
+        <LinearProgressBar {...{...defaultProps, value: 100}} />
+      );
       expect(await driver.isSuccessIconDisplayed()).toBe(false);
-    })
+    });
 
     it('should not show percentages value while in progress', async () => {
-      const driver = createDriver(<LinearProgressBar {...{ ...defaultProps, value: 50 }} />);
+      const driver = createDriver(
+        <LinearProgressBar {...{...defaultProps, value: 50}} />
+      );
       expect(await driver.isPercentagesProgressDisplayed()).toBe(false);
-    })
+    });
 
     it('should not show error icon while in progress', async () => {
-      const driver = createDriver(<LinearProgressBar {...{ ...defaultProps, error: true }} />);
+      const driver = createDriver(
+        <LinearProgressBar {...{...defaultProps, error: true}} />
+      );
       expect(await driver.isErrorIconDisplayed()).toBe(false);
-    })
+    });
 
     describe('testkit methods', () => {
       it('should allow getting numeric value from component', async () => {
-        const value = 50
-        const driver = createDriver(<LinearProgressBar {...{ ...defaultProps, value }} />);
+        const value = 50;
+        const driver = createDriver(
+          <LinearProgressBar {...{...defaultProps, value}} />
+        );
         expect(await driver.getNumericValue()).toBe(value);
-      })
-    })
+      });
+    });
 
     describe('when with progress indication', () => {
       let driver;
       let props: LinearProgressBarProps = defaultProps;
 
       beforeEach(() => {
-        props = { ...defaultProps, showProgressIndication: true };
+        props = {...defaultProps, showProgressIndication: true};
       });
 
       it('should show success icon when reaching 100%', async () => {
-        driver = createDriver(<LinearProgressBar {...{ ...props, value: 100, successIcon: <div /> }} />);
+        driver = createDriver(
+          <LinearProgressBar
+            {...{...props, value: 100, successIcon: <div />}}
+          />
+        );
         expect(await driver.isSuccessIconDisplayed()).toBe(true);
-      })
+      });
 
       it('should show success icon when reaching 100% and value passed as string', async () => {
-        driver = createDriver(<LinearProgressBar {...{ ...props, value: '100' as any, successIcon: <div /> }} />);
+        driver = createDriver(
+          <LinearProgressBar
+            {...{...props, value: '100' as any, successIcon: <div />}}
+          />
+        );
         expect(await driver.isSuccessIconDisplayed()).toBe(true);
-      })
+      });
 
       it('should show percentages value when reaching 100% and success icon not provided', async () => {
-        driver = createDriver(<LinearProgressBar {...{ ...props, value: 100 }} />);
+        driver = createDriver(
+          <LinearProgressBar {...{...props, value: 100}} />
+        );
         expect(await driver.getValue()).toBe('100%');
-      })
+      });
 
       it('should show error icon on failure', async () => {
-        driver = createDriver(<LinearProgressBar {...{ ...props, error: true, errorIcon: <div /> }} />);
+        driver = createDriver(
+          <LinearProgressBar {...{...props, error: true, errorIcon: <div />}} />
+        );
         expect(await driver.isErrorIconDisplayed()).toBe(true);
-      })
+      });
 
       it('should show percentages value when error icon not provided', async () => {
-        driver = createDriver(<LinearProgressBar {...{ ...props, value: 33, error: true, errorIcon: null }} />);
+        driver = createDriver(
+          <LinearProgressBar
+            {...{...props, value: 33, error: true, errorIcon: null}}
+          />
+        );
         expect(await driver.isErrorIconDisplayed()).toBe(false);
         expect(await driver.getValue()).toBe('33%');
-      })
+      });
 
       it('should show percentages value while in progress', async () => {
-        driver = createDriver(<LinearProgressBar {...{ ...props, value: 50 }} />);
+        driver = createDriver(<LinearProgressBar {...{...props, value: 50}} />);
         expect(await driver.getValue()).toBe('50%');
-      })
+      });
 
       it('should show percentages value of 0 when passing value lesser than 0', async () => {
-        driver = createDriver(<LinearProgressBar {...{ ...props, value: -1 }} />);
+        driver = createDriver(<LinearProgressBar {...{...props, value: -1}} />);
         expect(await driver.getValue()).toBe('0%');
-      })
+      });
 
       it('should show percentages value of 0 when not passing a value', async () => {
-        driver = createDriver(<LinearProgressBar {...{ showProgressIndication: true}} />);
+        driver = createDriver(
+          <LinearProgressBar {...{showProgressIndication: true}} />
+        );
         expect(await driver.getValue()).toBe('0%');
-      })
+      });
 
       it('should show value in percentages rounded down', async () => {
         const floatValue = 3.9;
         const floatValueRoundDown = Math.floor(floatValue);
 
-        driver = createDriver(<LinearProgressBar {...{ ...props, value: floatValue }} />);
+        driver = createDriver(
+          <LinearProgressBar {...{...props, value: floatValue}} />
+        );
         expect(await driver.getValue()).toBe(`${floatValueRoundDown}%`);
-      })
+      });
+    });
+
+    describe('`min` property', () => {
+      it('should allow setting `min` props', async () => {
+        const min = -5;
+        const driver = createDriver(
+          <LinearProgressBar {...{...defaultProps, min}} />
+        );
+        expect(await driver.getMinValue()).toBe(min);
+      });
     });
   }
-
-
 
   runTestkitExistsSuite({
     Element: <LinearProgressBar value={0} />,

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.tsx
@@ -3,7 +3,7 @@ import style from './LinearProgressBar.st.css';
 import {ProgressBarDataHooks, ProgressBarDataKeys} from './DataHooks';
 
 export interface LinearProgressBarProps {
-  /** represent the progress state in percentages (0 - no progress, 100 - progress completed) */
+  /** represent the progress state in percentages (min || 0 - no progress, max || 100 - progress completed) */
   value?: number | string;
   /** should be true if had failure during the progress */
   error?: boolean;
@@ -11,10 +11,12 @@ export interface LinearProgressBarProps {
   showProgressIndication?: boolean;
   /** an indication icon (any react component) that will be presented when 'error' and 'showProgressIndication' are set to true */
   errorIcon?: JSX.Element;
-  /** an indication icon (any react component) that will be presented when 'showProgressIndication' are set to true and 'value' is 100 */
+  /** an indication icon (any react component) that will be presented when 'showProgressIndication' are set to true and 'value' is equal or bigger than 'max' */
   successIcon?: JSX.Element;
   /** minimum value for progress bar, default value: 0 */
   min?: number;
+  /** maximum value for progress bar, default value: 100 */
+  max?: number;
 }
 
 const FULL_PROGRESS = 100;
@@ -61,24 +63,34 @@ const renderBarSection = (value: number | string) => {
   );
 };
 
-const normalizeProps = (props: LinearProgressBarProps) => {
-  const value = parseInt(props.value as any, 10);
+const getRelativeValue = (props: LinearProgressBarProps): number => {
+  const {value, min, max} = props;
+  const relativeValue = ((+value - min) / (max - min)) * 100;
+  return parseInt(relativeValue as any, 10);
+};
 
-  if (props.value >= FULL_PROGRESS) {
+const normalizeProps = (props: LinearProgressBarProps) => {
+  if (props.value >= props.max) {
     return {...props, value: FULL_PROGRESS};
   }
 
-  if (props.value < 0) {
+  if (
+    props.value < props.min ||
+    [undefined, null, ''].includes(props.value as string)
+  ) {
     return {...props, value: NO_PROGRESS};
   }
 
-  return {...props, value};
+  return {...props, value: getRelativeValue(props)};
 };
 
-const getDataAttributes = (props: LinearProgressBarProps) => {
+const getDataAttributes = (
+  props: LinearProgressBarProps
+): {[key in ProgressBarDataKeys]: number | string} => {
   return {
     [ProgressBarDataKeys.value]: props.value,
     [ProgressBarDataKeys.min]: props.min,
+    [ProgressBarDataKeys.max]: props.max,
   };
 };
 
@@ -111,6 +123,6 @@ export const LinearProgressBar: React.FunctionComponent<
 LinearProgressBar.displayName = 'LinearProgressBar';
 
 LinearProgressBar.defaultProps = {
-  value: 0,
-  min: 0,
+  min: NO_PROGRESS,
+  max: FULL_PROGRESS,
 };

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.tsx
@@ -112,4 +112,5 @@ LinearProgressBar.displayName = 'LinearProgressBar';
 
 LinearProgressBar.defaultProps = {
   value: 0,
+  min: 0,
 };

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import style from './LinearProgressBar.st.css';
+import {ProgressBarDataHooks, ProgressBarDataKeys} from './DataHooks';
 
 export interface LinearProgressBarProps {
   /** represent the progress state in percentages (0 - no progress, 100 - progress completed) */
@@ -12,6 +13,8 @@ export interface LinearProgressBarProps {
   errorIcon?: JSX.Element;
   /** an indication icon (any react component) that will be presented when 'showProgressIndication' are set to true and 'value' is 100 */
   successIcon?: JSX.Element;
+  /** minimum value for progress bar, default value: 0 */
+  min?: number;
 }
 
 const FULL_PROGRESS = 100;
@@ -25,24 +28,32 @@ const resolveIndicationElement = (props: LinearProgressBarProps) => {
   );
 
   if (props.error && props.errorIcon) {
-    return wrapped('error-icon', props.errorIcon);
+    return wrapped(ProgressBarDataHooks.errorIcon, props.errorIcon);
   }
 
   if (props.value === FULL_PROGRESS && props.successIcon) {
-    return wrapped('success-icon', props.successIcon);
+    return wrapped(ProgressBarDataHooks.successIcon, props.successIcon);
   }
 
-  return wrapped('progress-percentages', <span>{`${props.value}%`}</span>);
+  return wrapped(
+    ProgressBarDataHooks.progressPercentage,
+    <span>{`${props.value}%`}</span>
+  );
 };
 
 const renderBarSection = (value: number | string) => {
   const progressWidth = {width: `${value}%`};
   return (
-    <div className={style.barContainer}>
-      <div data-hook="progressbar-background" className={style.barBackground} />
+    <div
+      data-hook={ProgressBarDataHooks.container}
+      className={style.barContainer}
+    >
       <div
-        data-hook="progressbar-foreground"
-        data-progress-value={value}
+        data-hook={ProgressBarDataHooks.background}
+        className={style.barBackground}
+      />
+      <div
+        data-hook={ProgressBarDataHooks.foreground}
         style={progressWidth}
         className={style.barForeground}
       />
@@ -64,20 +75,30 @@ const normalizeProps = (props: LinearProgressBarProps) => {
   return {...props, value};
 };
 
+const getDataAttributes = (props: LinearProgressBarProps) => {
+  return {
+    [ProgressBarDataKeys.value]: props.value,
+    [ProgressBarDataKeys.min]: props.min,
+  };
+};
+
 export const LinearProgressBar: React.FunctionComponent<
   LinearProgressBarProps
 > = (props: LinearProgressBarProps) => {
   const {error, showProgressIndication} = props;
   const _props = normalizeProps(props);
   const success = _props.value === FULL_PROGRESS;
-
   return (
-    <div {...style('root', {error, success}, _props)}>
+    <div
+      {...getDataAttributes(_props)}
+      data-min={_props.min}
+      {...style('root', {error, success}, _props)}
+    >
       {renderBarSection(_props.value)}
 
       {showProgressIndication && (
         <div
-          data-hook="progress-indicator"
+          data-hook={ProgressBarDataHooks.progressIndicator}
           className={style.progressIndicationSection}
         >
           {resolveIndicationElement(_props)}

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.uni.driver.ts
@@ -55,8 +55,10 @@ export const linearProgressBarUniDriverFactory = (
     if (!(await base.exists())) {
       return null;
     }
-    return +(await base.attr(ProgressBarDataKeys.min));
+    const minValue = await base.attr(ProgressBarDataKeys.min);
+    return !!minValue ? +minValue : null;
   };
+
   return {
     ...baseUniDriverFactory(base),
     getWidth: async () => {

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.uni.driver.ts
@@ -2,9 +2,10 @@ import {
   BaseUniDriver,
   baseUniDriverFactory,
 } from 'wix-ui-test-utils/base-driver';
-import { UniDriver, StylableUnidriverUtil } from 'wix-ui-test-utils/unidriver';
+import {UniDriver, StylableUnidriverUtil} from 'wix-ui-test-utils/unidriver';
 import styles from './LinearProgressBar.st.css';
-import { ReactBase } from '../../../test/utils/unidriver/ReactBase';
+import {ReactBase} from '../../../test/utils/unidriver/ReactBase';
+import {ProgressBarDataHooks, ProgressBarDataKeys} from './DataHooks';
 
 export interface LinearProgressBarUniDriver extends BaseUniDriver {
   /** Get the width of the foreground bar (the progress) */
@@ -19,14 +20,16 @@ export interface LinearProgressBarUniDriver extends BaseUniDriver {
   getValue(): Promise<string>;
   /** Get the progress numeric value */
   getNumericValue(): Promise<number>;
-  /** Returms true if has progress completed (value is 100) */
+  /** Returns true if has progress completed (value is 100) */
   isCompleted(): Promise<boolean>;
-  /** Returms true if has error */
+  /** Returns true if has error */
   hasError(): Promise<boolean>;
+  /** Returns min value prop */
+  getMinValue(): Promise<number>;
 }
 
 export const linearProgressBarUniDriverFactory = (
-  base: UniDriver,
+  base: UniDriver
 ): LinearProgressBarUniDriver => {
   const byDataHook = dataHook => `[data-hook="${dataHook}"]`;
   const stylableUnidriverUtil = new StylableUnidriverUtil(styles);
@@ -36,7 +39,7 @@ export const linearProgressBarUniDriverFactory = (
       return null;
     }
     return base
-      .$(byDataHook('progress-percentages'))
+      .$(byDataHook(ProgressBarDataHooks.progressPercentage))
       .$('span')
       .text();
   };
@@ -45,25 +48,32 @@ export const linearProgressBarUniDriverFactory = (
     if (!(await base.exists())) {
       return null;
     }
-    const value = await base
-      .$(byDataHook('progressbar-foreground'))
-      .attr('data-progress-value');
-    return +value;
+    return +(await base.attr(ProgressBarDataKeys.value));
+  };
+
+  const getMinValue = async () => {
+    if (!(await base.exists())) {
+      return null;
+    }
+    return +(await base.attr(ProgressBarDataKeys.min));
   };
   return {
     ...baseUniDriverFactory(base),
     getWidth: async () => {
-      const bar = base.$(byDataHook('progressbar-foreground'));
+      const bar = base.$(byDataHook(ProgressBarDataHooks.foreground));
       const reactBase = ReactBase(bar);
       return (await reactBase.getStyle()).width;
     },
-    isSuccessIconDisplayed: () => base.$(byDataHook('success-icon')).exists(),
-    isErrorIconDisplayed: () => base.$(byDataHook('error-icon')).exists(),
+    isSuccessIconDisplayed: () =>
+      base.$(byDataHook(ProgressBarDataHooks.successIcon)).exists(),
+    isErrorIconDisplayed: () =>
+      base.$(byDataHook(ProgressBarDataHooks.errorIcon)).exists(),
     isPercentagesProgressDisplayed: () =>
-      base.$(byDataHook('progress-percentages')).exists(),
+      base.$(byDataHook(ProgressBarDataHooks.progressPercentage)).exists(),
     getValue: () => getValue(),
     getNumericValue: async () => getNumericValue(),
     isCompleted: async () => (await getValue()) === '100',
     hasError: () => stylableUnidriverUtil.hasStyleState(base, 'error'),
+    getMinValue,
   };
 };


### PR DESCRIPTION
closes #1295 

- Add `min` prop (default 0)
- Add `max` prop (default 100)
- `value` defaults to `min`
- Percentage is relative to `min` & `max`

Add correct tests.
Add correct methods for both testKits (Uni/React)

*Use less "magic strings" using enums.
