### PR TITLE
wix-ui-framework: support globs in `wuf update`

### DIFF
--- a/packages/wix-ui-framework/package.json
+++ b/packages/wix-ui-framework/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "commander": "^2.20.0",
-    "deep-diff": "^1.0.2",
     "jscodeshift": "^0.6.4",
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
`wuf update` command:

1. by default looks at `.wuf/required-component-files.json`
1. traverses file system
1. matches folders that look similar to `.wuf/required-component-files.json`

previously it was matching strictly

this PR introduces support for globs in that json, so that this is possible:

```
{
  "index.ts*": "",
  "Component.ts*": "",
  "docs": {
    "index.story.ts*": ""
  }
}
```

this way both `index.ts` and `index.tsx` files are considered as
matched. Also, it can be something more complex, like `index.[tj]s*` or
even `specs/*?(.uni).driver.[tj]s*`.