### PR TITLE
add `compat` mode and `srcDir` to standalone generation

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@storybook/react": "^5.0.0",
-    "@stylable/cli": "^2.1.0",
+    "@stylable/cli": "^2.2.2",
     "@types/classnames": "^2.2.3",
     "@types/enzyme": "^3.1.9",
     "@types/jest": "^22.1.1",

--- a/packages/wix-ui-core/scripts/build-standalone.js
+++ b/packages/wix-ui-core/scripts/build-standalone.js
@@ -19,7 +19,7 @@ function buildStandalone() {
   execa.sync(
     'stc',
     [
-      `--outDir=${outDir}`,
+      `--outDir=${path.join(outDir, 'src')}`,
       '--srcDir=src',
       '--cssFilename=[filename].global.css',
       '--compat',
@@ -50,7 +50,7 @@ function buildStandaloneEs() {
   execa.sync(
     'stc',
     [
-      `--outDir=${esOutDir}`,
+      `--outDir=${path.join(esOutDir, 'src')}`,
       '--srcDir=src',
       '--cssFilename=[filename].global.css',
       '--compat',

--- a/packages/wix-ui-core/scripts/build-standalone.js
+++ b/packages/wix-ui-core/scripts/build-standalone.js
@@ -20,7 +20,9 @@ function buildStandalone() {
     'stc',
     [
       `--outDir=${outDir}`,
+      '--srcDir=src',
       '--cssFilename=[filename].global.css',
+      '--compat',
       '--cjs',
       '--css',
       '--icr',
@@ -49,7 +51,9 @@ function buildStandaloneEs() {
     'stc',
     [
       `--outDir=${esOutDir}`,
+      '--srcDir=src',
       '--cssFilename=[filename].global.css',
+      '--compat',
       '--cjs',
       '--css',
       '--icr',


### PR DESCRIPTION
This PR adds compat mode (with `require` vs `import`) to the stylable output

and also removes unwanted files from being generated into the `standalone` directory (`dist`)