### PR TITLE
wix-storybook-utils: fix(function-to-string): guard `ensureShorthandProperties`

### DIFF
--- a/packages/wix-storybook-utils/src/ComponentSource/function-to-string.js
+++ b/packages/wix-storybook-utils/src/ComponentSource/function-to-string.js
@@ -41,11 +41,13 @@ const functionToString = prop => {
       ? ast.body.body[0].argument
       : ast.body;
 
-  ensureShorthandProperties({
-    ast: arrowFunctionBody,
-    parentPath: ast,
-    scope: ast,
-  });
+  try {
+    ensureShorthandProperties({
+      ast: arrowFunctionBody,
+      parentPath: ast,
+      scope: ast,
+    });
+  } catch (e) {}
 
   const arrowFuncExpr = types.arrowFunctionExpression(
     ast.params,


### PR DESCRIPTION
ocasionally transpilled storybook yields `Couldn't find a Program` error.

Does not happen on local environment.

This is a quick fix in order to avoid traversing the whole ast.
`function-to-string` feature isn't too important anyway.