### PR TITLE
InputWithOptions - allow input arrow navigation.

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
@@ -130,7 +130,6 @@ export class DropdownContent extends React.PureComponent<
       }
       case 'ArrowLeft':
       case 'ArrowRight': {
-        evt.preventDefault();
         return;
       }
       default:

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
@@ -80,19 +80,6 @@ describe('Dropdown', () => {
       );
       expect(preventDefaultSpy).toHaveBeenCalled();
       preventDefaultSpy.mockClear();
-
-      Simulate.keyDown(
-        document.querySelector('[data-hook="open-dropdown-button"]'),
-        { key: 'ArrowLeft', preventDefault: preventDefaultSpy },
-      );
-      expect(preventDefaultSpy).toHaveBeenCalled();
-      preventDefaultSpy.mockClear();
-
-      Simulate.keyDown(
-        document.querySelector('[data-hook="open-dropdown-button"]'),
-        { key: 'ArrowRight', preventDefault: preventDefaultSpy },
-      );
-      expect(preventDefaultSpy).toHaveBeenCalled();
     });
 
     it('should show content on hover', async () => {


### PR DESCRIPTION
- Don't prevent default in ArrowLeft/ArrowRight

Closes - https://jira.wixpress.com/browse/ECL-58?filter=-1