### PR TITLE
upgrade stylable cli to 2.2.7

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@storybook/react": "^5.0.0",
-    "@stylable/cli": "^2.2.2",
+    "@stylable/cli": "^2.2.7",
     "@types/classnames": "^2.2.3",
     "@types/enzyme": "^3.1.9",
     "@types/jest": "^22.1.1",


### PR DESCRIPTION
This PR verifies that this library has stylable above `2.2.7`.

(and also release a version with it 🤖)