### PR TITLE
`<Popover/>` - make sure that width prop is not being overwritten

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -667,6 +667,7 @@ function runTests(createDriver, container) {
 
   describe('createModifiers', () => {
     const defaultProps = {
+      width: undefined,
       moveBy: undefined,
       minWidth: undefined,
       dynamicWidth: undefined,

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -244,6 +244,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
 
     const modifiers = createModifiers({
       minWidth,
+      width,
       dynamicWidth,
       moveBy,
       appendTo,
@@ -269,7 +270,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
               ref={ref}
               data-hook="popover-content"
               data-content-element={this.contentHook}
-              style={{ width, ...popperStyles, zIndex, maxWidth }}
+              style={{ ...popperStyles, zIndex, maxWidth }}
               data-placement={popperPlacement || placement}
               className={classNames(style.popover, {
                 [style.withArrow]: showArrow,

--- a/packages/wix-ui-core/src/components/popover/modifiers.ts
+++ b/packages/wix-ui-core/src/components/popover/modifiers.ts
@@ -21,7 +21,12 @@ interface styles {
   width?: string;
 }
 
-const resolveWidth = ({ minWidth, dynamicWidth, referenceWidth }): styles => {
+const resolveWidth = ({
+  width,
+  minWidth,
+  dynamicWidth,
+  referenceWidth,
+}): styles => {
   return {
     minWidth: minWidth
       ? typeof minWidth === 'string'
@@ -30,11 +35,12 @@ const resolveWidth = ({ minWidth, dynamicWidth, referenceWidth }): styles => {
       : dynamicWidth
       ? `${referenceWidth}px`
       : undefined,
-    width: 'auto',
+    width: width || 'auto',
   };
 };
 
 export const createModifiers = ({
+  width,
   moveBy,
   appendTo,
   shouldAnimate,
@@ -65,7 +71,7 @@ export const createModifiers = ({
     },
   };
 
-  if (dynamicWidth || minWidth) {
+  if (dynamicWidth || minWidth || width) {
     modifiers.setPopperWidth = {
       enabled: true,
       order: 840,
@@ -75,6 +81,7 @@ export const createModifiers = ({
         data.styles = {
           ...data.styles,
           ...resolveWidth({
+            width,
             referenceWidth,
             minWidth,
             dynamicWidth,


### PR DESCRIPTION
This PR is fixing a bug where width prop is being ignored when `dynamicWidth` prop is enabled.