### PR TITLE
wix-ui-framework: `wuf update` support --ignore flag

### DIFF
--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
@@ -126,8 +126,6 @@ export const exportTestkits: (a: Options) => Promise<void> = async opts => {
     testkitImportsSource,
   ].join('\n');
 
-  console.log(options.template);
-
   try {
     fs.writeFileSync(options.output, source);
   } catch (e) {

--- a/packages/wix-ui-framework/src/cli-commands/update-components-list/index.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/update-components-list/index.spec.ts
@@ -95,6 +95,70 @@ describe('updateComponentsList', () => {
       expect(JSON.parse(output)).toEqual(expectedOutput);
     });
 
+    it('should skip items in --ignore and not write them to .wuf/components.json', async () => {
+      const fakeFs = cista({
+        '.wuf/required-component-files.json': `{ "index.js": "" }`,
+        'src/components/test-component/index.js': '',
+        'src/components/skipped-component/index.js': '',
+        'src/components/skipped-component2/index.js': '',
+        '.wuf/components.json': '',
+      });
+
+      const expectedOutput = {
+        'test-component': {
+          path: 'src/components/test-component',
+        },
+      };
+
+      await updateComponentsList({
+        maxMismatch: 0,
+        ignore: '(skipped-component|skipped-component2)',
+        _process: { cwd: fakeFs.dir },
+      });
+
+      const output = fs.readFileSync(
+        `${fakeFs.dir}/.wuf/components.json`,
+        'utf8',
+      );
+
+      expect(JSON.parse(output)).toEqual(expectedOutput);
+    });
+
+    // TODO: intentionally skipped, feature not implemented
+    it.skip('should support regex in file names', async () => {
+      const fakeFs = cista({
+        '.wuf/required-component-files.json': `{
+          "index.js": "",
+          "test": { ".*\.driver\.(uni\.)?(js|ts)": "" }
+        }`,
+        'src/components/test-component/index.js': '',
+        'src/components/test-component/test/thing.driver.js': '',
+        'src/components/test-component/test/thing.driver.ts': '',
+        'src/components/test-component/test/thing.driver.uni.js': '',
+        'src/components/test-component/test/non-matched': '',
+        '.wuf/components.json': '',
+      });
+
+      const expectedOutput = {
+        'test-component': {
+          path: 'src/components/test-component',
+          missingFiles: ['src/components/test-components/test/non-matched'],
+        },
+      };
+
+      await updateComponentsList({
+        maxMismatch: 1,
+        _process: { cwd: fakeFs.dir },
+      });
+
+      const output = fs.readFileSync(
+        `${fakeFs.dir}/.wuf/components.json`,
+        'utf8',
+      );
+
+      expect(JSON.parse(output)).toEqual(expectedOutput);
+    });
+
     it('should not add `missingFiles` if there are none', async () => {
       const fakeFs = cista({
         '.wuf/required-component-files.json': `{ "index.js": "", "docs": {"index.story.js": "" } }`,

--- a/packages/wix-ui-framework/src/cli-commands/update-components-list/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/update-components-list/index.ts
@@ -18,6 +18,7 @@ interface Options {
   components?: Path;
   output?: Path;
   maxMismatch?: number;
+  ignore?: string;
   _process: Process;
 }
 
@@ -31,6 +32,7 @@ export const updateComponentsList: (
     components: pathResolve(opts.components || 'src/components'),
     output: pathResolve(opts.output || '.wuf/components.json'),
     maxMismatch: opts.maxMismatch || 0,
+    ignore: opts.ignore,
   };
 
   if (!(await fileExists(options.shape))) {
@@ -53,6 +55,9 @@ export const updateComponentsList: (
   });
 
   const analyzedComponents = Object.keys(componentsFs)
+    .filter(componentName =>
+      opts.ignore ? !new RegExp(opts.ignore).test(componentName) : true,
+    )
     .map(name => ({
       name,
       structure: componentsFs[name],

--- a/packages/wix-ui-framework/src/index.ts
+++ b/packages/wix-ui-framework/src/index.ts
@@ -67,7 +67,10 @@ program
     '--output <string>',
     'Path to output file. Default is `.wuf/components.json`',
   )
-
+  .option(
+    '--ignore <string>',
+    'Regular expression of known paths to ignore. For example --ignore (Button|Table). Default is undefined',
+  )
   .option(
     '--max-mismatch <number>',
     'Optional number of maximum mismatches between shape defined in required-component-files.json and component. Default is 0',

--- a/packages/wix-ui-framework/test/__snapshots__/cli.spec.ts.snap
+++ b/packages/wix-ui-framework/test/__snapshots__/cli.spec.ts.snap
@@ -61,6 +61,7 @@ Options:
   --shape <string>         Path to json file describing folder structure of required files. Default is \`.wuf/required-component-files.json\`
   --components <string>    Path to folder where components reside. Default is \`src/components\`
   --output <string>        Path to output file. Default is \`.wuf/components.json\`
+  --ignore <string>        Regular expression of known paths to ignore. For example --ignore (Button|Table). Default is undefined
   --max-mismatch <number>  Optional number of maximum mismatches between shape defined in required-component-files.json and component. Default is 0
   -h, --help               output usage information"
 `;


### PR DESCRIPTION
1. user defines component shape
2. user runs `wuf update` to generate `components.json`
3. user finds out that some folders adhere to the shape, but are not actually components
4. user uses `--ignore NonComponent` to skip it from being added to `components.json`