### PR TITLE
`<Popover/>` - omit data-hook from portal stylable spread

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -787,6 +787,51 @@ function runTests(createDriver, container) {
     });
   });
 
+  describe('data-hook', () => {
+    it('should be found on target element container',  async () => {
+      const driver = createDriver(
+        <Popover data-hook="random" appendTo="window" shown placement="bottom">
+          <Popover.Element>Element</Popover.Element>
+          <Popover.Content>Content</Popover.Content>
+        </Popover>,
+      );
+      const target = await driver.getTargetElement()
+      expect(target.parentNode.getAttribute('data-hook')).toBe('random')
+    }) 
+    
+    it('should construct data-content-hook',  async () => {
+      const driver = createDriver(
+        <Popover data-hook="random" appendTo="window" shown placement="bottom">
+          <Popover.Element>Element</Popover.Element>
+          <Popover.Content>Content</Popover.Content>
+        </Popover>,
+      );
+      const target = await driver.getTargetElement()
+      expect(target.parentNode.getAttribute('data-content-hook')).toMatch(/popover-content-random-/)
+    }) 
+
+    it('should apply data-content-element on content element',  async () => {
+      const driver = createDriver(
+        <Popover data-hook="random" appendTo="window" shown placement="bottom">
+          <Popover.Element>Element</Popover.Element>
+          <Popover.Content>Content</Popover.Content>
+        </Popover>,
+      );
+      const content = await driver.getContentElement()
+      expect(content.getAttribute('data-content-element')).toMatch(/popover-content-random-/)
+    }) 
+    it('should not override portal component data-hook',  async () => {
+      const driver = createDriver(
+        <Popover data-hook="random" appendTo="window" shown placement="bottom">
+          <Popover.Element>Element</Popover.Element>
+          <Popover.Content>Content</Popover.Content>
+        </Popover>,
+      );
+      const content = await driver.getContentElement()
+      expect(content.parentNode.getAttribute('data-hook')).toBe('popover-portal')
+    }) 
+  })
+
   describe('Arrow', () => {
     function customArrow(placement, arrowProps) {
       return <p data-test={`custom-arrow-${placement}`} {...arrowProps} />;

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -442,7 +442,6 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
 
   componentDidUpdate(prevProps) {
     const { shown } = this.props;
-    const rest = this.props
     if (this.portalNode) {
       // Re-calculate the portal's styles
       this.stylesObj = style('root', {}, omit('data-hook', this.props)) ;

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -41,10 +41,18 @@ if (isTestEnv) {
   testId = popoverTestUtils.generateId();
 }
 
+const omit = (key, obj) => {
+  const { [key]: omitted, ...rest } = obj;
+  return rest;
+}
+
 export type Placement = PopperJS.Placement;
 export type AppendTo = PopperJS.Boundary | 'parent' | Element | Predicate;
 
 export interface PopoverProps {
+  /** hook for testing purposes */
+  "data-hook"?: string,
+  /** custom classname */
   className?: string;
   /** The location to display the content */
   placement: Placement;
@@ -434,10 +442,10 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
 
   componentDidUpdate(prevProps) {
     const { shown } = this.props;
-
+    const rest = this.props
     if (this.portalNode) {
       // Re-calculate the portal's styles
-      this.stylesObj = style('root', {}, this.props);
+      this.stylesObj = style('root', {}, omit('data-hook', this.props)) ;
 
       // Apply the styles to the portal
       this.applyStylesToPortaledNode();


### PR DESCRIPTION
This fixes a bug where data-hook attribute is attached to portal element to instead of just on the target/trigger element.