### PR TITLE
wix-ui-framework: support `component-name` in component generator codemods

### DIFF
--- a/packages/wix-ui-framework/CHANGELOG.md
+++ b/packages/wix-ui-framework/CHANGELOG.md
@@ -11,6 +11,10 @@ Types of changes:
 1. **Fixed** for any bug fixes.
 1. **Security** in case of vulnerabilities.
 
+# 3.3.1 - 17:17:53
+## Added
+- `wuf generate` - support `component-name` in generator codemod options
+
 # 3.3.0 - 2019-09-20
 ## Added
 - `wuf generate` - support `component-name` in template files to generate kebab-case

--- a/packages/wix-ui-framework/package.json
+++ b/packages/wix-ui-framework/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "wuf": "./bin/wuf.js"
   },
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Wix",
     "email": "fed-infra@wix.com"

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/codemods/stories-file-kebab.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/codemods/stories-file-kebab.js
@@ -1,0 +1,11 @@
+module.exports = (file, api, options) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  root.get().node.program.body.push(
+    `// TODO: move to correct position
+import '../src/${options['component-name']}/docs/index.story';`,
+  );
+
+  return root.toSource();
+};

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/run-codemods.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/run-codemods.spec.ts
@@ -3,9 +3,17 @@ const defineTest = require('jscodeshift/dist/testUtils').defineTest;
 const options = {
   ComponentName: 'MyNewComponent',
   componentName: 'myNewComponent',
+  'component-name': 'my-new-component',
 };
 
 defineTest(__dirname, '__test__/codemods/stories-file', options, 'stories');
+
+defineTest(
+  __dirname,
+  '__test__/codemods/stories-file-kebab',
+  options,
+  'stories-with-kebab',
+);
 
 defineTest(__dirname, '__test__/codemods/index-file', options, 'index');
 

--- a/packages/wix-ui-framework/src/cli-commands/generate/__testfixtures__/stories-with-kebab.input.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__testfixtures__/stories-with-kebab.input.js
@@ -1,0 +1,12 @@
+/**
+ * Storybook list of stories
+ *
+ * This is a file fixture used to test the stories.js codemod.
+ */
+
+import './Introduction';
+import './Playground/Playground';
+
+// 1. Foundations
+import '../src/Typography/docs/index.story'; // 1.2 Typography
+import '../src/new-icons/docs'; // 1.4 Icons

--- a/packages/wix-ui-framework/src/cli-commands/generate/__testfixtures__/stories-with-kebab.output.js
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__testfixtures__/stories-with-kebab.output.js
@@ -1,0 +1,15 @@
+/**
+ * Storybook list of stories
+ *
+ * This is a file fixture used to test the stories.js codemod.
+ */
+
+import './Introduction';
+import './Playground/Playground';
+
+// 1. Foundations
+import '../src/Typography/docs/index.story'; // 1.2 Typography
+import '../src/new-icons/docs'; // 1.4 Icons
+
+// TODO: move to correct position
+import '../src/my-new-component/docs/index.story';

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-codemods.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-codemods.ts
@@ -33,6 +33,7 @@ const runCodemod: ({
       -t ${codemodPath} \
       --ComponentName=${codemodValues.ComponentName} \
       --componentName=${codemodValues.componentName} \
+      --component-name=${codemodValues['component-name']} \
       --verbose=2`;
 
     const execProc = exec(command);


### PR DESCRIPTION
This PR adds support for `options['component-name']`.

It allows codemods that are run during component generation to use
kebab-case name of the component

needed for wix-ui-core