### PR TITLE
wix-ui-framework: add more utils to `export-testkits` template

### DIFF
--- a/packages/wix-ui-framework/CHANGELOG.md
+++ b/packages/wix-ui-framework/CHANGELOG.md
@@ -11,6 +11,10 @@ Types of changes:
 1. **Fixed** for any bug fixes.
 1. **Security** in case of vulnerabilities.
 
+# 3.2.0 - 2019-07-24
+## Added
+- `wuf exports-testkits` - support `toCamel`, `toKebab`, `toSnake`, `toPascal` utils in template
+
 # 3.1.1 - 2019-07-16
 ## Added
 - `wuf export-testkits` - add `tslint:disable` before warning banner

--- a/packages/wix-ui-framework/package.json
+++ b/packages/wix-ui-framework/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "wuf": "./bin/wuf.js"
   },
-  "version": "3.1.1",
+  "version": "3.2.0",
   "author": {
     "name": "Wix",
     "email": "fed-infra@wix.com"

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/__fixtures__/utils-template.ejs
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/__fixtures__/utils-template.ejs
@@ -1,0 +1,8 @@
+<%
+const name = "TheAwesomeComponent";
+const kebabName = "the-awesome-component";
+%>
+toCamel(name) === "<%= utils.toCamel(name) %>"
+toKebab(name) === "<%= utils.toKebab(name) %>"
+toSnake(name) === "<%= utils.toSnake(name) %>"
+toPascal(kebabName) === "<%= utils.toPascal(name) %>"

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/__fixtures__/utils-template.output
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/__fixtures__/utils-template.output
@@ -1,0 +1,5 @@
+
+toCamel(name) === "theAwesomeComponent"
+toKebab(name) === "the-awesome-component"
+toSnake(name) === "the_awesome_component"
+toPascal(kebabName) === "TheAwesomeComponent"

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.spec.ts
@@ -265,7 +265,39 @@ describe('exportTestkits', () => {
       );
     });
 
-    it('should run throw error for erroneous ejs', () => {
+    it('should include global utils variable', async () => {
+      const fakeFs = cista({
+        '.wuf/testkits/template.ejs': fs.readFileSync(
+          path.resolve(__dirname, '__fixtures__', 'utils-template.ejs'),
+          'utf8',
+        ),
+        '.wuf/components.json': '{}',
+      });
+
+      await exportTestkits({
+        template: '.wuf/testkits/template.ejs',
+        components: '.wuf/components.json',
+        output: `.wuf/testkits/output.js`,
+        _process: { cwd: fakeFs.dir },
+      });
+
+      const output = fs.readFileSync(
+        path.resolve(fakeFs.dir, '.wuf', 'testkits', 'output.js'),
+        'utf8',
+      );
+
+      expect(output).toEqual(
+        [
+          warningBanner(`.wuf/testkits/template.ejs`),
+          fs.readFileSync(
+            path.resolve(__dirname, '__fixtures__', 'utils-template.output'),
+            'utf8',
+          ),
+        ].join('\n'),
+      );
+    });
+
+    it('should throw error for erroneous ejs', () => {
       const fakeFs = cista({
         '.wuf/testkits/definitions.js': ';',
         '.wuf/testkits/template.ejs': `<% components.map(c => { %><%= c.name %>\n<% ) %>`,

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
@@ -87,7 +87,7 @@ const ejsSource = ({ source, definitions, components }) => {
     toKebab: kebabCase,
     toSnake: snakeCase,
     toPascal: (s: string) => {
-      const camel = camelCase(s);
+      const camel: string = camelCase(s);
       return camel[0].toUpperCase() + camel.substring(1);
     },
   };

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as ejs from 'ejs';
 import * as camelCase from 'lodash/camelCase';
+import * as kebabCase from 'lodash/kebabCase';
+import * as snakeCase from 'lodash/snakeCase';
 
 import { fileExists } from '../../file-exists';
 import { objectEntries } from '../../object-entries';
@@ -82,6 +84,12 @@ const guards: (a: Options) => Promise<void> = async unsafeOptions => {
 const ejsSource = ({ source, definitions, components }) => {
   const utils = {
     toCamel: camelCase,
+    toKebab: kebabCase,
+    toSnake: snakeCase,
+    toPascal: (s: string) => {
+      const camel = camelCase(s);
+      return camel[0].toUpperCase() + camel.substring(1);
+    },
   };
 
   const componentsForEjs = objectEntries({ ...components, ...definitions }).map(


### PR DESCRIPTION
a harmless addition of more utility functions for `exports-testkits` template:

`toCamel`
`toKebab`
`toSnake`
`toPascal`

also includes 3.2.0 release with updates