### PR TITLE
wix-ui-core - Adding a dependency on stylable cli

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -81,6 +81,7 @@
   },
   "devDependencies": {
     "@storybook/react": "^5.0.0",
+    "@stylable/cli": "1.2.10",
     "@types/classnames": "^2.2.3",
     "@types/enzyme": "^3.1.9",
     "@types/jest": "^22.1.1",

--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -37,7 +37,6 @@
     "@storybook/addon-options": "^3.3.15",
     "@storybook/react": "^3.3.15",
     "terser": "3.14.0",
-    "@stylable/cli": "1.2.10",
     "@types/jest": "^22.2.3",
     "@types/node": "^8.9.1",
     "@types/react": "~16.4.2",

--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -37,6 +37,7 @@
     "@storybook/addon-options": "^3.3.15",
     "@storybook/react": "^3.3.15",
     "terser": "3.14.0",
+    "@stylable/cli": "1.2.10",
     "@types/jest": "^22.2.3",
     "@types/node": "^8.9.1",
     "@types/react": "~16.4.2",


### PR DESCRIPTION
Today `wix-ui-core` & `wix-ui-icons-common` are using stylable cli (`stc`) in their build scripts. They don't have a `devDependency` on them and it's working because it is in [yoshi's dependencies](https://github.com/wix/yoshi/blob/f0ff9ed3c7ceca20f7003ffe63c4e81acabe1a72/packages/yoshi/package.json#L26)

We plan on removing this dependency from Yoshi, because it is not needed in our codebase, and the only usage of it is here.