### PR TITLE
Correct import path

### DIFF
--- a/packages/wix-storybook-utils/stories/sections/code-examples.story.js
+++ b/packages/wix-storybook-utils/stories/sections/code-examples.story.js
@@ -1,4 +1,4 @@
-import { header, code } from '../../Sections';
+import { header, code } from '../../src/Sections';
 
 import importsExample from '!raw-loader!../examples/code-with-imports';
 import classWithArrowsExample from '!raw-loader!../examples/class-with-arrows';


### PR DESCRIPTION
`npm start` from `wix-ui/packages/wix-storybook-utils/` is failing to compile because the Sections module path is incorrect.

Not sure if this should go into `master` but that's where I discovered the issue.