### PR TITLE
<ButtonNext> - touch action

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.st.css
+++ b/packages/wix-ui-core/src/components/button-next/button-next.st.css
@@ -1,5 +1,5 @@
 :import {
-  -st-from: "../../hocs/Focusable/Focusable.st.css";
+  -st-from: '../../hocs/Focusable/Focusable.st.css';
   -st-default: Focusable;
 }
 
@@ -9,9 +9,11 @@
   display: inline-flex;
   align-items: center;
   cursor: pointer;
+  touch-action: manipulation;
 }
 
-.content {}
+.content {
+}
 
 .prefix {
   flex-shrink: 0;


### PR DESCRIPTION
Adding touch-action: manipulation removes the need for browsers to
delay the generation of click events when the user taps the screen
for touchscreen