### PR TITLE
prevent default for enter click event when select dropdown option

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -177,6 +177,7 @@ export class DropdownComponent extends React.PureComponent<
           this.onKeyboardSelect();
           const { multi } = this.props;
           !multi && this.close();
+          evt.preventDefault();
           break;
         }
         case 'Tab': {


### PR DESCRIPTION
Fixed bug when  `onSelect` triggered by keyboard (by Enter key) and if component is inside form -- form will be submitted 