### PR TITLE
<AutoExample/> - Fix [object Object] in a list prop

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/components/list.js
+++ b/packages/wix-storybook-utils/src/AutoExample/components/list.js
@@ -6,7 +6,7 @@ import Dropdown from '../../ui/dropdown';
 import RadioGroup from '../../ui/radio-group';
 import Button from '../../ui/button';
 
-import NO_VALUE_TYPE from '../../AutoExample/no-value-type';
+import NO_VALUE_TYPE from '../no-value-type';
 
 const isThing = type => thing => typeof thing === type; // eslint-disable-line
 const isUndefined = isThing('undefined');
@@ -44,7 +44,8 @@ export default class List extends React.Component {
 
   createOptions = values =>
     values.map((option, id) => {
-      option = option || {};
+      if (typeof option !== 'string') option = option || {};
+
       return {
         id: option.id || id,
 


### PR DESCRIPTION
For example when there's a prop like this:
`type: PropTypes.oneOf([
    '',
    'compact',
    'compactSide',
    'uniformSide',
    'uniformFull',
  ]),`

The docs looks like this:
![Screen Shot 2019-10-15 at 17 41 23](https://user-images.githubusercontent.com/35173937/66842483-06276280-ef74-11e9-8fa7-30a10771f027.png)

Adding a check for a string value fix the problem