### PR TITLE
wix-ui-core: fix(Input): use namespaced import specifier for `classnames`

### DIFF
--- a/packages/wix-ui-core/src/components/input/Input.tsx
+++ b/packages/wix-ui-core/src/components/input/Input.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import style from './Input.st.css';
 import { Omit } from 'type-zoo';
-import classnames from 'classnames';
+import * as classnames from 'classnames';
 
 type OmittedInputProps = 'value' | 'prefix';
 export type AriaAutoCompleteType = 'list' | 'none' | 'both';


### PR DESCRIPTION
a small change which fixes error like this:

```
TypeError: classnames_1.default is not a function
    at Input.render (Input.js:31)
```

this error is not visible in wix-ui-core but rather in component
libraries that depend on wix-ui-core (e.g. wix-ui-adi).

code transpilers in those libraries fail to resolve such import