### PR TITLE
`<Popover/>` - change display: inline-block to display: inline-flex

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.st.css
+++ b/packages/wix-ui-core/src/components/popover/Popover.st.css
@@ -24,7 +24,7 @@
   /*popper sets tooltip in absolute position according to this container*/
   position: relative;
   /*popper adds an extra div that needs to be measured without stretching*/
-  display: inline-block;
+  display: inline-flex;
 }
 
 .popoverAnimation {}


### PR DESCRIPTION
This PR should fix "page jump" problems when popover content element is positioning itself through a div that has `display: block`. I have changed it to be `display: inline-flex` instead.