### PR TITLE
wix-ui-framework: support kebab-case file names in geneator template

### DIFF
--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/__snapshots__/copy-templates.spec.ts.snap
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/__snapshots__/copy-templates.spec.ts.snap
@@ -2,7 +2,10 @@
 
 exports[`copyTemplates should work as expected when description is not provided 1`] = `
 Object {
-  "test-generated/src/MyNewComponent/MyNewComponent.js": "import React from 'react';
+  "test-generated": Object {
+    "src": Object {
+      "MyNewComponent": Object {
+        "MyNewComponent.js": "import React from 'react';
 import PropTypes from 'prop-types';
 
 import Text from '../Text';
@@ -66,7 +69,7 @@ class MyNewComponent extends React.PureComponent {
 
 export default MyNewComponent;
 ",
-  "test-generated/src/MyNewComponent/MyNewComponent.meta.js": "import MyNewComponent from './MyNewComponent';
+        "MyNewComponent.meta.js": "import MyNewComponent from './MyNewComponent';
 import Registry from '@ui-autotools/registry';
 
 const metadata = Registry.getComponentMetadata(MyNewComponent);
@@ -75,7 +78,7 @@ metadata.exportedFrom({
   path: 'src/MyNewComponent/MyNewComponent.js',
 });
 ",
-  "test-generated/src/MyNewComponent/MyNewComponent.st.css": ":import {
+        "MyNewComponent.st.css": ":import {
   -st-from: \\"wix-ui-core/dist/src/themes/backoffice/colors.st.css\\";
   -st-named: G30,R30;
 }
@@ -101,7 +104,7 @@ metadata.exportedFrom({
   justify-content: space-evenly;
 }
 ",
-  "test-generated/src/MyNewComponent/MyNewComponent.uni.driver.js": "import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
+        "MyNewComponent.uni.driver.js": "import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
 
 export const myNewComponentDriverFactory = base => {
   return {
@@ -121,7 +124,8 @@ export const myNewComponentDriverFactory = base => {
   };
 };
 ",
-  "test-generated/src/MyNewComponent/docs/index.story.js": "import React from 'react';
+        "docs": Object {
+          "index.story.js": "import React from 'react';
 import {
   header,
   tabs,
@@ -219,9 +223,11 @@ export default {
   ],
 };
 ",
-  "test-generated/src/MyNewComponent/index.js": "export { default } from './MyNewComponent.js';
+        },
+        "index.js": "export { default } from './MyNewComponent.js';
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponent.e2e.js": "import {
+        "test": Object {
+          "MyNewComponent.e2e.js": "import {
   waitForVisibilityOf,
   scrollToElement,
 } from 'wix-ui-test-utils/protractor';
@@ -260,7 +266,7 @@ describe('MyNewComponent', () => {
   });
 });
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponent.private.uni.driver.js": "import { myNewComponentDriverFactory as publicDriverFactory } from '../MyNewComponent.uni.driver';
+          "MyNewComponent.private.uni.driver.js": "import { myNewComponentDriverFactory as publicDriverFactory } from '../MyNewComponent.uni.driver';
 
 export const myNewComponentPrivateDriverFactory = base => {
   return {
@@ -270,7 +276,7 @@ export const myNewComponentPrivateDriverFactory = base => {
   };
 };
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponent.spec.js": "import React from 'react';
+          "MyNewComponent.spec.js": "import React from 'react';
 import { createRendererWithUniDriver, cleanup } from '../../../test/utils/unit';
 
 import MyNewComponent from '../MyNewComponent';
@@ -310,7 +316,7 @@ describe('MyNewComponent', () => {
   });
 });
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponent.visual.js": "import React from 'react';
+          "MyNewComponent.visual.js": "import React from 'react';
 import { storiesOf } from '@storybook/react';
 import MyNewComponent from '../MyNewComponent';
 
@@ -340,7 +346,7 @@ tests.forEach(({ describe, its }) => {
   });
 });
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponentStories.js": "import React from 'react';
+          "MyNewComponentStories.js": "import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { getTestStoryKind } from '../../../stories/storiesHierarchy';
 import { storySettings } from './storySettings';
@@ -357,7 +363,7 @@ TestStories.add(testStoryNames.DEFAULT, () => (
   />
 ));
 ",
-  "test-generated/src/MyNewComponent/test/storySettings.js": "import { Category } from '../../../stories/storiesHierarchy';
+          "storySettings.js": "import { Category } from '../../../stories/storiesHierarchy';
 
 export const storySettings = {
   category: Category.COMPONENTS,
@@ -368,21 +374,32 @@ export const storySettings = {
   },
 };
 ",
-  "test-generated/src/index.js": "// explicit test file
+        },
+      },
+      "index.js": "// explicit test file
 ",
-  "test-generated/stories/index.js": "",
-  "test-generated/testkit/protractor.js": "// explicit test file
+    },
+    "stories": Object {
+      "index.js": "",
+    },
+    "testkit": Object {
+      "protractor.js": "// explicit test file
 ",
-  "test-generated/testkit/puppeteer.js": "// explicit test file
+      "puppeteer.js": "// explicit test file
 ",
-  "test-generated/testkit/testkit-definitions.js": "// explicit test file
+      "testkit-definitions.js": "// explicit test file
 ",
+    },
+  },
 }
 `;
 
 exports[`copyTemplates should work as expected when description is provided 1`] = `
 Object {
-  "test-generated/src/MyNewComponent/MyNewComponent.js": "import React from 'react';
+  "test-generated": Object {
+    "src": Object {
+      "MyNewComponent": Object {
+        "MyNewComponent.js": "import React from 'react';
 import PropTypes from 'prop-types';
 
 import Text from '../Text';
@@ -446,7 +463,7 @@ class MyNewComponent extends React.PureComponent {
 
 export default MyNewComponent;
 ",
-  "test-generated/src/MyNewComponent/MyNewComponent.meta.js": "import MyNewComponent from './MyNewComponent';
+        "MyNewComponent.meta.js": "import MyNewComponent from './MyNewComponent';
 import Registry from '@ui-autotools/registry';
 
 const metadata = Registry.getComponentMetadata(MyNewComponent);
@@ -455,7 +472,7 @@ metadata.exportedFrom({
   path: 'src/MyNewComponent/MyNewComponent.js',
 });
 ",
-  "test-generated/src/MyNewComponent/MyNewComponent.st.css": ":import {
+        "MyNewComponent.st.css": ":import {
   -st-from: \\"wix-ui-core/dist/src/themes/backoffice/colors.st.css\\";
   -st-named: G30,R30;
 }
@@ -481,7 +498,7 @@ metadata.exportedFrom({
   justify-content: space-evenly;
 }
 ",
-  "test-generated/src/MyNewComponent/MyNewComponent.uni.driver.js": "import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
+        "MyNewComponent.uni.driver.js": "import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
 
 export const myNewComponentDriverFactory = base => {
   return {
@@ -501,7 +518,8 @@ export const myNewComponentDriverFactory = base => {
   };
 };
 ",
-  "test-generated/src/MyNewComponent/docs/index.story.js": "import React from 'react';
+        "docs": Object {
+          "index.story.js": "import React from 'react';
 import {
   header,
   tabs,
@@ -599,9 +617,11 @@ export default {
   ],
 };
 ",
-  "test-generated/src/MyNewComponent/index.js": "export { default } from './MyNewComponent.js';
+        },
+        "index.js": "export { default } from './MyNewComponent.js';
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponent.e2e.js": "import {
+        "test": Object {
+          "MyNewComponent.e2e.js": "import {
   waitForVisibilityOf,
   scrollToElement,
 } from 'wix-ui-test-utils/protractor';
@@ -640,7 +660,7 @@ describe('MyNewComponent', () => {
   });
 });
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponent.private.uni.driver.js": "import { myNewComponentDriverFactory as publicDriverFactory } from '../MyNewComponent.uni.driver';
+          "MyNewComponent.private.uni.driver.js": "import { myNewComponentDriverFactory as publicDriverFactory } from '../MyNewComponent.uni.driver';
 
 export const myNewComponentPrivateDriverFactory = base => {
   return {
@@ -650,7 +670,7 @@ export const myNewComponentPrivateDriverFactory = base => {
   };
 };
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponent.spec.js": "import React from 'react';
+          "MyNewComponent.spec.js": "import React from 'react';
 import { createRendererWithUniDriver, cleanup } from '../../../test/utils/unit';
 
 import MyNewComponent from '../MyNewComponent';
@@ -690,7 +710,7 @@ describe('MyNewComponent', () => {
   });
 });
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponent.visual.js": "import React from 'react';
+          "MyNewComponent.visual.js": "import React from 'react';
 import { storiesOf } from '@storybook/react';
 import MyNewComponent from '../MyNewComponent';
 
@@ -720,7 +740,7 @@ tests.forEach(({ describe, its }) => {
   });
 });
 ",
-  "test-generated/src/MyNewComponent/test/MyNewComponentStories.js": "import React from 'react';
+          "MyNewComponentStories.js": "import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { getTestStoryKind } from '../../../stories/storiesHierarchy';
 import { storySettings } from './storySettings';
@@ -737,7 +757,7 @@ TestStories.add(testStoryNames.DEFAULT, () => (
   />
 ));
 ",
-  "test-generated/src/MyNewComponent/test/storySettings.js": "import { Category } from '../../../stories/storiesHierarchy';
+          "storySettings.js": "import { Category } from '../../../stories/storiesHierarchy';
 
 export const storySettings = {
   category: Category.COMPONENTS,
@@ -748,14 +768,22 @@ export const storySettings = {
   },
 };
 ",
-  "test-generated/src/index.js": "// explicit test file
+        },
+      },
+      "index.js": "// explicit test file
 ",
-  "test-generated/stories/index.js": "",
-  "test-generated/testkit/protractor.js": "// explicit test file
+    },
+    "stories": Object {
+      "index.js": "",
+    },
+    "testkit": Object {
+      "protractor.js": "// explicit test file
 ",
-  "test-generated/testkit/puppeteer.js": "// explicit test file
+      "puppeteer.js": "// explicit test file
 ",
-  "test-generated/testkit/testkit-definitions.js": "// explicit test file
+      "testkit-definitions.js": "// explicit test file
 ",
+    },
+  },
 }
 `;

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/__snapshots__/copy-templates.spec.ts.snap
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/__snapshots__/copy-templates.spec.ts.snap
@@ -1,5 +1,388 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`copyTemplates given template with lower case \`component\` should rename \`component\` to given component name but in kebab-case  1`] = `
+Object {
+  "test-generated": Object {
+    "src": Object {
+      "index.js": "// explicit test file
+",
+      "my-new-component": Object {
+        "component.js": "import React from 'react';
+import PropTypes from 'prop-types';
+
+import Text from '../Text';
+import Button from '../Button';
+import styles from './my-new-component.st.css';
+
+/** MyNewComponent */
+class MyNewComponent extends React.PureComponent {
+  static displayName = 'MyNewComponent';
+
+  static propTypes = {
+    dataHook: PropTypes.string,
+
+    /** Text for the button */
+    buttonText: PropTypes.string,
+  };
+
+  static defaultProps = {
+    buttonText: 'Click me!',
+  };
+
+  state = {
+    count: 0,
+  };
+
+  _handleClick = () => {
+    this.setState(({ count }) => ({
+      count: count + 1,
+    }));
+  };
+
+  render() {
+    const { count } = this.state;
+    const { dataHook, buttonText } = this.props;
+    const isEven = count % 2 === 0;
+
+    return (
+      <div className={styles.root} data-hook={dataHook}>
+        <Text dataHook=\\"myNewComponent-count\\">
+          You clicked this button {isEven ? 'even' : 'odd'} number (
+          <span
+            {...styles('number', { even: isEven, odd: !isEven }, this.props)}
+          >
+            {count}
+          </span>
+          ) of times
+        </Text>
+
+        <div className={styles.button}>
+          <Button
+            onClick={this._handleClick}
+            dataHook=\\"myNewComponent-button\\"
+          >
+            {buttonText}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default MyNewComponent;
+",
+        "docs": Object {
+          "index.story.js": "import React from 'react';
+import {
+  header,
+  tabs,
+  tab,
+  description,
+  importExample,
+  title,
+  columns,
+  divider,
+  code as baseCode,
+  playground,
+  api,
+  testkit,
+} from 'wix-storybook-utils/Sections';
+
+import { storySettings } from '../test/storySettings';
+import allComponents from '../../../stories/utils/allComponents';
+
+import MyNewComponent from '..';
+
+const code = config => baseCode({ components: allComponents, ...config });
+
+export default {
+  category: storySettings.category,
+  storyName: 'MyNewComponent',
+
+  component: MyNewComponent,
+  componentPath: '..',
+
+  componentProps: {
+    buttonText: 'Hello World!',
+  },
+
+  exampleProps: {
+    // Put here presets of props, for more info:
+    // https://github.com/wix/wix-ui/blob/master/packages/wix-storybook-utils/docs/usage.md#using-list
+  },
+
+  sections: [
+    header({
+      issueUrl: 'https://github.com/wix/wix-style-react/issues/new',
+      sourceUrl:
+        'https://github.com/wix/wix-style-react/tree/master/src/MyNewComponent/',
+      component: <MyNewComponent buttonText=\\"Click me!\\" />,
+    }),
+
+    tabs([
+      tab({
+        title: 'Description',
+        sections: [
+          columns([
+            description({
+              title: 'Description',
+              text:
+                'This line here should briefly describe component in just a sentence or two. It should be short and easy to read.',
+            }),
+          ]),
+
+          columns([
+            importExample(
+              \\"import MyNewComponent from 'wix-style-react/MyNewComponent';\\",
+            ),
+          ]),
+
+          divider(),
+
+          title('Examples'),
+
+          columns([
+            description({
+              title: 'Simple Usage',
+              text: 'A simple example with compact preview',
+            }),
+
+            code({
+              compact: true,
+              source: '<MyNewComponent buttonText=\\"Hello World!\\"/>',
+            }),
+          ]),
+
+          code({
+            title: 'Full Interactive Preview',
+            description: 'A non compact version of same code example as above',
+            source: '<MyNewComponent buttonText=\\"Hello World!\\"/>',
+          }),
+        ],
+      }),
+
+      ...[
+        { title: 'API', sections: [api()] },
+        { title: 'Testkit', sections: [testkit()] },
+        { title: 'Playground', sections: [playground()] },
+      ].map(tab),
+    ]),
+  ],
+};
+",
+        },
+        "index.js": "export { default } from './my-new-component.js';
+",
+        "my-new-component.meta.js": "import MyNewComponent from './my-new-component';
+import Registry from '@ui-autotools/registry';
+
+const metadata = Registry.getComponentMetadata(MyNewComponent);
+
+metadata.exportedFrom({
+  path: 'src/my-new-component/my-new-component.js',
+});
+",
+        "my-new-component.st.css": ":import {
+  -st-from: \\"wix-ui-core/dist/src/themes/backoffice/colors.st.css\\";
+  -st-named: G30,R30;
+}
+
+.root {
+  text-align: center;
+}
+
+.number {
+  -st-states: odd, even;
+}
+
+.number:even {
+  background: value(G30);
+}
+
+.number:odd {
+  background: value(R30);
+}
+
+.button {
+  display: flex;
+  justify-content: space-evenly;
+}
+",
+        "my-new-component.uni.driver.js": "import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
+
+export const myNewComponentDriverFactory = base => {
+  return {
+    ...baseUniDriverFactory(base),
+
+    /** Get the current count */
+    getCountText: async () =>
+      base.$('[data-hook=\\"myNewComponent-count\\"]').text(),
+
+    /** Click the button */
+    clickButton: async () =>
+      base.$('[data-hook=\\"myNewComponent-button\\"]').click(),
+
+    /** Get the button's text */
+    getButtonText: async () =>
+      base.$('[data-hook=\\"myNewComponent-button\\"]').text(),
+  };
+};
+",
+        "test": Object {
+          "my-new-component.e2e.js": "import {
+  waitForVisibilityOf,
+  scrollToElement,
+} from 'wix-ui-test-utils/protractor';
+
+import { eyesItInstance } from '../../../test/utils/eyes-it';
+import { createTestStoryUrl } from '../../../test/utils/storybook-helpers';
+import { myNewComponentTestkitFactory } from '../../../testkit/protractor';
+import { storySettings } from './storySettings';
+
+const eyes = eyesItInstance();
+
+describe('MyNewComponent', () => {
+  const createStoryUrl = testName =>
+    createTestStoryUrl({ ...storySettings, testName });
+
+  const createDriver = async (dataHook = storySettings.dataHook) => {
+    const driver = myNewComponentTestkitFactory({ dataHook });
+
+    await waitForVisibilityOf(
+      await driver.element(),
+      \`Cannot find <MyNewComponent/> component with dataHook of \${dataHook}\`,
+    );
+
+    await scrollToElement(await driver.element());
+
+    return driver;
+  };
+
+  const testStoryNames = storySettings.testStoryNames;
+
+  eyes.it('should increase count when button clicked', async () => {
+    await browser.get(createStoryUrl(testStoryNames.DEFAULT));
+    const driver = await createDriver();
+    await driver.clickButton();
+    expect(await driver.getCountText()).toBe('You clicked this button odd number (1) of times');
+  });
+});
+",
+          "my-new-component.private.uni.driver.js": "import { myNewComponentDriverFactory as publicDriverFactory } from '../my-new-component.uni.driver';
+
+export const myNewComponentPrivateDriverFactory = base => {
+  return {
+    ...publicDriverFactory(base),
+
+    // Add here driver methods that considered \\"private\\"
+  };
+};
+",
+          "my-new-component.spec.js": "import React from 'react';
+import { createRendererWithUniDriver, cleanup } from '../../../test/utils/unit';
+
+import MyNewComponent from '../my-new-component';
+import { myNewComponentPrivateDriverFactory } from './my-new-component.private.uni.driver';
+
+describe('MyNewComponent', () => {
+  const render = createRendererWithUniDriver(
+    myNewComponentPrivateDriverFactory,
+  );
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render', async () => {
+    const { driver } = render(<MyNewComponent />);
+
+    expect(await driver.exists()).toBeTruthy();
+    expect(await driver.getButtonText()).toEqual('Click me!');
+  });
+
+  it('should increment', async () => {
+    const { driver } = render(<MyNewComponent />);
+
+    await driver.clickButton();
+    await driver.clickButton();
+
+    expect(await driver.getCountText()).toEqual(
+      'You clicked this button even number (2) of times',
+    );
+  });
+
+  it('should allow changing the button text', async () => {
+    const { driver } = render(<MyNewComponent buttonText=\\"Press me\\" />);
+
+    expect(await driver.getButtonText()).toEqual('Press me');
+  });
+});
+",
+          "my-new-component.visual.js": "import React from 'react';
+import { storiesOf } from '@storybook/react';
+import MyNewComponent from '../my-new-component';
+
+const commonProps = {
+  //use for repeated props across the tests (e.g. {buttonText: 'example'})
+};
+
+const tests = [
+  {
+    describe: 'sanity', // prop name (e.g. size)
+    its: [
+      {
+        it: 'default', //prop vaiation (e.g. small)
+        props: {
+          // the simulation (e.g. {size: \\"small\\"})
+        },
+      },
+    ],
+  },
+];
+
+tests.forEach(({ describe, its }) => {
+  its.forEach(({ it, props }) => {
+    storiesOf(\`MyNewComponent/\${describe}\`, module).add(it, () => (
+      <MyNewComponent {...commonProps} {...props} />
+    ));
+  });
+});
+",
+          "my-new-componentStories.js": "import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { getTestStoryKind } from '../../../stories/storiesHierarchy';
+import { storySettings } from './storySettings';
+
+import MyNewComponent from '..';
+
+const TestStories = storiesOf(getTestStoryKind(storySettings), module);
+const { testStoryNames, dataHook } = storySettings;
+
+TestStories.add(testStoryNames.DEFAULT, () => (
+  <MyNewComponent
+    dataHook={dataHook}
+    buttonText=\\"Press me for a surprise\\"
+  />
+));
+",
+          "storySettings.js": "import { Category } from '../../../stories/storiesHierarchy';
+
+export const storySettings = {
+  category: Category.COMPONENTS,
+  storyName: 'MyNewComponent',
+  dataHook: 'story-my-new-component',
+  testStoryNames: {
+    DEFAULT: 'Default',
+  },
+};
+",
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`copyTemplates should work as expected when description is not provided 1`] = `
 Object {
   "test-generated": Object {

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/copy-templates.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/copy-templates.spec.ts
@@ -44,4 +44,26 @@ describe('copyTemplates', () => {
 
     expect(output).toMatchSnapshot();
   });
+
+  describe('given template with lower case `component`', () => {
+    it('should rename `component` to given component name but in kebab-case ', async () => {
+      const fakeFs = cista();
+      await copyTemplates({
+        ComponentName: 'MyNewComponent',
+        description: undefined,
+        templates: path.join(__dirname, 'templates-kebab-case'),
+        _process: {
+          cwd: fakeFs.dir,
+        },
+      });
+
+      const output = await fsToJson({
+        path: '.',
+        cwd: fakeFs.dir,
+        withContent: true,
+      });
+
+      expect(output).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/copy-templates.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/copy-templates.spec.ts
@@ -1,71 +1,47 @@
-import * as fs from 'fs';
 import * as path from 'path';
-import * as tempy from 'tempy';
-import globby from 'globby';
-import * as logger from '../../../logger';
+import * as cista from 'cista';
+import { fsToJson } from '../../../fs-to-json';
+
 import { copyTemplates } from '../tasks/copy-templates';
 
-// Extracted from
-// https://github.com/wix/yoshi/blob/master/packages/create-yoshi-app/src/getFilesInDir.js
-const getDirSnapshot = absoluteDirPath => {
-  const filesPaths = globby.sync(['**/*', '!node_modules'], {
-    cwd: absoluteDirPath,
-    dot: true,
-    gitignore: true,
-  });
-
-  const files = {};
-
-  filesPaths.forEach(filePath => {
-    const content = fs.readFileSync(
-      path.join(absoluteDirPath, filePath),
-      'utf-8',
-    );
-
-    files[filePath] = content;
-  });
-
-  return files;
-};
-
 describe('copyTemplates', () => {
-  let succesSpy;
-  let tempDir;
-
-  beforeEach(() => {
-    tempDir = tempy.directory();
-
-    // Silent logs
-    succesSpy = jest.spyOn(logger, 'success').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    succesSpy.mockRestore();
-  });
-
   it('should work as expected when description is provided', async () => {
+    const fakeFs = cista();
     await copyTemplates({
       ComponentName: 'MyNewComponent',
       description: 'This is a very cool component, yall',
       templates: path.join(__dirname, 'templates'),
       _process: {
-        cwd: tempDir,
+        cwd: fakeFs.dir,
       },
     });
 
-    expect(getDirSnapshot(tempDir)).toMatchSnapshot();
+    const output = await fsToJson({
+      path: '.',
+      cwd: fakeFs.dir,
+      withContent: true,
+    });
+
+    expect(output).toMatchSnapshot();
   });
 
   it('should work as expected when description is not provided', async () => {
+    const fakeFs = cista();
     await copyTemplates({
       ComponentName: 'MyNewComponent',
       description: undefined,
       templates: path.join(__dirname, 'templates'),
       _process: {
-        cwd: tempDir,
+        cwd: fakeFs.dir,
       },
     });
 
-    expect(getDirSnapshot(tempDir)).toMatchSnapshot();
+    const output = await fsToJson({
+      path: '.',
+      cwd: fakeFs.dir,
+      withContent: true,
+    });
+
+    expect(output).toMatchSnapshot();
   });
 });

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/component-name.meta.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/component-name.meta.js
@@ -1,0 +1,8 @@
+import {%ComponentName%} from './{%component-name%}';
+import Registry from '@ui-autotools/registry';
+
+const metadata = Registry.getComponentMetadata({%ComponentName%});
+
+metadata.exportedFrom({
+  path: 'src/{%component-name%}/{%component-name%}.js',
+});

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/component-name.st.css
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/component-name.st.css
@@ -1,0 +1,25 @@
+:import {
+  -st-from: "wix-ui-core/dist/src/themes/backoffice/colors.st.css";
+  -st-named: G30,R30;
+}
+
+.root {
+  text-align: center;
+}
+
+.number {
+  -st-states: odd, even;
+}
+
+.number:even {
+  background: value(G30);
+}
+
+.number:odd {
+  background: value(R30);
+}
+
+.button {
+  display: flex;
+  justify-content: space-evenly;
+}

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/component-name.uni.driver.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/component-name.uni.driver.js
@@ -1,0 +1,19 @@
+import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
+
+export const {%componentName%}DriverFactory = base => {
+  return {
+    ...baseUniDriverFactory(base),
+
+    /** Get the current count */
+    getCountText: async () =>
+      base.$('[data-hook="{%componentName%}-count"]').text(),
+
+    /** Click the button */
+    clickButton: async () =>
+      base.$('[data-hook="{%componentName%}-button"]').click(),
+
+    /** Get the button's text */
+    getButtonText: async () =>
+      base.$('[data-hook="{%componentName%}-button"]').text(),
+  };
+};

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/component.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/component.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Text from '../Text';
+import Button from '../Button';
+import styles from './{%component-name%}.st.css';
+
+/** {%description%} */
+class {%ComponentName%} extends React.PureComponent {
+  static displayName = '{%ComponentName%}';
+
+  static propTypes = {
+    dataHook: PropTypes.string,
+
+    /** Text for the button */
+    buttonText: PropTypes.string,
+  };
+
+  static defaultProps = {
+    buttonText: 'Click me!',
+  };
+
+  state = {
+    count: 0,
+  };
+
+  _handleClick = () => {
+    this.setState(({ count }) => ({
+      count: count + 1,
+    }));
+  };
+
+  render() {
+    const { count } = this.state;
+    const { dataHook, buttonText } = this.props;
+    const isEven = count % 2 === 0;
+
+    return (
+      <div className={styles.root} data-hook={dataHook}>
+        <Text dataHook="{%componentName%}-count">
+          You clicked this button {isEven ? 'even' : 'odd'} number (
+          <span
+            {...styles('number', { even: isEven, odd: !isEven }, this.props)}
+          >
+            {count}
+          </span>
+          ) of times
+        </Text>
+
+        <div className={styles.button}>
+          <Button
+            onClick={this._handleClick}
+            dataHook="{%componentName%}-button"
+          >
+            {buttonText}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default {%ComponentName%};

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/docs/index.story.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/docs/index.story.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import {
+  header,
+  tabs,
+  tab,
+  description,
+  importExample,
+  title,
+  columns,
+  divider,
+  code as baseCode,
+  playground,
+  api,
+  testkit,
+} from 'wix-storybook-utils/Sections';
+
+import { storySettings } from '../test/storySettings';
+import allComponents from '../../../stories/utils/allComponents';
+
+import {%ComponentName%} from '..';
+
+const code = config => baseCode({ components: allComponents, ...config });
+
+export default {
+  category: storySettings.category,
+  storyName: '{%ComponentName%}',
+
+  component: {%ComponentName%},
+  componentPath: '..',
+
+  componentProps: {
+    buttonText: 'Hello World!',
+  },
+
+  exampleProps: {
+    // Put here presets of props, for more info:
+    // https://github.com/wix/wix-ui/blob/master/packages/wix-storybook-utils/docs/usage.md#using-list
+  },
+
+  sections: [
+    header({
+      issueUrl: 'https://github.com/wix/wix-style-react/issues/new',
+      sourceUrl:
+        'https://github.com/wix/wix-style-react/tree/master/src/{%ComponentName%}/',
+      component: <{%ComponentName%} buttonText="Click me!" />,
+    }),
+
+    tabs([
+      tab({
+        title: 'Description',
+        sections: [
+          columns([
+            description({
+              title: 'Description',
+              text:
+                'This line here should briefly describe component in just a sentence or two. It should be short and easy to read.',
+            }),
+          ]),
+
+          columns([
+            importExample(
+              "import {%ComponentName%} from 'wix-style-react/{%ComponentName%}';",
+            ),
+          ]),
+
+          divider(),
+
+          title('Examples'),
+
+          columns([
+            description({
+              title: 'Simple Usage',
+              text: 'A simple example with compact preview',
+            }),
+
+            code({
+              compact: true,
+              source: '<{%ComponentName%} buttonText="Hello World!"/>',
+            }),
+          ]),
+
+          code({
+            title: 'Full Interactive Preview',
+            description: 'A non compact version of same code example as above',
+            source: '<{%ComponentName%} buttonText="Hello World!"/>',
+          }),
+        ],
+      }),
+
+      ...[
+        { title: 'API', sections: [api()] },
+        { title: 'Testkit', sections: [testkit()] },
+        { title: 'Playground', sections: [playground()] },
+      ].map(tab),
+    ]),
+  ],
+};

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/index.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/index.js
@@ -1,0 +1,1 @@
+export { default } from './{%component-name%}.js';

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-name.e2e.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-name.e2e.js
@@ -1,0 +1,38 @@
+import {
+  waitForVisibilityOf,
+  scrollToElement,
+} from 'wix-ui-test-utils/protractor';
+
+import { eyesItInstance } from '../../../test/utils/eyes-it';
+import { createTestStoryUrl } from '../../../test/utils/storybook-helpers';
+import { {%componentName%}TestkitFactory } from '../../../testkit/protractor';
+import { storySettings } from './storySettings';
+
+const eyes = eyesItInstance();
+
+describe('{%ComponentName%}', () => {
+  const createStoryUrl = testName =>
+    createTestStoryUrl({ ...storySettings, testName });
+
+  const createDriver = async (dataHook = storySettings.dataHook) => {
+    const driver = {%componentName%}TestkitFactory({ dataHook });
+
+    await waitForVisibilityOf(
+      await driver.element(),
+      `Cannot find <{%ComponentName%}/> component with dataHook of ${dataHook}`,
+    );
+
+    await scrollToElement(await driver.element());
+
+    return driver;
+  };
+
+  const testStoryNames = storySettings.testStoryNames;
+
+  eyes.it('should increase count when button clicked', async () => {
+    await browser.get(createStoryUrl(testStoryNames.DEFAULT));
+    const driver = await createDriver();
+    await driver.clickButton();
+    expect(await driver.getCountText()).toBe('You clicked this button odd number (1) of times');
+  });
+});

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-name.private.uni.driver.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-name.private.uni.driver.js
@@ -1,0 +1,9 @@
+import { {%componentName%}DriverFactory as publicDriverFactory } from '../{%component-name%}.uni.driver';
+
+export const {%componentName%}PrivateDriverFactory = base => {
+  return {
+    ...publicDriverFactory(base),
+
+    // Add here driver methods that considered "private"
+  };
+};

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-name.spec.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-name.spec.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { createRendererWithUniDriver, cleanup } from '../../../test/utils/unit';
+
+import {%ComponentName%} from '../{%component-name%}';
+import { {%componentName%}PrivateDriverFactory } from './{%component-name%}.private.uni.driver';
+
+describe('{%ComponentName%}', () => {
+  const render = createRendererWithUniDriver(
+    {%componentName%}PrivateDriverFactory,
+  );
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render', async () => {
+    const { driver } = render(<{%ComponentName%} />);
+
+    expect(await driver.exists()).toBeTruthy();
+    expect(await driver.getButtonText()).toEqual('Click me!');
+  });
+
+  it('should increment', async () => {
+    const { driver } = render(<{%ComponentName%} />);
+
+    await driver.clickButton();
+    await driver.clickButton();
+
+    expect(await driver.getCountText()).toEqual(
+      'You clicked this button even number (2) of times',
+    );
+  });
+
+  it('should allow changing the button text', async () => {
+    const { driver } = render(<{%ComponentName%} buttonText="Press me" />);
+
+    expect(await driver.getButtonText()).toEqual('Press me');
+  });
+});

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-name.visual.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-name.visual.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import {%ComponentName%} from '../{%component-name%}';
+
+const commonProps = {
+  //use for repeated props across the tests (e.g. {buttonText: 'example'})
+};
+
+const tests = [
+  {
+    describe: 'sanity', // prop name (e.g. size)
+    its: [
+      {
+        it: 'default', //prop vaiation (e.g. small)
+        props: {
+          // the simulation (e.g. {size: "small"})
+        },
+      },
+    ],
+  },
+];
+
+tests.forEach(({ describe, its }) => {
+  its.forEach(({ it, props }) => {
+    storiesOf(`{%ComponentName%}/${describe}`, module).add(it, () => (
+      <{%ComponentName%} {...commonProps} {...props} />
+    ));
+  });
+});

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-nameStories.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/component-nameStories.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { getTestStoryKind } from '../../../stories/storiesHierarchy';
+import { storySettings } from './storySettings';
+
+import {%ComponentName%} from '..';
+
+const TestStories = storiesOf(getTestStoryKind(storySettings), module);
+const { testStoryNames, dataHook } = storySettings;
+
+TestStories.add(testStoryNames.DEFAULT, () => (
+  <{%ComponentName%}
+    dataHook={dataHook}
+    buttonText="Press me for a surprise"
+  />
+));

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/storySettings.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/component-name/test/storySettings.js
@@ -1,0 +1,10 @@
+import { Category } from '../../../stories/storiesHierarchy';
+
+export const storySettings = {
+  category: Category.COMPONENTS,
+  storyName: '{%ComponentName%}',
+  dataHook: 'story-{%component-name%}',
+  testStoryNames: {
+    DEFAULT: 'Default',
+  },
+};

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/index.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/templates-kebab-case/test-generated/src/index.js
@@ -1,0 +1,1 @@
+// explicit test file

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/verify-working-directory.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/verify-working-directory.spec.ts
@@ -1,4 +1,4 @@
-import * as tempy from 'tempy';
+import * as cista from 'cista';
 
 import * as logger from '../../../logger';
 import * as utils from '../utils';
@@ -38,7 +38,8 @@ describe('verifyWorkingDirectory', () => {
   it('should not fail when git repo is clean', async () => {
     mockGitStatus(true);
 
-    await verifyWorkingDirectory(tempy.directory());
+    const fakeFs = cista();
+    await verifyWorkingDirectory(fakeFs.dir);
 
     expect(errorSpy).not.toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
@@ -47,7 +48,8 @@ describe('verifyWorkingDirectory', () => {
   it('should fail when git repo is dirty', async () => {
     mockGitStatus(false);
 
-    await verifyWorkingDirectory(tempy.directory());
+    const fakeFs = cista();
+    await verifyWorkingDirectory(fakeFs.dir);
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(errorSpy).toHaveBeenCalledWith(errorMessage);

--- a/packages/wix-ui-framework/src/cli-commands/generate/index.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/index.spec.ts
@@ -64,7 +64,7 @@ describe('generate', () => {
       });
 
       // set permissions for fake jscodeshift so that we're able to execute and write to file
-      fs.chmodSync(`${fakeFs.dir}/node_modules/.bin/jscodeshift`, 0o500); // read and execute
+      fs.chmodSync(`${fakeFs.dir}/node_modules/.bin/jscodeshift`, 0o500); // read & execute
       fs.chmodSync(`${fakeFs.dir}/assert-file`, 0o600); // read & write
 
       await generate({


### PR DESCRIPTION
This PR allows to use `component-name` string in file names of `wuf
generate` templates.

This makes it possible to generate components with kebab-case naming convention, very much like wix-ui-core does

---

PR diff is big, because i added test fixtures