### PR TITLE
wix-storybook-utils: fix(Autodocs): hide lifecycle methods from methods table

### DIFF
--- a/packages/wix-storybook-utils/src/AutoDocs/index.test.tsx
+++ b/packages/wix-storybook-utils/src/AutoDocs/index.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 
 import AutoDocs from './';
+import { hiddenMethods } from './methods-table';
 
 const testkit = () => {
   let component;
@@ -20,7 +21,7 @@ const testkit = () => {
       propsTables: () => byHook('autodocs-props-table'),
       propRows: () => byHook('autodocs-prop-row-name'),
       methodsTable: () => byHook('autodocs-methods-table'),
-      methodsTableTitle: () => byHook('autodocs-methods-table-title'),
+      methodsTableRows: () => byHook('autodocs-methods-table-row'),
     },
   };
 };
@@ -60,6 +61,30 @@ describe('AutoDocs', () => {
       });
 
       expect(driver.get.propsTables().length).toEqual(2);
+    });
+  });
+
+  describe('methods table', () => {
+    it('should not render lifecycle methods', () => {
+      const driver = testkit();
+      const methods = [
+        ...hiddenMethods,
+        '_privateMethod',
+        'publicCoolMethod',
+        'publicAwesomeMethod',
+      ].map(name => ({ name, params: [], description: '' }));
+
+      driver.when.created({
+        metadata: {
+          props: {},
+          methods,
+        },
+      });
+
+      const rows = driver.get.methodsTableRows();
+      expect(rows.length).toEqual(2);
+      expect(rows.at(0).text()).toEqual('publicCoolMethod');
+      expect(rows.at(1).text()).toEqual('publicAwesomeMethod');
     });
   });
 });

--- a/packages/wix-storybook-utils/src/AutoDocs/methods-table.tsx
+++ b/packages/wix-storybook-utils/src/AutoDocs/methods-table.tsx
@@ -1,5 +1,23 @@
 import React from 'react';
 
+export const hiddenMethods = [
+  'UNSAFE_componentWillMount',
+  'UNSAFE_componentWillReceiveProps',
+  'UNSAFE_componentWillUpdate',
+  'componentDidCatch',
+  'componentDidMount',
+  'componentDidUpdate',
+  'componentWillUnmount',
+  'constructor',
+  'forceUpdate',
+  'getDerivedStateFromError',
+  'getDerivedStateFromProps',
+  'getSnapshotBeforeUpdate',
+  'render',
+  'setState',
+  'shouldComponentUpdate',
+];
+
 export const MethodsTable = ({ methods = [] }) => (
   <table data-hook="autodocs-methods-table">
     <thead>
@@ -11,13 +29,15 @@ export const MethodsTable = ({ methods = [] }) => (
     </thead>
 
     <tbody>
-      {methods.map(({ name = '', params = [], description = '' }) => (
-        <tr key={name}>
-          <td>{name}</td>
-          <td>{params.map(({ name: paramName }) => paramName).join(', ')}</td>
-          <td>{description}</td>
-        </tr>
-      ))}
+      {methods
+        .filter(({ name }) => !hiddenMethods.includes(name))
+        .map(({ name = '', params = [], description = '' }) => (
+          <tr data-hook="autodocs-methods-table-row" key={name}>
+            <td>{name}</td>
+            <td>{params.map(({ name: paramName }) => paramName).join(', ')}</td>
+            <td>{description}</td>
+          </tr>
+        ))}
     </tbody>
   </table>
 );


### PR DESCRIPTION
prevent things like `getDerivedStateFromProps` visible in autodocs API tables