### PR TITLE
wix-ui-framework: export-testkits: merge definitions and components files

### DIFF
--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.spec.ts
@@ -69,6 +69,37 @@ describe('exportTestkits', () => {
         ].join('\n'),
       );
     });
+
+    it('should include all definitions file entries in components array', async () => {
+      const fakeFs = cista({
+        '.wuf/testkits/definitions.json':
+          '{ "NotInComponents": { "specialName": "CubicsRube" } }',
+        '.wuf/testkits/template.ejs':
+          '<%= components.map(c => c.specialName || c.name).join("\\n") %>',
+        '.wuf/components.json': '{ "Thingy": {}, "Thongy": {} }',
+        output: ';',
+      });
+
+      await exportTestkits({
+        definitions: '.wuf/testkits/definitions.json',
+        output: 'output',
+        _process: { cwd: fakeFs.dir },
+      });
+
+      const output = fs.readFileSync(
+        path.resolve(fakeFs.dir, 'output'),
+        'utf8',
+      );
+
+      expect(output).toEqual(
+        [
+          warningBanner(`.wuf/testkits/template.ejs`),
+          'Thingy',
+          'Thongy',
+          'CubicsRube',
+        ].join('\n'),
+      );
+    });
   });
 
   describe('when definitions option missing', () => {

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
@@ -83,11 +83,13 @@ const ejsSource = ({ source, definitions, components }) => {
     toCamel: camelCase,
   };
 
-  const componentsForEjs = objectEntries(components).map(([name, value]) => ({
-    name,
-    ...value,
-    ...(definitions[name] || {}),
-  }));
+  const componentsForEjs = objectEntries({ ...components, ...definitions }).map(
+    ([name, value]) => ({
+      name,
+      ...value,
+      ...(definitions[name] || {}),
+    }),
+  );
 
   try {
     return ejs.render(source, {


### PR DESCRIPTION
this PR allows to support cases when definition file has entries which
aren't found in components.json

it's useful when `wuf update` writes `components.json` file properly,
but library has components that do not conform to convention but still
have exported testkits for non conventional components. Also known as snowflake components :)