### PR TITLE
`withEllipsedTooltip` - let the user decide on where to append the tooltip

### DIFF
--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -128,9 +128,9 @@ class EllipsedTooltip extends React.Component<
         {({ Tooltip, tooltipStyle }) => {
           return (
             <Tooltip
+              appendTo="scrollParent"
               {...tooltipProps}
               {...tooltipStyle('root', {}, tooltipProps || this.props)}
-              appendTo="scrollParent"
               content={<div>{this.textNode.textContent}</div>}
               showArrow
             >


### PR DESCRIPTION
This PR will let users overwrite default value of appendTo.