### PR TITLE
wix-ui-core: fix appveyor/windows build

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -65,8 +65,8 @@
     "build-standalone": "node scripts/build-standalone.js",
     "build-puppeteer-testkits": "webpack --config ./scripts/puppeteer.webpack.config.js",
     "test:browser": "wix-ui-mocha-runner",
-    "update-components": ".wuf/update-components.sh",
-    "update-components-standalone": ".wuf/update-components-standalone.sh"
+    "update-components": "bash .wuf/update-components.sh",
+    "update-components-standalone": "bash .wuf/update-components-standalone.sh"
   },
   "dependencies": {
     "@stylable/dom-test-kit": "^0.1.0",


### PR DESCRIPTION
fixes errors like [this](https://ci.appveyor.com/project/AlexShemeshWix/wix-ui-yi3yp/builds/28210629):

```
'.wuf' is not recognized as an internal or external command, operable program or batch file.
```