### PR TITLE
wix-ui-framework: release(3.0.0)

### DIFF
--- a/packages/wix-ui-framework/CHANGELOG.md
+++ b/packages/wix-ui-framework/CHANGELOG.md
@@ -11,6 +11,10 @@ Types of changes:
 1. **Fixed** for any bug fixes.
 1. **Security** in case of vulnerabilities.
 
+# 3.0.0 - 2019-06-28
+## Changed
+- `wuf export-testkits` - support ejs template in `--template` file. Potentially breaking change
+
 # 2.5.0 - 2019-06-25
 ## Added
 - `wuf update` - support glob patterns in `--shape` file

--- a/packages/wix-ui-framework/package.json
+++ b/packages/wix-ui-framework/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "wuf": "./bin/wuf.js"
   },
-  "version": "2.5.0",
+  "version": "3.0.0",
   "author": {
     "name": "Wix",
     "email": "fed-infra@wix.com"


### PR DESCRIPTION
`wuf export-testkits` - support ejs template in `--template` file. Potentially breaking change