### PR TITLE
wix-ui-test-utils - factory creators - add options parameter with dataHook passed

### DIFF
--- a/packages/wix-ui-test-utils/src/protractor/protractor.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor.ts
@@ -4,22 +4,30 @@ import {UniDriver} from '@unidriver/core';
 import {BaseUniDriver} from '../base-driver';
 
 export function protractorTestkitFactoryCreator<T>(
-  driverFactory: (e: ElementFinder) => T
+  driverFactory: (wrapper: ElementFinder, body: ElementFinder) => T
 ) {
-  return (obj: {dataHook: string; wrapper?: ElementFinder}) =>
-    obj.wrapper
-      ? driverFactory(obj.wrapper.$(`[data-hook='${obj.dataHook}']`))
-      : driverFactory($(`[data-hook='${obj.dataHook}']`));
+  return (obj: { dataHook: string; wrapper?: ElementFinder }) => {
+    const wrapper =
+      obj.wrapper && obj.wrapper.$(`[data-hook='${obj.dataHook}']`);
+    const body = $('body');
+    return wrapper
+      ? driverFactory(wrapper, body)
+      : driverFactory(body.$(`[data-hook='${obj.dataHook}']`), body);
+  };
 }
 
 export function protractorUniTestkitFactoryCreator<T extends BaseUniDriver>(
-  driverFactory: (base: UniDriver, body: UniDriver) => T
+  driverFactory: (
+    base: UniDriver,
+    body: UniDriver,
+    options: { dataHook: string }
+  ) => T
 ) {
-  return (obj: {dataHook: string}) => {
+  return (obj: { dataHook: string }) => {
     const base = protractorUniDriver(
       async () => await $(`[data-hook='${obj.dataHook}']`)
     );
     const body = protractorUniDriver(async () => await $('body'));
-    return driverFactory(base, body);
+    return driverFactory(base, body, {dataHook: obj.dataHook});
   };
 }

--- a/packages/wix-ui-test-utils/src/protractor/protractor.ts
+++ b/packages/wix-ui-test-utils/src/protractor/protractor.ts
@@ -4,15 +4,23 @@ import {UniDriver} from '@unidriver/core';
 import {BaseUniDriver} from '../base-driver';
 
 export function protractorTestkitFactoryCreator<T>(
-  driverFactory: (wrapper: ElementFinder, body: ElementFinder) => T
+  driverFactory: (
+    wrapper: ElementFinder,
+    body: ElementFinder,
+    options: { dataHook: string }
+  ) => T
 ) {
   return (obj: { dataHook: string; wrapper?: ElementFinder }) => {
     const wrapper =
       obj.wrapper && obj.wrapper.$(`[data-hook='${obj.dataHook}']`);
     const body = $('body');
     return wrapper
-      ? driverFactory(wrapper, body)
-      : driverFactory(body.$(`[data-hook='${obj.dataHook}']`), body);
+      ? driverFactory(wrapper, body, {
+          dataHook: obj.dataHook,
+        })
+      : driverFactory(body.$(`[data-hook='${obj.dataHook}']`), body, {
+          dataHook: obj.dataHook,
+        });
   };
 }
 

--- a/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
+++ b/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
@@ -6,16 +6,27 @@ import {pupUniDriver} from '@unidriver/puppeteer';
 export function puppeteerTestkitFactoryCreator<T>(
   driverFactory: (e: ElementHandle | null, page: Page) => T
 ) {
-  return async (obj: {dataHook: string; page: Page}) =>
+  return async (obj: {
+    dataHook: string;
+    page: Page;
+    options: { dataHook: string };
+  }) =>
     driverFactory(await obj.page.$(`[data-hook='${obj.dataHook}']`), obj.page);
 }
 
 export function puppeteerUniTestkitFactoryCreator<T extends BaseUniDriver>(
-  driverFactory: (base: UniDriver, body: UniDriver) => T
+  driverFactory: (
+    base: UniDriver,
+    body: UniDriver,
+    options: { dataHook: string }
+  ) => T
 ) {
-  return async (obj: {dataHook: string; page: Page}) => {
-    const base = pupUniDriver({page: obj.page, selector: `[data-hook='${obj.dataHook}']`});
+  return async (obj: { dataHook: string; page: Page }) => {
+    const base = pupUniDriver({
+      page: obj.page,
+      selector: `[data-hook='${obj.dataHook}']`,
+    });
     const body = pupUniDriver({page: obj.page, selector: 'body'});
-    return driverFactory(base, body);
+    return driverFactory(base, body, {dataHook: obj.dataHook});
   };
 }

--- a/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
+++ b/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
@@ -4,14 +4,16 @@ import {UniDriver} from '@unidriver/core';
 import {pupUniDriver} from '@unidriver/puppeteer';
 
 export function puppeteerTestkitFactoryCreator<T>(
-  driverFactory: (e: ElementHandle | null, page: Page) => T
+  driverFactory: (
+    e: ElementHandle | null,
+    page: Page,
+    options: { dataHook: string }
+  ) => T
 ) {
-  return async (obj: {
-    dataHook: string;
-    page: Page;
-    options: { dataHook: string };
-  }) =>
-    driverFactory(await obj.page.$(`[data-hook='${obj.dataHook}']`), obj.page);
+  return async (obj: { dataHook: string; page: Page }) =>
+    driverFactory(await obj.page.$(`[data-hook='${obj.dataHook}']`), obj.page, {
+      dataHook: obj.dataHook,
+    });
 }
 
 export function puppeteerUniTestkitFactoryCreator<T extends BaseUniDriver>(

--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -21,7 +21,7 @@ export type TestkitOutputRegular<T extends BaseDriver> = (data: {
   dataHook: string;
 }) => T;
 
-export type TestkitOutputUni<T extends BaseDriver> = (
+export type TestkitOutputUni<T extends BaseUniDriver> = (
   base: UniDriver,
   body: UniDriver,
   options: { dataHook: string }

--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -1,16 +1,31 @@
 import * as React from 'react';
 import * as ReactDom from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import {renderIntoDocument, Simulate} from 'react-dom/test-utils';
+
 import {reactEventTrigger} from '../react-helpers';
-import {DriverFactory, BaseDriver} from '../driver-factory';
+import {BaseDriver} from '../driver-factory';
 import {BaseUniDriver} from '../base-driver';
-import {UniDriverFactory} from '../uni-driver-factory';
+
+import {UniDriver} from '@unidriver/core';
 import {jsdomReactUniDriver} from '@unidriver/jsdom-react';
 
 export interface TestkitArgs {
   wrapper: HTMLElement;
   dataHook: string;
 }
+
+export type TestkitOutputRegular<T extends BaseDriver> = (data: {
+  element: Element | undefined;
+  wrapper: HTMLElement;
+  eventTrigger: typeof Simulate;
+  dataHook: string;
+}) => T;
+
+export type TestkitOutputUni<T extends BaseDriver> = (
+  base: UniDriver,
+  body: UniDriver,
+  options: { dataHook: string }
+) => T;
 
 const getElement = ({wrapper, dataHook}: TestkitArgs) => {
   const domInstance = ReactDom.findDOMNode(wrapper) as HTMLElement;
@@ -27,22 +42,27 @@ const getElement = ({wrapper, dataHook}: TestkitArgs) => {
 };
 
 export function testkitFactoryCreator<T extends BaseDriver>(
-  driverFactory: DriverFactory<T>
+  driverFactory: TestkitOutputRegular<T>
 ) {
   return (testkitArgs: TestkitArgs) =>
     driverFactory({
       element: getElement(testkitArgs) as Element,
       wrapper: testkitArgs.wrapper,
-      eventTrigger: reactEventTrigger()
+      eventTrigger: reactEventTrigger(),
+      dataHook: testkitArgs.dataHook,
     });
 }
 
 export function uniTestkitFactoryCreator<T extends BaseUniDriver>(
-  driverFactory: UniDriverFactory<T>
+  driverFactory: TestkitOutputUni<T>
 ) {
   return (testkitArgs: TestkitArgs) => {
     const element = getElement(testkitArgs) as Element;
-    return driverFactory(jsdomReactUniDriver(element), jsdomReactUniDriver(document.body));
+    return driverFactory(
+      jsdomReactUniDriver(element),
+      jsdomReactUniDriver(document.body),
+      {dataHook: testkitArgs.dataHook}
+    );
   };
 }
 
@@ -58,9 +78,7 @@ export function isTestkitExists<T extends BaseDriver>(
     ? {[dataHookPropName]: dataHook}
     : {'data-hook': dataHook, dataHook}; // For backward compatibility add dataHook which is used in Wix-Style-React
   const elementToRender = React.cloneElement(Element, extraProps);
-  const renderedElement = ReactTestUtils.renderIntoDocument(
-    <div>{elementToRender}</div>
-  );
+  const renderedElement = renderIntoDocument(<div>{elementToRender}</div>);
   const wrapper = div.appendChild(renderedElement as any);
   const testkit = testkitFactory({wrapper, dataHook});
   return testkit.exists();
@@ -78,9 +96,7 @@ export async function isUniTestkitExists<T extends BaseUniDriver>(
     ? {[dataHookPropName]: dataHook}
     : {'data-hook': dataHook, dataHook};
   const elementToRender = React.cloneElement(Element, extraProps);
-  const renderedElement = ReactTestUtils.renderIntoDocument(
-    <div>{elementToRender}</div>
-  );
+  const renderedElement = renderIntoDocument(<div>{elementToRender}</div>);
   const wrapper = div.appendChild(renderedElement as any);
   const testkit = testkitFactory({wrapper, dataHook});
   return await testkit.exists();


### PR DESCRIPTION
This PR is adding a third argument in unidriver and additional argument in regular on all factory creators in order to use dataHook in our tests as unique identifier not only for the whole component but also for internal components. In order to avoid issues like this: https://github.com/wix/wix-style-react/issues/4191
 