### PR TITLE
Allow using default namedExports.

### DIFF
--- a/packages/wix-ui-core/src/components/loadable/Loadable.tsx
+++ b/packages/wix-ui-core/src/components/loadable/Loadable.tsx
@@ -94,7 +94,7 @@ export class Loadable<LoadableExports> extends React.Component<
    async flow. We should determine type of flow and according to it sync or async set the state.
   */
   private loadSyncOrAsync = (): LoadedMap<LoadableExports> => {
-    const { loader, namedExports } = this.props;
+    const { loader, namedExports = {} } = this.props;
 
     const resolvedModules: {
       [Key in keyof LoadableExports]?: LoadableExports[Key]


### PR DESCRIPTION
This is a small enhancement for Loadable, that allows to not specify `namedExports` field every time. It should be useful when we have single lazy loaded component with `default` export.

And we can bypass `namedExports`:

*Loadable.js*
```diff
<Loadable
   loader={{
     Tooltip: () => import('../A')
   }}
- namedExports={{
-   Tooltip: 'default',
- }}
  >
  /*...*/
</Loadable>
```

*A.js*
```js
export default A;
```