### PR TITLE
wix-storybook-utils: fix(AutoTestkit/flatten): ensure falsy objects dont throw error

### DIFF
--- a/packages/wix-storybook-utils/src/AutoTestkit/flatten.test.ts
+++ b/packages/wix-storybook-utils/src/AutoTestkit/flatten.test.ts
@@ -100,4 +100,34 @@ describe('flatten', () => {
       expect(flatten(assertion)).toEqual(expectation);
     });
   });
+
+  describe('given array of erroneous', () => {
+    it('should skip them and work with non erroneous', () => {
+      const assertion = [
+        {
+          a: 1,
+          type: 'unknown',
+          name: 'first',
+        },
+        null,
+        [],
+        0,
+        false,
+        {
+          b: 2,
+          type: 'unknown',
+          name: 'second',
+        },
+      ];
+
+      const expectation = [
+        { a: 1, type: 'unknown', name: 'first' },
+        { b: 2, type: 'unknown', name: 'second' },
+      ];
+
+      // intentional ignore, JS consumer might pass falsy input
+      // @ts-ignore
+      expect(flatten(assertion)).toEqual(expectation);
+    });
+  });
 });

--- a/packages/wix-storybook-utils/src/AutoTestkit/flatten.ts
+++ b/packages/wix-storybook-utils/src/AutoTestkit/flatten.ts
@@ -3,17 +3,19 @@ import { Descriptor } from './typings';
 const isNested = (item: Descriptor) => item.type === 'object';
 
 export const flatten = (methodsList: Descriptor[], name = '') =>
-  methodsList.reduce((list, item: Descriptor) => {
-    if (isNested(item)) {
-      list = list.concat(
-        flatten(item.props, name ? `${name}.${item.name}` : item.name),
-      );
-    } else {
-      list.push({
-        ...item,
-        ...(name ? { name: `${name}.${item.name}` } : {}),
-      });
-    }
+  methodsList
+    .filter(i => i && i.type)
+    .reduce((list, item: Descriptor) => {
+      if (isNested(item)) {
+        list = list.concat(
+          flatten(item.props, name ? `${name}.${item.name}` : item.name),
+        );
+      } else {
+        list.push({
+          ...item,
+          ...(name ? { name: `${name}.${item.name}` } : {}),
+        });
+      }
 
-    return list;
-  }, []);
+      return list;
+    }, []);


### PR DESCRIPTION
TS prevents stuff like that, however, autodocs users are js, so
defensive programing ;)