### PR TITLE
wix-ui-core|image: fix props changes ignored

### DIFF
--- a/packages/wix-ui-core/src/components/image/image.tsx
+++ b/packages/wix-ui-core/src/components/image/image.tsx
@@ -80,6 +80,15 @@ export class Image extends React.PureComponent<ImageProps, ImageState> {
     status: ImageStatus.loading,
   };
 
+  componentDidUpdate(prevProps: Readonly<ImageProps>) {
+    if (prevProps.src !== this.props.src || prevProps.srcSet !== this.props.srcSet || prevProps.errorImage !== this.props.errorImage) {
+      this.setState({
+        src: this.getSrc(),
+        status: ImageStatus.loading
+      })
+    }
+  }
+
   render() {
     const { resizeMode } = this.props;
 


### PR DESCRIPTION
 reset the state when component receiving new src/srcSt/errorImage props