### PR TITLE
<WithEllipsedTooltip/> - fix stylable classes clashes problem

### DIFF
--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -6,7 +6,6 @@ import { getDisplayName } from '../utils';
 import { Loadable } from '../../components/loadable';
 import { TooltipProps } from '../../components/tooltip';
 const debounce = require('lodash/debounce');
-import classnames from 'classnames';
 
 class LoadableTooltip extends Loadable<{
   Tooltip: React.ComponentType<TooltipProps>;

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -129,7 +129,7 @@ class EllipsedTooltip extends React.Component<
           return (
             <Tooltip
               {...tooltipProps}
-              {...tooltipStyle('root', {}, tooltipProps)}
+              {...tooltipStyle('root', {}, tooltipProps || this.props)}
               appendTo="scrollParent"
               content={<div>{this.textNode.textContent}</div>}
               showArrow

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -6,6 +6,7 @@ import { getDisplayName } from '../utils';
 import { Loadable } from '../../components/loadable';
 import { TooltipProps } from '../../components/tooltip';
 const debounce = require('lodash/debounce');
+import classnames from 'classnames';
 
 class LoadableTooltip extends Loadable<{
   Tooltip: React.ComponentType<TooltipProps>;
@@ -17,7 +18,8 @@ interface EllipsedTooltipProps {
   showTooltip?: boolean;
   shouldLoadAsync?: boolean;
   style?: object;
-};
+  tooltipProps?: object;
+}
 
 interface EllipsedTooltipState {
   isEllipsisActive: boolean;
@@ -102,7 +104,7 @@ class EllipsedTooltip extends React.Component<
   }
 
   render() {
-    const { shouldLoadAsync, showTooltip } = this.props;
+    const { shouldLoadAsync, showTooltip, tooltipProps } = this.props;
     const { isEllipsisActive } = this.state;
     const shouldLoadTooltip = isEllipsisActive && showTooltip;
 
@@ -127,7 +129,8 @@ class EllipsedTooltip extends React.Component<
         {({ Tooltip, tooltipStyle }) => {
           return (
             <Tooltip
-              {...tooltipStyle('root', {}, this.props)}
+              {...tooltipProps}
+              {...tooltipStyle('root', {}, tooltipProps)}
               appendTo="scrollParent"
               content={<div>{this.textNode.textContent}</div>}
               showArrow
@@ -144,7 +147,12 @@ class EllipsedTooltip extends React.Component<
 export const withEllipsedTooltip = ({
   showTooltip,
   shouldLoadAsync,
-}: { showTooltip?: boolean; shouldLoadAsync?: boolean } = {}) => Comp => {
+  tooltipProps,
+}: {
+  showTooltip?: boolean;
+  shouldLoadAsync?: boolean;
+  tooltipProps?: object;
+} = {}) => Comp => {
   const WrapperComponent: React.SFC<WrapperComponentProps> = props => (
     <EllipsedTooltip
       {...props}
@@ -152,6 +160,7 @@ export const withEllipsedTooltip = ({
       shouldLoadAsync={shouldLoadAsync}
       showTooltip={showTooltip}
       data-hook="ellipsed-tooltip-wrapper"
+      tooltipProps={tooltipProps}
     />
   );
 


### PR DESCRIPTION
This PR will divide passed props for Tooltip and Text component so that it would not clash with the consumer passed classnames.