### PR TITLE
`<Tooltip/>` - remove hyphens

### DIFF
--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.st.css
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.st.css
@@ -11,5 +11,4 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
-  hyphens: auto;
 }


### PR DESCRIPTION
This PR will remove hyphens css rule which breaks words instead of moving them to new line. 