### PR TITLE
`<Tooltip/>` -  break word to tooltip content only

### DIFF
--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.st.css
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.st.css
@@ -6,3 +6,10 @@
 .root {
   -st-extends: Popover;
 }
+
+.root::popoverContent {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+}

--- a/packages/wix-ui-core/stories/Tooltip/examples.ts
+++ b/packages/wix-ui-core/stories/Tooltip/examples.ts
@@ -1,6 +1,6 @@
 export const basic = `
 <div style={{ display: 'flex', justifyContent: 'center'}}>
-  <Tooltip upgrade appendTo="window" content="Enter your postal code, so postman can easier send you a mail.">
+  <Tooltip maxWidth={100} upgrade appendTo="window" content="https://github.com/wix/wix-ui/commits/master/docs/icons.md">
     Hover me
   </Tooltip>
 </div>


### PR DESCRIPTION
This suppose to fix the break-word on tooltip components.