### PR TITLE
wix-ui-core: upgrade wix-storybook-utils@3.0.7

### DIFF
--- a/packages/wix-ui-core/.storybook/webpack.config.js
+++ b/packages/wix-ui-core/.storybook/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = ({config}) => {
           'https://github.com/wix/wix-ui/tree/master/packages/wix-ui-core/src/components/',
         importFormat:
           "import {%componentName} from '%moduleName/%componentName'",
+        issueURL: "https://github.com/wix/wix-ui/issues/new"
       },
     },
   });

--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -114,7 +114,7 @@
     "typescript": "~3.0.3",
     "wait-for-cond": "^1.5.1",
     "webpack-dev-middleware": "3.6.0",
-    "wix-storybook-utils": "^2.0.45",
+    "wix-storybook-utils": "^3.0.7",
     "wix-ui-icons-common": "^2.0.0",
     "wix-ui-mocha-runner": "^0.1.6",
     "yoshi": "^3.28.0",


### PR DESCRIPTION
this PR upgrades wix-storybook-utils version to 3.0.0

the visual of storybook is going to change and be more similar to what wix-style-react & wix-ui-tpa have

miraculously no code changes are required!