### PR TITLE
<Popover/> - override basic uniDriver onClick and test it

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -111,6 +111,23 @@ function runTests(createDriver, container) {
       expect(onMouseLeave).toBeCalled();
     });
 
+    describe('onClick', () => {
+      it('should execute onClick callback', async () => {
+        const onClick = jest.fn();
+
+        const driver = createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: false,
+            onClick,
+          }),
+        );
+
+        await driver.click();
+        expect(onClick).toBeCalled();
+      });
+    });
+
     describe('onClickOutside', () => {
       it('should be triggered when outside of the popover is called', async () => {
         const onClickOutside = jest.fn();

--- a/packages/wix-ui-core/src/components/popover/Popover.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.uni.driver.ts
@@ -11,6 +11,7 @@ export const testkit = (base: UniDriver, body: UniDriver) => {
 
   return {
     ...baseUniDriverFactory(base),
+    click: async () => await byHook('popover-element').click(),
     getTargetElement: async () => safeGetNative(byHook('popover-element')),
 
     getPortalElement: async () =>


### PR DESCRIPTION
@mykas @shlomitc 
as part of fixing the wsr `ColorInput` uniDriver to use unidriver for internal drivers, i ran into this `click` function that was not working properly in wix-ui-core and was not tested.
