### PR TITLE
`<Popover/>` - add long words or url links handling

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.st.css
+++ b/packages/wix-ui-core/src/components/popover/Popover.st.css
@@ -44,6 +44,11 @@
   border-color: value(contentBorderColor);
   border-radius: value(contentBorderRadius);
   padding: value(contentPadding);
+
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
 }
 
 .arrow {

--- a/packages/wix-ui-core/stories/Tooltip/examples.ts
+++ b/packages/wix-ui-core/stories/Tooltip/examples.ts
@@ -1,6 +1,6 @@
 export const basic = `
 <div style={{ display: 'flex', justifyContent: 'center'}}>
-  <Tooltip upgrade appendTo="window" content="Enter your postal code, so postman can easier send you a mail.">
+  <Tooltip maxWidth={100} upgrade appendTo="window" content="http://localhost:6006/?selectedKind=Components&selectedStory=BadgeSelect&full=0&addons=0&stories=1&panelRight=0">
     Hover me
   </Tooltip>
 </div>


### PR DESCRIPTION
This will fix multiple issues where user is entering URLs for long words in to the content element and it will not break the text according to maxWidth value.