### PR TITLE
AddressInput - Allow passing inputClassName to nativeInput

### DIFF
--- a/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
@@ -997,6 +997,13 @@ describe('AddressInput', () => {
     });
   });
 
+  it('should pass inputClassName to the native input', async () => {
+    const inputClassName = 'my-input-class';
+    init({ inputClassName });
+    const input = driver.getInput();
+    expect(input.className).toContain(inputClassName);
+  });
+
   describe('fixedFooter', () => {
     it('Should show fixedFooter', async () => {
       init({ fixedFooter: <div data-hook="fixed-footer" /> });

--- a/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
@@ -115,6 +115,8 @@ export type AddressInputProps = Pick<
   onMouseLeave?(): void;
   /** A custom formatter for maps API response */
   converterType?: Converter;
+  /** Pass a custom class to the input element */
+  inputClassName?: string;
 };
 
 export interface AddressInputState {
@@ -471,6 +473,7 @@ export class AddressInput extends React.PureComponent<
       fixed,
       optionStyle,
       moveBy,
+      inputClassName,
     } = this.props;
     const options = this._options();
 
@@ -492,6 +495,7 @@ export class AddressInput extends React.PureComponent<
       onMouseEnter: this.props.onMouseEnter,
       onMouseLeave: this.props.onMouseLeave,
       style: inputStyle,
+      inputClassName,
     };
 
     const states = {};

--- a/packages/wix-ui-core/src/components/input/Input.spec.tsx
+++ b/packages/wix-ui-core/src/components/input/Input.spec.tsx
@@ -50,6 +50,7 @@ describe('Input', () => {
         role="input"
         type="password"
         value="hunter2"
+        inputClassName="my-input-class"
       />,
     );
 
@@ -65,6 +66,7 @@ describe('Input', () => {
     expect(input.tabIndex).toBe(1);
     expect(input.type).toBe('password');
     expect(input.value).toBe('hunter2');
+    expect(input.className).toBe(`${style.nativeInput} my-input-class`);
   });
 
   it('should render prefix and suffix', async () => {

--- a/packages/wix-ui-core/src/components/input/Input.tsx
+++ b/packages/wix-ui-core/src/components/input/Input.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import style from './Input.st.css';
 import { Omit } from 'type-zoo';
+import classnames from 'classnames';
 
 type OmittedInputProps = 'value' | 'prefix';
 export type AriaAutoCompleteType = 'list' | 'none' | 'both';
 export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, OmittedInputProps> {
   className?: string;
+  inputClassName?: string;
   error?: string | boolean;
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
@@ -53,6 +55,7 @@ export class Input extends React.Component<InputProps, InputState> {
       style: styleProp,
       prefix: prefixProps,
       suffix: suffixProp,
+      inputClassName,
       ...allOtherProps
     } = this.props;
 
@@ -69,7 +72,7 @@ export class Input extends React.Component<InputProps, InputState> {
         <input
           {...allOtherProps}
           ref={input => (this.input = input)}
-          className={style.nativeInput}
+          className={classnames(style.nativeInput, inputClassName)}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
         />


### PR DESCRIPTION
### Why ? 

There's a need to pass a specific class from a consumer (`wix-ui-santa`) to handle platform (see https://github.com/wix-private/santa/blob/master/static/css/scss/accessibility.scss) `!important` usage in global css.

Could be solved in `wix-ui-santa` using ref but i wanted to avoid that

### Done

- [x] Tests
- [x] Pass as `inputClassName`