### PR TITLE
wix-ui-core: lint project and add "pretest": "npm run lint"

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -42,6 +42,7 @@
     "prebuild": "npm run update-components && npm run update-components-standalone",
     "build": "npm run build:named-exports && yoshi build && (npm run generate-stylable-components | npm run generate-es-stylable-components) && npm run generate-stylable-hocs && npm run transpile-mixins && (npm run import-path | npm run build:named-exports) && build-storybook && npm run build-standalone && npm run build-puppeteer-testkits",
     "pr-postbuild": "npm install teamcity-surge-autorelease@^1.0.0 --no-save && teamcity-surge-autorelease",
+    "pretest": "npm run lint",
     "test": "npm run test:unit && npm run test:e2e && npm run sanity && npm run a11y",
     "test:watch": "yoshi test --jest --watch",
     "test:unit": "yoshi test --jest && wix-ui-mocha-runner",

--- a/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsBasicClient.spec.ts
+++ b/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsBasicClient.spec.ts
@@ -128,8 +128,8 @@ describe('GoogleMapsBasicClient', () => {
       client.loadScript(CLIENT_ID, LANG);
       const firstCall = appendChildSpy.mock.calls[0][0];
       expect(firstCall.src.indexOf(EXPECTED_CLIENT_URL)).not.toBe(-1);
-    })
-  })
+    });
+  });
 
   describe('Functionality', () => {
     describe('autocomplete', () => {

--- a/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsBasicClient.ts
+++ b/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsBasicClient.ts
@@ -31,7 +31,6 @@ const serializeResult = results => ({
 
 // placeDetails is not required at the moment
 export class GoogleMapsBasicClient implements Omit<MapsClient, 'placeDetails'> {
-  
   private _autocomplete;
   private _geocoder;
   private _loadScriptPromise;

--- a/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsIframeClient.e2e.ts
+++ b/packages/wix-ui-core/src/clients/GoogleMaps/GoogleMapsIframeClient.e2e.ts
@@ -1,11 +1,17 @@
 import { browser } from 'protractor';
 
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { googleMapsIframeClientTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 describe('Google Maps Iframe client', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'GoogleMapsIframeClient');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'GoogleMapsIframeClient',
+  });
   const dataHook = 'story-google-maps-iframe-client';
   const searchTest = 'Broadway';
   const broadwayPlaceId = 'ChIJOSMjjVlWwokRnpaTPyaFi9o';

--- a/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
@@ -1182,13 +1182,13 @@ describe('AddressInput', () => {
       const onBlur = jest.fn();
       GoogleMapsClientStub.setAddresses([helper.ADDRESS_1, helper.ADDRESS_2]);
       GoogleMapsClientStub.setGeocode(helper.GEOCODE_1);
-      init({onBlur});
+      init({ onBlur });
       driver.click();
       driver.setValue('n');
       await waitForCond(() => driver.isContentElementExists());
       driver.triggerMouseDownOnDropdownContent();
       expect(onBlur).not.toHaveBeenCalled();
-    })
+    });
   });
 
   describe('testkit', () => {

--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.e2e.ts
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.e2e.ts
@@ -1,12 +1,17 @@
 import * as eyes from 'eyes.it';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { autocompleteTestkitFactory } from '../../testkit/protractor';
 import { browser } from 'protractor';
-import * as eventually from 'wix-eventually';
 import { Category } from '../../../stories/utils';
 
 describe('Autocomplete', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Autocomplete');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Autocomplete',
+  });
   const dataHook = 'storybook-autocomplete';
 
   beforeEach(() => browser.get(storyUrl));

--- a/packages/wix-ui-core/src/components/button-next/button-next.meta.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.meta.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ButtonNext } from '.';
-import More from 'wix-ui-icons-common/More'
+import More from 'wix-ui-icons-common/More';
 import Registry from '@ui-autotools/registry';
 
 const buttonMetadata = Registry.getComponentMetadata(ButtonNext);

--- a/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.spec.tsx
@@ -31,7 +31,7 @@ describe('ButtonNext', () => {
   describe('"focus" method', () => {
     it('should allow to focus on button using the focus method on its ref', async () => {
       const ref = React.createRef<any>();
-      const driver = await createDriver(<ButtonNext ref={ref}/>);
+      const driver = await createDriver(<ButtonNext ref={ref} />);
       expect(await driver.isFocused()).toEqual(false);
       ref.current.focus();
       expect(await driver.isFocused()).toEqual(true);

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 
 import style from './button-next.st.css';
-import {isStatelessComponent} from "../../utils";
+import { isStatelessComponent } from '../../utils';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -59,7 +59,8 @@ class ButtonNextComponent extends React.Component<ButtonProps> {
     } = this.props;
     const htmlTabIndex = disabled ? -1 : rest.tabIndex || 0;
     const htmlHref = disabled ? undefined : href;
-    const reference = isStatelessComponent(Component) && typeof Component !== 'string'
+    const reference =
+      isStatelessComponent(Component) && typeof Component !== 'string'
         ? undefined
         : ref => (this.innerComponentRef = ref);
 

--- a/packages/wix-ui-core/src/components/button-next/button-next.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.uni.driver.ts
@@ -14,11 +14,11 @@ export interface ButtonNextDriver extends BaseUniDriver {
 }
 
 export const buttonNextDriverFactory = (base: UniDriver): ButtonNextDriver => ({
-    ...baseUniDriverFactory(base),
-    getButtonTextContent: async () => base.text(),
-    isFocused: async () => document.activeElement === await base.getNative(),
-    isButtonDisabled: async () => {
-       //Using aria-disabled to know if button is disabled.
-       return (await base.attr('aria-disabled')) === 'true';
-    },
+  ...baseUniDriverFactory(base),
+  getButtonTextContent: async () => base.text(),
+  isFocused: async () => document.activeElement === (await base.getNative()),
+  isButtonDisabled: async () => {
+    //Using aria-disabled to know if button is disabled.
+    return (await base.attr('aria-disabled')) === 'true';
+  },
 });

--- a/packages/wix-ui-core/src/components/captcha/Captcha.e2e.ts
+++ b/packages/wix-ui-core/src/components/captcha/Captcha.e2e.ts
@@ -19,7 +19,10 @@ const captchaTestInstanceFactory = protractorUniTestkitFactoryCreator<
 >(CaptchaTestInstanceDriverFactory);
 
 describe('Captcha', () => {
-  const storyUrl = createStoryUrl({ kind: Category.COMPONENTS, story: 'Captcha' });
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Captcha',
+  });
 
   beforeAll(async () => {
     await browser.get(storyUrl);

--- a/packages/wix-ui-core/src/components/captcha/test-assets/CaptchaTestComponent.testDriver.ts
+++ b/packages/wix-ui-core/src/components/captcha/test-assets/CaptchaTestComponent.testDriver.ts
@@ -1,6 +1,6 @@
-import {browser, $, $$} from 'protractor';
-import {waitForVisibilityOf} from 'wix-ui-test-utils/protractor';
-import {constants} from './constants';
+import { browser, $, $$ } from 'protractor';
+import { waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import { constants } from './constants';
 
 import {
   UniDriver,
@@ -11,7 +11,7 @@ import {
 async function isCaptchaVerified() {
   await waitForVisibilityOf($(`[data-hook=${constants.verifiedTokenDataHook}`));
   const verifiedToken = await $(
-    `[data-hook=${constants.verifiedTokenDataHook}]`
+    `[data-hook=${constants.verifiedTokenDataHook}]`,
   ).getText();
   return (
     verifiedToken !== constants.verifiedTokenMark &&
@@ -56,7 +56,7 @@ export interface CaptchaTestComponentDriver extends BaseUniDriver {
 }
 
 export const CaptchaTestInstanceDriverFactory = (
-  base: UniDriver
+  base: UniDriver,
 ): CaptchaTestComponentDriver => {
   return {
     ...baseUniDriverFactory(base),

--- a/packages/wix-ui-core/src/components/checkbox/Checkbox.e2e.ts
+++ b/packages/wix-ui-core/src/components/checkbox/Checkbox.e2e.ts
@@ -1,12 +1,18 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { checkboxTestkitFactory } from '../../testkit/protractor';
 import { Key } from 'selenium-webdriver';
 import { Category } from '../../../stories/utils';
 
 describe('Checkbox', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Checkbox');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Checkbox',
+  });
   const dataHook = 'storybook-checkbox';
 
   beforeEach(() => browser.get(storyUrl));

--- a/packages/wix-ui-core/src/components/circular-progress-bar/Arc.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/Arc.tsx
@@ -16,7 +16,7 @@ export interface ArcProps {
   className: string;
 }
 
-export const Arc: React.SFC<ArcProps> = (props: ArcProps) => {
+export const Arc: React.FunctionComponent<ArcProps> = (props: ArcProps) => {
   const { value, strokeWidth, size, className } = props;
   const viewBox = `${-size / 2} ${-size / 2} ${size} ${size}`;
   const d = arc((size - strokeWidth) / 2, value);

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.e2e.ts
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.e2e.ts
@@ -1,17 +1,21 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import {
   circularProgressBarTestkitFactory,
   CircularProgressBarDriver,
 } from '../../testkit/protractor';
-import { Key } from 'selenium-webdriver';
 import * as autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
-import { CircularProgressBarProps } from './CircularProgressBar';
 import { Category } from '../../../stories/utils';
 
 describe('CircularProgressBar', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'CircularProgressBar');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'CircularProgressBar',
+  });
   const dataHook = 'circular-progress-bar';
   let driver: CircularProgressBarDriver;
 

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.spec.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.spec.tsx
@@ -8,195 +8,228 @@ import { circularProgressBarTestkitFactory as enzymeCircularProgressBarTestkitFa
 import { circularProgressBarUniDriverFactory } from './CircularProgressBar.uni.driver';
 
 const createCircularProgressBar = (props = {}) => {
-    return <CircularProgressBar {...props} />;
+  return <CircularProgressBar {...props} />;
 };
 
-describe( 'CircularProgressBar' , () => {
+describe('CircularProgressBar', () => {
+  const testContainer = new ReactDOMTestContainer().unmountAfterEachTest();
 
-    const testContainer = new ReactDOMTestContainer().unmountAfterEachTest();
+  const defaultProps = {
+    value: 40,
+  };
 
-    const defaultProps = {
-        value: 40,
-    };
+  describe('[sync]', () => {
+    runTests(
+      testContainer.createLegacyRenderer(circularProgressBarDriverFactory),
+    );
+  });
 
-    describe('[sync]', () => {
-        runTests(testContainer.createLegacyRenderer(circularProgressBarDriverFactory));
+  describe('[async]', () => {
+    runTests(
+      testContainer.createUniRenderer(circularProgressBarUniDriverFactory),
+    );
+  });
+
+  function runTests(render) {
+    it('should render', async () => {
+      const driver = render(createCircularProgressBar({ ...defaultProps }));
+      expect(await driver.exists()).toBe(true);
     });
 
-    describe('[async]', () => {
-        runTests(testContainer.createUniRenderer(circularProgressBarUniDriverFactory));
+    describe('on completion', () => {
+      const successProps = {
+        successIcon: <div />,
+      };
+
+      it('should display success icon when reaching 100% and value passed as NUMBER', async () => {
+        const props = {
+          value: 100,
+        };
+
+        const driver = render(
+          createCircularProgressBar({ ...props, ...successProps }),
+        );
+        expect(await driver.isSuccessIconDisplayed()).toBe(true);
+      });
+
+      it('should display success icon when reaching 100% and value passed as STRING', async () => {
+        const props = {
+          value: '100' as any,
+          showProgressIndication: true /* was in original test. I think it can be removed */,
+        };
+
+        const driver = render(
+          createCircularProgressBar({ ...props, ...successProps }),
+        );
+        expect(await driver.isSuccessIconDisplayed()).toBe(true);
+      });
+
+      it('should display "100%" percentage when reaching 100% and showProgressIndication is true', async () => {
+        const props = {
+          value: 100,
+          showProgressIndication: true,
+        };
+        const driver = render(
+          createCircularProgressBar({ ...props, ...successProps }),
+        );
+        expect(await driver.getValue()).toBe('100%');
+      });
+
+      it('should display "100%" percentage when passing value above 100 and showProgressIndication is true', async () => {
+        const props = {
+          value: 140,
+          showProgressIndication: true,
+        };
+        const driver = render(
+          createCircularProgressBar({ ...props, ...successProps }),
+        );
+        expect(await driver.getValue()).toBe('100%');
+      });
+
+      it('should display success icon when passing value above 100', async () => {
+        const props = {
+          value: 140,
+        };
+        const driver = render(
+          createCircularProgressBar({ ...props, ...successProps }),
+        );
+        expect(await driver.isSuccessIconDisplayed()).toBe(true);
+      });
     });
 
-    function runTests(render) {
+    describe('on error', () => {
+      const errorProps = {
+        error: true,
+      };
 
-        it('should render', async () => {
-            const driver = render(createCircularProgressBar({...defaultProps}));
-            expect(await driver.exists()).toBe(true);
-        });
+      it('should display error icon', async () => {
+        const props = {
+          errorIcon: <div />,
+        };
 
-        describe('on completion', () => {
+        const driver = render(
+          createCircularProgressBar({
+            ...defaultProps,
+            ...errorProps,
+            ...props,
+          }),
+        );
+        expect(await driver.isErrorIconDisplayed()).toBe(true);
+      });
 
-            const successProps ={
-                successIcon: <div/>,
-            };
+      it('should show percentage when error label and icon are not provided', async () => {
+        const props = {
+          errorIcon: null,
+          showProgressIndication: true,
+        };
 
-            it('should display success icon when reaching 100% and value passed as NUMBER', async () => {
-                const props = {
-                     value: 100,
-                };
+        const driver = render(
+          createCircularProgressBar({
+            ...defaultProps,
+            ...errorProps,
+            ...props,
+          }),
+        );
+        expect(await driver.isErrorIconDisplayed()).toBe(false);
+        expect(await driver.getValue()).toBe('40%');
+      });
 
-                const driver = render(createCircularProgressBar({...props, ...successProps}));
-                expect(await driver.isSuccessIconDisplayed()).toBe(true);
-            });
+      it('should show errorLabel when error icon is not provided', async () => {
+        const props = {
+          errorLabel: 'Failed',
+          errorIcon: null,
+          showProgressIndication: true,
+        };
 
-            it('should display success icon when reaching 100% and value passed as STRING', async () => {
-                const props = {
-                    value: '100' as any,
-                    showProgressIndication: true, /* was in original test. I think it can be removed */
-                };
+        const driver = render(
+          createCircularProgressBar({
+            ...defaultProps,
+            ...errorProps,
+            ...props,
+          }),
+        );
+        expect(await driver.isErrorIconDisplayed()).toBe(false);
+        expect(await driver.getValue()).toBe('Failed');
+      });
 
-                const driver = render(createCircularProgressBar({...props, ...successProps}));
-                expect(await driver.isSuccessIconDisplayed()).toBe(true);
-            });
+      it('should show error icon and percentage when encountering an error without an errorLabel', async () => {
+        const props = {
+          value: 50,
+          errorIcon: <div />,
+          showProgressIndication: true,
+        };
+        const driver = render(
+          createCircularProgressBar({ ...props, ...errorProps }),
+        );
+        expect(await driver.isErrorIconDisplayed()).toBe(true);
+        expect(await driver.getValue()).toBe('50%');
+      });
 
-            it('should display "100%" percentage when reaching 100% and showProgressIndication is true', async () => {
-                const props = {
-                    value: 100,
-                    showProgressIndication: true,
-                };
-                const driver = render(createCircularProgressBar({...props, ...successProps}));
-                expect(await driver.getValue()).toBe('100%');
-            });
-
-            it('should display "100%" percentage when passing value above 100 and showProgressIndication is true', async () => {
-                const props = {
-                    value: 140,
-                    showProgressIndication: true,
-                };
-                const driver = render(createCircularProgressBar({...props, ...successProps}));
-                expect(await driver.getValue()).toBe('100%');
-            });
-
-            it('should display success icon when passing value above 100', async () => {
-                const props = {
-                    value: 140,
-                };
-                const driver = render(createCircularProgressBar({...props, ...successProps}));
-                expect(await driver.isSuccessIconDisplayed()).toBe(true);
-            });
-        });
-
-        describe('on error', () => {
-
-            const errorProps = {
-                error: true,
-            };
-
-            it('should display error icon', async () => {
-                const props = {
-                    errorIcon: <div/>,
-                };
-
-                const driver = render(createCircularProgressBar({...defaultProps, ...errorProps ,...props}));
-                expect(await driver.isErrorIconDisplayed()).toBe(true);
-            });
-
-            it('should show percentage when error label and icon are not provided', async () => {
-                const props = {
-                    errorIcon: null,
-                    showProgressIndication: true,
-                };
-
-                const driver = render(createCircularProgressBar({...defaultProps, ...errorProps, ...props}));
-                expect(await driver.isErrorIconDisplayed()).toBe(false);
-                expect(await driver.getValue()).toBe('40%');
-            });
-
-            it('should show errorLabel when error icon is not provided', async () => {
-                const props = {
-                    errorLabel: 'Failed',
-                    errorIcon: null,
-                    showProgressIndication: true,
-                };
-
-                const driver = render(createCircularProgressBar({...defaultProps, ...errorProps, ...props}));
-                expect(await driver.isErrorIconDisplayed()).toBe(false);
-                expect(await driver.getValue()).toBe('Failed');
-            });
-
-            it('should show error icon and percentage when encountering an error without an errorLabel', async () => {
-                const props = {
-                    value: 50,
-                    errorIcon: <div />,
-                    showProgressIndication: true,
-                };
-                const driver = render(createCircularProgressBar({...props , ...errorProps}));
-                expect(await driver.isErrorIconDisplayed()).toBe(true);
-                expect(await driver.getValue()).toBe('50%');
-            });
-
-            it('should show error icon and errorLabel when encountering an error', async () => {
-                const props = {
-                    value: 50,
-                    errorLabel: 'Failed',
-                    errorIcon: <div />,
-                    showProgressIndication: true,
-                };
-                const driver = render(createCircularProgressBar({...props, ...errorProps}));
-                expect(await driver.isErrorIconDisplayed()).toBe(true);
-                expect(await driver.getValue()).toBe('Failed');
-            });
-        });
-
-        describe( 'in progress' , () =>{
-
-            it('should display percentages value', async () => {
-                const props = {
-                    showProgressIndication: true,
-                };
-                const driver = render(createCircularProgressBar({...defaultProps , ...props}));
-                expect(await driver.getValue()).toBe('40%');
-            });
-
-            it('should display percentages value of 0 when passing value below 0', async () => {
-                const props = {
-                    value: -1,
-                    showProgressIndication: true,
-                };
-                const driver = render(createCircularProgressBar({ ...props}));
-                expect(await driver.getValue()).toBe('0%');
-            });
-
-            it('should show percentages value of 0 when not passing a value', async () => {
-                const props = {
-                    showProgressIndication: true,
-                };
-                const driver = render(createCircularProgressBar({ ...props}));
-                expect(await driver.getValue()).toBe('0%');
-            });
-
-            it('should show value in percentages rounded down', async () => {
-                const floatValue = 3.9;
-                const floatValueRoundDown = Math.floor(floatValue);
-                const props = {
-                    value: floatValue,
-                    showProgressIndication: true,
-                };
-
-                const driver = render(createCircularProgressBar({ ...props}));
-                expect(await driver.getValue()).toBe(`${floatValueRoundDown}%`);
-            });
-
-            it('should not display percentages value by default', async () => {
-                const driver = render(createCircularProgressBar({ ...defaultProps}));
-                expect(await driver.isPercentagesProgressDisplayed()).toBe(false);
-            });
-        });
-    }
-
-    runTestkitExistsSuite({
-        Element: <CircularProgressBar value={0} />,
-        testkitFactory: circularProgressBarTestkitFactory,
-        enzymeTestkitFactory: enzymeCircularProgressBarTestkitFactory,
+      it('should show error icon and errorLabel when encountering an error', async () => {
+        const props = {
+          value: 50,
+          errorLabel: 'Failed',
+          errorIcon: <div />,
+          showProgressIndication: true,
+        };
+        const driver = render(
+          createCircularProgressBar({ ...props, ...errorProps }),
+        );
+        expect(await driver.isErrorIconDisplayed()).toBe(true);
+        expect(await driver.getValue()).toBe('Failed');
+      });
     });
+
+    describe('in progress', () => {
+      it('should display percentages value', async () => {
+        const props = {
+          showProgressIndication: true,
+        };
+        const driver = render(
+          createCircularProgressBar({ ...defaultProps, ...props }),
+        );
+        expect(await driver.getValue()).toBe('40%');
+      });
+
+      it('should display percentages value of 0 when passing value below 0', async () => {
+        const props = {
+          value: -1,
+          showProgressIndication: true,
+        };
+        const driver = render(createCircularProgressBar({ ...props }));
+        expect(await driver.getValue()).toBe('0%');
+      });
+
+      it('should show percentages value of 0 when not passing a value', async () => {
+        const props = {
+          showProgressIndication: true,
+        };
+        const driver = render(createCircularProgressBar({ ...props }));
+        expect(await driver.getValue()).toBe('0%');
+      });
+
+      it('should show value in percentages rounded down', async () => {
+        const floatValue = 3.9;
+        const floatValueRoundDown = Math.floor(floatValue);
+        const props = {
+          value: floatValue,
+          showProgressIndication: true,
+        };
+
+        const driver = render(createCircularProgressBar({ ...props }));
+        expect(await driver.getValue()).toBe(`${floatValueRoundDown}%`);
+      });
+
+      it('should not display percentages value by default', async () => {
+        const driver = render(createCircularProgressBar({ ...defaultProps }));
+        expect(await driver.isPercentagesProgressDisplayed()).toBe(false);
+      });
+    });
+  }
+
+  runTestkitExistsSuite({
+    Element: <CircularProgressBar value={0} />,
+    testkitFactory: circularProgressBarTestkitFactory,
+    enzymeTestkitFactory: enzymeCircularProgressBarTestkitFactory,
+  });
 });

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.spec.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.spec.tsx
@@ -24,17 +24,17 @@ describe('CircularProgressBar', () => {
     );
   });
 
-  describe('[async]', async () => {
+  describe('[async]', () => {
     runTests(
-      await testContainer.createUniRendererAsync(
-        circularProgressBarUniDriverFactory,
-      ),
+      testContainer.createUniRendererAsync(circularProgressBarUniDriverFactory),
     );
   });
 
   function runTests(render) {
     it('should render', async () => {
-      const driver = render(createCircularProgressBar({ ...defaultProps }));
+      const driver = await render(
+        createCircularProgressBar({ ...defaultProps }),
+      );
       expect(await driver.exists()).toBe(true);
     });
 
@@ -48,7 +48,7 @@ describe('CircularProgressBar', () => {
           value: 100,
         };
 
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({ ...props, ...successProps }),
         );
         expect(await driver.isSuccessIconDisplayed()).toBe(true);
@@ -60,7 +60,7 @@ describe('CircularProgressBar', () => {
           showProgressIndication: true /* was in original test. I think it can be removed */,
         };
 
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({ ...props, ...successProps }),
         );
         expect(await driver.isSuccessIconDisplayed()).toBe(true);
@@ -71,7 +71,7 @@ describe('CircularProgressBar', () => {
           value: 100,
           showProgressIndication: true,
         };
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({ ...props, ...successProps }),
         );
         expect(await driver.getValue()).toBe('100%');
@@ -82,7 +82,7 @@ describe('CircularProgressBar', () => {
           value: 140,
           showProgressIndication: true,
         };
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({ ...props, ...successProps }),
         );
         expect(await driver.getValue()).toBe('100%');
@@ -92,7 +92,7 @@ describe('CircularProgressBar', () => {
         const props = {
           value: 140,
         };
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({ ...props, ...successProps }),
         );
         expect(await driver.isSuccessIconDisplayed()).toBe(true);
@@ -109,7 +109,7 @@ describe('CircularProgressBar', () => {
           errorIcon: <div />,
         };
 
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({
             ...defaultProps,
             ...errorProps,
@@ -125,7 +125,7 @@ describe('CircularProgressBar', () => {
           showProgressIndication: true,
         };
 
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({
             ...defaultProps,
             ...errorProps,
@@ -143,7 +143,7 @@ describe('CircularProgressBar', () => {
           showProgressIndication: true,
         };
 
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({
             ...defaultProps,
             ...errorProps,
@@ -160,7 +160,7 @@ describe('CircularProgressBar', () => {
           errorIcon: <div />,
           showProgressIndication: true,
         };
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({ ...props, ...errorProps }),
         );
         expect(await driver.isErrorIconDisplayed()).toBe(true);
@@ -174,7 +174,7 @@ describe('CircularProgressBar', () => {
           errorIcon: <div />,
           showProgressIndication: true,
         };
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({ ...props, ...errorProps }),
         );
         expect(await driver.isErrorIconDisplayed()).toBe(true);
@@ -187,7 +187,7 @@ describe('CircularProgressBar', () => {
         const props = {
           showProgressIndication: true,
         };
-        const driver = render(
+        const driver = await render(
           createCircularProgressBar({ ...defaultProps, ...props }),
         );
         expect(await driver.getValue()).toBe('40%');
@@ -198,7 +198,7 @@ describe('CircularProgressBar', () => {
           value: -1,
           showProgressIndication: true,
         };
-        const driver = render(createCircularProgressBar({ ...props }));
+        const driver = await render(createCircularProgressBar({ ...props }));
         expect(await driver.getValue()).toBe('0%');
       });
 
@@ -206,7 +206,7 @@ describe('CircularProgressBar', () => {
         const props = {
           showProgressIndication: true,
         };
-        const driver = render(createCircularProgressBar({ ...props }));
+        const driver = await render(createCircularProgressBar({ ...props }));
         expect(await driver.getValue()).toBe('0%');
       });
 
@@ -218,12 +218,14 @@ describe('CircularProgressBar', () => {
           showProgressIndication: true,
         };
 
-        const driver = render(createCircularProgressBar({ ...props }));
+        const driver = await render(createCircularProgressBar({ ...props }));
         expect(await driver.getValue()).toBe(`${floatValueRoundDown}%`);
       });
 
       it('should not display percentages value by default', async () => {
-        const driver = render(createCircularProgressBar({ ...defaultProps }));
+        const driver = await render(
+          createCircularProgressBar({ ...defaultProps }),
+        );
         expect(await driver.isPercentagesProgressDisplayed()).toBe(false);
       });
     });

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.spec.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.spec.tsx
@@ -24,9 +24,11 @@ describe('CircularProgressBar', () => {
     );
   });
 
-  describe('[async]', () => {
+  describe('[async]', async () => {
     runTests(
-      testContainer.createUniRenderer(circularProgressBarUniDriverFactory),
+      await testContainer.createUniRendererAsync(
+        circularProgressBarUniDriverFactory,
+      ),
     );
   });
 

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import style from './CircularProgressBar.st.css';
 import { Arc } from './Arc';
-import { dataHooks } from "./constants";
+import { dataHooks } from './constants';
 
 export interface CircularProgressBarProps {
   /** represent the progress state in percentages (0 - no progress, 100 - progress completed) */
@@ -109,7 +109,10 @@ export const CircularProgressBar: React.SFC<CircularProgressBarProps> = (
     <div {...style('root', { error, success }, _props)}>
       {renderArcs(_props)}
       {showProgressIndication && (
-        <div data-hook={dataHooks.progressIndicator} className={style.progressIndicator}>
+        <div
+          data-hook={dataHooks.progressIndicator}
+          className={style.progressIndicator}
+        >
           {value}
         </div>
       )}

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
@@ -95,9 +95,9 @@ const normalizeProps = (props: CircularProgressBarProps) => {
   return { ...props, value };
 };
 
-export const CircularProgressBar: React.SFC<CircularProgressBarProps> = (
-  props: CircularProgressBarProps,
-) => {
+export const CircularProgressBar: React.FunctionComponent<
+  CircularProgressBarProps
+> = (props: CircularProgressBarProps) => {
   const { error, showProgressIndication } = props;
   const _props = normalizeProps(props);
   const success = _props.value === FULL_PROGRESS;

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.uni.driver.ts
@@ -1,50 +1,50 @@
 import {
-    BaseUniDriver,
-    baseUniDriverFactory,
+  BaseUniDriver,
+  baseUniDriverFactory,
 } from 'wix-ui-test-utils/base-driver';
 import { UniDriver, StylableUnidriverUtil } from 'wix-ui-test-utils/unidriver';
 import styles from './CircularProgressBar.st.css';
 import { dataHooks } from './constants';
 
 export interface CircularProgressBarUniDriver extends BaseUniDriver {
-    /** Returns boolean that indicates if the success icon exists */
-    isSuccessIconDisplayed(): Promise<boolean>;
-    /** Returns boolean that indicates if the error icon exists */
-    isErrorIconDisplayed(): Promise<boolean>;
-    /** Returns boolean that indicates if the progress percentages text exists */
-    isPercentagesProgressDisplayed(): Promise<boolean>;
-    /** Get the progress percentages value */
-    getValue(): Promise<string>;
-    /** Returns true if has progress completed (value is 100) */
-    isCompleted(): Promise<boolean>;
-    /** Returns true if has error */
-    hasError(): Promise<boolean>;
+  /** Returns boolean that indicates if the success icon exists */
+  isSuccessIconDisplayed(): Promise<boolean>;
+  /** Returns boolean that indicates if the error icon exists */
+  isErrorIconDisplayed(): Promise<boolean>;
+  /** Returns boolean that indicates if the progress percentages text exists */
+  isPercentagesProgressDisplayed(): Promise<boolean>;
+  /** Get the progress percentages value */
+  getValue(): Promise<string>;
+  /** Returns true if has progress completed (value is 100) */
+  isCompleted(): Promise<boolean>;
+  /** Returns true if has error */
+  hasError(): Promise<boolean>;
 }
 
 export const circularProgressBarUniDriverFactory = (
-    base: UniDriver,
+  base: UniDriver,
 ): CircularProgressBarUniDriver => {
-    const byDataHook = dataHook => `[data-hook="${dataHook}"]`;
-    const stylableUnidriverUtil = new StylableUnidriverUtil(styles);
+  const byDataHook = dataHook => `[data-hook="${dataHook}"]`;
+  const stylableUnidriverUtil = new StylableUnidriverUtil(styles);
 
-    const getValue = async () => {
-        if (!(await base.exists())) {
-            return null;
-        }
+  const getValue = async () => {
+    if (!(await base.exists())) {
+      return null;
+    }
 
-        return base
-            .$(byDataHook(dataHooks.progressIndicator))
-            .text();
-    };
+    return base.$(byDataHook(dataHooks.progressIndicator)).text();
+  };
 
-    return {
-        ...baseUniDriverFactory(base),
-        isSuccessIconDisplayed: () => base.$(byDataHook(dataHooks.successIcon)).exists(),
-        isErrorIconDisplayed: () => base.$(byDataHook(dataHooks.errorIcon)).exists(),
-        isPercentagesProgressDisplayed: () =>
-            base.$(byDataHook(dataHooks.progressIndicator)).exists(),
-        getValue: () => getValue(),
-        isCompleted: async () => (await getValue()) === '100',
-        hasError: () => stylableUnidriverUtil.hasStyleState(base, 'error'),
-    };
+  return {
+    ...baseUniDriverFactory(base),
+    isSuccessIconDisplayed: () =>
+      base.$(byDataHook(dataHooks.successIcon)).exists(),
+    isErrorIconDisplayed: () =>
+      base.$(byDataHook(dataHooks.errorIcon)).exists(),
+    isPercentagesProgressDisplayed: () =>
+      base.$(byDataHook(dataHooks.progressIndicator)).exists(),
+    getValue: () => getValue(),
+    isCompleted: async () => (await getValue()) === '100',
+    hasError: () => stylableUnidriverUtil.hasStyleState(base, 'error'),
+  };
 };

--- a/packages/wix-ui-core/src/components/circular-progress-bar/constants.ts
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/constants.ts
@@ -1,7 +1,7 @@
 export enum dataHooks {
-    progressIndicator = 'progress-indicator',
-    successIcon = 'success-icon',
-    errorIcon = 'error-icon',
-    progressArcForeground = 'progressarc-foreground',
-    progressArcBackground = 'progressarc-background',
+  progressIndicator = 'progress-indicator',
+  successIcon = 'success-icon',
+  errorIcon = 'error-icon',
+  progressArcForeground = 'progressarc-foreground',
+  progressArcBackground = 'progressarc-background',
 }

--- a/packages/wix-ui-core/src/components/circular-progress-bar/index.ts
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/index.ts
@@ -1,1 +1,4 @@
-export { CircularProgressBar, CircularProgressBarProps } from './CircularProgressBar';
+export {
+  CircularProgressBar,
+  CircularProgressBarProps,
+} from './CircularProgressBar';

--- a/packages/wix-ui-core/src/components/deprecated/button/Button.e2e.ts
+++ b/packages/wix-ui-core/src/components/deprecated/button/Button.e2e.ts
@@ -1,6 +1,9 @@
 import * as eyes from 'eyes.it';
 import { browser, ExpectedConditions as EC } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import * as autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 import {
   buttonTestkitFactory,
@@ -9,7 +12,10 @@ import {
 import { Category } from '../../../../stories/utils';
 
 describe('Button', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Button');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Button',
+  });
   const dataHook = 'storybook-button';
   let driver: ButtonDriver;
 

--- a/packages/wix-ui-core/src/components/deprecated/button/Button.tsx
+++ b/packages/wix-ui-core/src/components/deprecated/button/Button.tsx
@@ -12,7 +12,7 @@ export interface ButtonProps
 /**
  * Button
  */
-export const Button: React.SFC<ButtonProps> = props => {
+export const Button: React.FunctionComponent<ButtonProps> = props => {
   const { disabled } = props;
 
   return <button {...props} {...style('root', { disabled }, props)} />;

--- a/packages/wix-ui-core/src/components/deprecated/divider/Divider.e2e.ts
+++ b/packages/wix-ui-core/src/components/deprecated/divider/Divider.e2e.ts
@@ -1,11 +1,17 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { dividerTestkitFactory } from '../../../testkit/protractor';
 import { Category } from '../../../../stories/utils';
 
 describe('Divider', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Divider');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Divider',
+  });
 
   beforeEach(() => browser.get(storyUrl));
 

--- a/packages/wix-ui-core/src/components/deprecated/divider/Divider.tsx
+++ b/packages/wix-ui-core/src/components/deprecated/divider/Divider.tsx
@@ -10,7 +10,9 @@ export interface DividerProps {
 /**
  * Divider
  */
-export const Divider: React.SFC<DividerProps> = (props: DividerProps) => {
+export const Divider: React.FunctionComponent<DividerProps> = (
+  props: DividerProps,
+) => {
   const { children, vertical } = props;
   const customDivider = !!children;
 

--- a/packages/wix-ui-core/src/components/deprecated/label/Label.e2e.ts
+++ b/packages/wix-ui-core/src/components/deprecated/label/Label.e2e.ts
@@ -1,11 +1,17 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { labelTestkitFactory } from '../../../testkit/protractor';
 import { Category } from '../../../../stories/utils';
 
 describe('Label', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Label');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Label',
+  });
 
   beforeEach(() => browser.get(storyUrl));
   eyes.it('should display correct content', () => {

--- a/packages/wix-ui-core/src/components/deprecated/label/Label.spec.tsx
+++ b/packages/wix-ui-core/src/components/deprecated/label/Label.spec.tsx
@@ -17,31 +17,31 @@ describe('Label', () => {
   });
 
   describe('[async]', () => {
-    runTests(testContainer.createUniRenderer(labelUniDriverFactory));
+    runTests(testContainer.createUniRendererAsync(labelUniDriverFactory));
   });
 
   function runTests(createDriver) {
     it('Renders children', async () => {
-      const driver = createDriver(<Label>HELLO</Label>);
+      const driver = await createDriver(<Label>HELLO</Label>);
 
       expect(await driver.getLabelText()).toBe('HELLO');
     });
 
     it('takes an id prop', async () => {
-      const driver = createDriver(<Label id="hey" />);
+      const driver = await createDriver(<Label id="hey" />);
 
       expect(await driver.getId()).toBe('hey');
     });
 
     describe('for attribute', () => {
       it('takes an htmlFor prop', async () => {
-        const driver = createDriver(<Label for="hey" />);
+        const driver = await createDriver(<Label for="hey" />);
 
         expect(await driver.getForAttribute()).toBe('hey');
       });
 
       it('shouldclick on Label takes an htmlFor prop', async () => {
-        const driver = createDriver(<Label for="hey" />);
+        const driver = await createDriver(<Label for="hey" />);
 
         expect(await driver.getForAttribute()).toBe('hey');
       });
@@ -49,24 +49,24 @@ describe('Label', () => {
 
     describe('ellipsis attribute', () => {
       it('should not have ellipsis by default', async () => {
-        const driver = createDriver(<Label>Hello World</Label>);
+        const driver = await createDriver(<Label>Hello World</Label>);
         expect(await driver.hasEllipsis()).toBeFalsy();
       });
 
       it('should have ellipsis', async () => {
-        const driver = createDriver(<Label ellipsis>Hello World</Label>);
+        const driver = await createDriver(<Label ellipsis>Hello World</Label>);
         expect(await driver.hasEllipsis()).toBeTruthy();
       });
     });
 
     it('takes a disabled prop', async () => {
-      const driver = createDriver(<Label disabled />);
+      const driver = await createDriver(<Label disabled />);
 
       expect(await driver.isDisabled()).toBe(true);
     });
 
     it('should not be disabled by default', async () => {
-      const driver = createDriver(<Label />);
+      const driver = await createDriver(<Label />);
 
       expect(await driver.isDisabled()).toBe(false);
     });

--- a/packages/wix-ui-core/src/components/deprecated/label/Label.spec.tsx
+++ b/packages/wix-ui-core/src/components/deprecated/label/Label.spec.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
-import { labelDriverFactory } from "./Label.driver";
-import { labelUniDriverFactory } from "./Label.uni.driver";
-import { ReactDOMTestContainer } from "../../../../test/dom-test-container";
-import { isEnzymeTestkitExists } from "wix-ui-test-utils/enzyme";
-import { isTestkitExists } from "wix-ui-test-utils/vanilla";
-import { labelTestkitFactory } from "../../../testkit";
-import { labelTestkitFactory as enzymeLabelTestkitFactory } from "../../../testkit/enzyme";
-import { Label } from "./Label";
-import { mount } from "enzyme";
+import * as React from 'react';
+import { labelDriverFactory } from './Label.driver';
+import { labelUniDriverFactory } from './Label.uni.driver';
+import { ReactDOMTestContainer } from '../../../../test/dom-test-container';
+import { isEnzymeTestkitExists } from 'wix-ui-test-utils/enzyme';
+import { isTestkitExists } from 'wix-ui-test-utils/vanilla';
+import { labelTestkitFactory } from '../../../testkit';
+import { labelTestkitFactory as enzymeLabelTestkitFactory } from '../../../testkit/enzyme';
+import { Label } from './Label';
+import { mount } from 'enzyme';
 
 describe('Label', () => {
   const testContainer = new ReactDOMTestContainer().unmountAfterEachTest();

--- a/packages/wix-ui-core/src/components/deprecated/label/Label.tsx
+++ b/packages/wix-ui-core/src/components/deprecated/label/Label.tsx
@@ -22,7 +22,7 @@ const defaultProps: LabelProps = {
 /**
  * Label
  */
-export const Label: React.SFC<LabelProps> = props => {
+export const Label: React.FunctionComponent<LabelProps> = props => {
   const { id, children, ellipsis, disabled } = props;
   return (
     <label

--- a/packages/wix-ui-core/src/components/deprecated/stylable-badge/Badge.e2e.ts
+++ b/packages/wix-ui-core/src/components/deprecated/stylable-badge/Badge.e2e.ts
@@ -1,11 +1,17 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { stylablebadgeTestkitFactory as badgeTestkitFactory } from '../../../testkit/protractor';
 import { Category } from '../../../../stories/utils';
 
 describe('Badge', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'StylableBadge');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'StylableBadge',
+  });
 
   beforeEach(() => browser.get(storyUrl));
   eyes.it('should display correct content', () => {

--- a/packages/wix-ui-core/src/components/deprecated/stylable-badge/Badge.tsx
+++ b/packages/wix-ui-core/src/components/deprecated/stylable-badge/Badge.tsx
@@ -9,7 +9,7 @@ export interface BadgeProps {
 /**
  * Badge
  */
-export const Badge: React.SFC<BadgeProps> = props => (
+export const Badge: React.FunctionComponent<BadgeProps> = props => (
   <span {...style('root', {}, props)}>{props.children}</span>
 );
 

--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
@@ -64,6 +64,7 @@ export class DropdownContent extends React.PureComponent<
     }
 
     let { hoveredIndex } = this.state;
+    // tslint:disable-next-line:no-constant-condition
     while (true) {
       hoveredIndex += interval;
       if (hoveredIndex === options.length) {

--- a/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.tsx
@@ -11,7 +11,7 @@ export interface DropdownOptionProps {
   onMouseEnterHandler: React.MouseEventHandler<HTMLDivElement> | undefined;
 }
 
-export type DropdownOptionType = React.SFC<DropdownOptionProps>;
+export type DropdownOptionType = React.FunctionComponent<DropdownOptionProps>;
 
 export const DropdownOption: DropdownOptionType = (
   props: DropdownOptionProps,

--- a/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.spec.tsx
@@ -1,3 +1,4 @@
+/* tslint:disable jsx-wrap-multiline */
 import * as React from 'react';
 import { OptionFactory } from './';
 import { Divider } from '../deprecated/divider';

--- a/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.spec.tsx
@@ -87,9 +87,15 @@ describe('OptionFactory', () => {
       expect(option.isDisabled).toBeFalsy();
       expect(option.isSelectable).toBeTruthy();
       expect(option.render(value)).toEqual([
-        <span className={style.nonHighlight} key={0}>va</span>,
-        <mark className={style.highlight} key={1}>lu</mark>,
-        <span className={style.nonHighlight} key={2}>e</span>
+        <span className={style.nonHighlight} key={0}>
+          va
+        </span>,
+        <mark className={style.highlight} key={1}>
+          lu
+        </mark>,
+        <span className={style.nonHighlight} key={2}>
+          e
+        </span>,
       ]);
     });
 
@@ -99,11 +105,22 @@ describe('OptionFactory', () => {
       });
       const option = OptionFactory.createHighlighted(existingOption, 'his sen');
       expect(option.render(value)).toEqual([
-        <span className={style.nonHighlight} key={0}>T</span>,
-        <mark className={style.highlight} key={1}>his</mark>,
-        <span className={style.nonHighlight} key={2}> is a </span>,
-        <mark className={style.highlight} key={3}>sen</mark>,
-        <span className={style.nonHighlight} key={4}>tence</span>,
+        <span className={style.nonHighlight} key={0}>
+          T
+        </span>,
+        <mark className={style.highlight} key={1}>
+          his
+        </mark>,
+        <span className={style.nonHighlight} key={2}>
+          {' '}
+          is a{' '}
+        </span>,
+        <mark className={style.highlight} key={3}>
+          sen
+        </mark>,
+        <span className={style.nonHighlight} key={4}>
+          tence
+        </span>,
       ]);
     });
 
@@ -114,8 +131,12 @@ describe('OptionFactory', () => {
       expect(option.isDisabled).toBeFalsy();
       expect(option.isSelectable).toBeTruthy();
       expect(option.render(value)).toEqual([
-        <mark className={style.highlight} key={0}>valu</mark>,
-        <span className={style.nonHighlight} key={1}>e</span>
+        <mark className={style.highlight} key={0}>
+          valu
+        </mark>,
+        <span className={style.nonHighlight} key={1}>
+          e
+        </span>,
       ]);
     });
 

--- a/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/OptionFactory.spec.tsx
@@ -113,8 +113,7 @@ describe('OptionFactory', () => {
           his
         </mark>,
         <span className={style.nonHighlight} key={2}>
-          {' '}
-          is a{' '}
+          {' is a '}
         </span>,
         <mark className={style.highlight} key={3}>
           sen

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.driver.ts
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.driver.ts
@@ -19,7 +19,7 @@ export const dropdownDriverFactory = args => {
     optionAt: (index: number) => getDropdownContentDriver(args).optionAt(index),
     triggerMouseDownOnDropdownContent: () =>
       getDropdownContentDriver(args).triggerMouseDown(),
-    dropdownContentDisplayed: () => getDropdownContentDriver  (args).exists(),
+    dropdownContentDisplayed: () => getDropdownContentDriver(args).exists(),
   };
 };
 

--- a/packages/wix-ui-core/src/components/ellipsis-tooltip/storySettings.ts
+++ b/packages/wix-ui-core/src/components/ellipsis-tooltip/storySettings.ts
@@ -1,6 +1,6 @@
 import { StorySettings, Category } from '../../../stories/utils';
 
-export const storySettings : StorySettings = {
+export const storySettings: StorySettings = {
   category: Category.COMPONENTS,
   storyName: 'EllipsisTooltip',
 };

--- a/packages/wix-ui-core/src/components/ellipsis-tooltip/tests/EllipsisTooltip.e2e.ts
+++ b/packages/wix-ui-core/src/components/ellipsis-tooltip/tests/EllipsisTooltip.e2e.ts
@@ -1,8 +1,7 @@
 import * as eyes from 'eyes.it';
 import { $, browser } from 'protractor';
 import {
-  getStoryUrl,
-  waitForVisibilityOf,
+  createStoryUrl,
   mouseEnter,
   hasEllipsis,
 } from 'wix-ui-test-utils/protractor';
@@ -17,7 +16,7 @@ import {
 const byDataHook = dataHook => $(`[data-hook="${dataHook}"]`);
 
 async function goToTestPage(testName) {
-  const storyUrl = getStoryUrl(testFolder, testName);
+  const storyUrl = createStoryUrl({ kind: testFolder, story: testName });
   await browser.get(storyUrl);
 }
 

--- a/packages/wix-ui-core/src/components/file-picker-button/test/FilePickerButton.e2e.ts
+++ b/packages/wix-ui-core/src/components/file-picker-button/test/FilePickerButton.e2e.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../testkit/protractor';
 import { DataHook } from './FilePickerButtonTestFixture';
 import * as path from 'path';
-import {Category} from '../../../../stories/utils';
+import { Category } from '../../../../stories/utils';
 
 describe('FilePickerButton', () => {
   const storyUrl = createStoryUrl({

--- a/packages/wix-ui-core/src/components/icon-with-options/IconWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/icon-with-options/IconWithOptions.tsx
@@ -31,7 +31,9 @@ export interface IconWithOptionsProps {
 /**
  * IconWithOptions
  */
-export const IconWithOptions: React.SFC<IconWithOptionsProps> = props => {
+export const IconWithOptions: React.FunctionComponent<
+  IconWithOptionsProps
+> = props => {
   const {
     placement,
     options,

--- a/packages/wix-ui-core/src/components/image/image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/image/image.browser.spec.tsx
@@ -7,10 +7,10 @@ import * as eventually from 'wix-eventually';
 
 describe('Image', () => {
   const testContainer = new ReactDOMTestContainer().unmountAfterEachTest();
-  const createDriver = testContainer.createUniRenderer(imageDriverFactory);
+  const createDriver = testContainer.createUniRendererAsync(imageDriverFactory);
 
   it('renders image element to dom', async () => {
-    const imageDriver = createDriver(<Image />);
+    const imageDriver = await createDriver(<Image />);
     const imageElement = await imageDriver.element();
 
     expect(imageElement.tagName).toBe('IMG');
@@ -18,7 +18,7 @@ describe('Image', () => {
 
   describe('renders provided props', () => {
     it('displays an alt prop', async () => {
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image alt="this is an informative text" />,
       );
 
@@ -27,7 +27,9 @@ describe('Image', () => {
 
     it('displays image with given src', async () => {
       const onLoadSpy = jest.fn();
-      const imageDriver = createDriver(<Image src={SRC} onLoad={onLoadSpy} />);
+      const imageDriver = await createDriver(
+        <Image src={SRC} onLoad={onLoadSpy} />,
+      );
 
       expect(await imageDriver.getLoadStatus()).toEqual('loading');
       await eventually(async () => {
@@ -39,7 +41,7 @@ describe('Image', () => {
 
     it('displays image with given srcSet', async () => {
       const onLoadSpy = jest.fn();
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image srcSet={SRC} onLoad={onLoadSpy} />,
       );
       await eventually(async () => {
@@ -50,7 +52,7 @@ describe('Image', () => {
     });
 
     it('renders provided src, and overrides the nativeProps src', async () => {
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image src={SRC} nativeProps={{ src: ERROR_IMAGE_SRC }} />,
       );
       await eventually(async () => {
@@ -62,7 +64,7 @@ describe('Image', () => {
   describe('props are not provided', () => {
     it('displays empty pixel when src/srcset are not provided', async () => {
       const onLoadSpy = jest.fn();
-      const imageDriver = createDriver(<Image onLoad={onLoadSpy} />);
+      const imageDriver = await createDriver(<Image onLoad={onLoadSpy} />);
 
       await eventually(async () => {
         expect(onLoadSpy).toHaveBeenCalled();
@@ -75,7 +77,7 @@ describe('Image', () => {
   describe('props are broken', () => {
     it('it displays the provided errorImage when the src is broken', async () => {
       const onErrorSpy = jest.fn();
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image
           src={BROKEN_SRC}
           errorImage={ERROR_IMAGE_SRC}
@@ -92,7 +94,7 @@ describe('Image', () => {
 
     it('displays empty pixel when srcSet is broken', async () => {
       const onErrorSpy = jest.fn();
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image srcSet={BROKEN_SRC} onError={onErrorSpy} />,
       );
 
@@ -105,7 +107,7 @@ describe('Image', () => {
 
     it('it displays the provided errorImage when the src and srcSet are broken', async () => {
       const onErrorSpy = jest.fn();
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image
           src={BROKEN_SRC}
           srcSet={BROKEN_SRC}
@@ -124,7 +126,7 @@ describe('Image', () => {
 
     it('displays an empty pixel when both src and errorImage are broken', async () => {
       const onErrorSpy = jest.fn();
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image src={BROKEN_SRC} errorImage={BROKEN_SRC} onError={onErrorSpy} />,
       );
 
@@ -137,7 +139,7 @@ describe('Image', () => {
 
     it('displays an empty pixel when both src and errorImage are broken', async () => {
       const onErrorSpy = jest.fn();
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image src={BROKEN_SRC} errorImage={BROKEN_SRC} onError={onErrorSpy} />,
       );
 
@@ -150,7 +152,7 @@ describe('Image', () => {
 
     it('displays an empty pixel when the provided src is broken and errorImage is not provided ', async () => {
       const onErrorSpy = jest.fn();
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image src={BROKEN_SRC} onError={onErrorSpy} />,
       );
 
@@ -164,7 +166,7 @@ describe('Image', () => {
 
   describe('resize mode', () => {
     it('specifies the image to contain its container', async () => {
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image src={SRC} resizeMode={'contain'} />,
       );
 
@@ -172,7 +174,7 @@ describe('Image', () => {
     });
 
     it('specifies the image to cover its container', async () => {
-      const imageDriver = createDriver(
+      const imageDriver = await createDriver(
         <Image src={SRC} resizeMode={'cover'} />,
       );
 
@@ -181,7 +183,9 @@ describe('Image', () => {
 
     // 'fill' is the default image behavior
     it('specifies the image to fill its container', async () => {
-      const imageDriver = createDriver(<Image src={SRC} resizeMode={'fill'} />);
+      const imageDriver = await createDriver(
+        <Image src={SRC} resizeMode={'fill'} />,
+      );
 
       expect(await imageDriver.getResizeMode()).toEqual('fill');
       expect(await imageDriver.getSrc()).toEqual(SRC);

--- a/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.spec.tsx
+++ b/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.spec.tsx
@@ -129,7 +129,11 @@ describe('InputWithOptions', () => {
     describe('onContentMouseDown', () => {
       it('should be called when mouse down event occurs', () => {
         const onContentMouseDown = jest.fn();
-        const props = { options: numericOptions, inputProps: { value: '' }, onContentMouseDown };
+        const props = {
+          options: numericOptions,
+          inputProps: { value: '' },
+          onContentMouseDown,
+        };
         const { driver } = setup(props);
 
         driver.click();
@@ -138,7 +142,11 @@ describe('InputWithOptions', () => {
       });
       it('should be called with event when mouse down event occurs', () => {
         const onContentMouseDown = jest.fn();
-        const props = { options: numericOptions, inputProps: { value: '' }, onContentMouseDown };
+        const props = {
+          options: numericOptions,
+          inputProps: { value: '' },
+          onContentMouseDown,
+        };
         const { driver } = setup(props);
         driver.click();
         driver.triggerMouseDownOnDropdownContent();

--- a/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
@@ -171,7 +171,7 @@ export class InputWithOptions extends React.PureComponent<
     onBlur && onBlur(event);
   };
 
-  _onContentMouseDown = (e) => {
+  _onContentMouseDown = e => {
     const { onContentMouseDown } = this.props;
     this.isEditing = false;
     onContentMouseDown && onContentMouseDown(e);

--- a/packages/wix-ui-core/src/components/input/Input.e2e.ts
+++ b/packages/wix-ui-core/src/components/input/Input.e2e.ts
@@ -1,11 +1,17 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { inputTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 describe('Input', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Input');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Input',
+  });
 
   beforeEach(() => {
     browser.get(storyUrl);

--- a/packages/wix-ui-core/src/components/label-with-options/LabelWithOptions.e2e.ts
+++ b/packages/wix-ui-core/src/components/label-with-options/LabelWithOptions.e2e.ts
@@ -1,12 +1,18 @@
 import * as eyes from 'eyes.it';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { labelWithOptionsTestkitFactory } from '../../testkit/protractor';
 import * as autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 import { browser } from 'protractor';
 import { Category } from '../../../stories/utils';
 
 describe('LabelWithOptions', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'LabelWithOptions');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'LabelWithOptions',
+  });
   const dataHook = 'storybook-labelwithoptions';
 
   beforeEach(() => browser.get(storyUrl));

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.driver.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.driver.ts
@@ -3,7 +3,7 @@ import {
   ComponentFactory,
   DriverFactory,
 } from 'wix-ui-test-utils/driver-factory';
-import {StylableDOMUtil} from '@stylable/dom-test-kit';
+import { StylableDOMUtil } from '@stylable/dom-test-kit';
 import style from './LinearProgressBar.st.css';
 import {
   ProgressBarDataHooks,
@@ -46,7 +46,7 @@ export interface LinearProgressBarDriver extends BaseDriver {
 
 export const linearProgressBarDriverFactory: DriverFactory<
   LinearProgressBarDriver
-> = ({element}: ComponentFactory) => {
+> = ({ element }: ComponentFactory) => {
   const stylableDOMUtil = new StylableDOMUtil(style);
 
   const getElement = dataHook =>
@@ -55,7 +55,7 @@ export const linearProgressBarDriverFactory: DriverFactory<
     !element
       ? null
       : getElement(ProgressBarDataHooks.progressPercentage).querySelector(
-          'span'
+          'span',
         ).innerHTML;
   const getDataAttribute = (key: string, parsingFunction?: Function) => {
     if (!element || !element.getAttribute(key)) {

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.e2e.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.e2e.ts
@@ -1,17 +1,22 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import {
   linearProgressBarTestkitFactory,
   LinearProgressBarDriver,
 } from '../../testkit/protractor';
-import { Key } from 'selenium-webdriver';
 import * as autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 import { LinearProgressBarProps } from './LinearProgressBar';
 import { Category } from '../../../stories/utils';
 
 describe('LinearProgresBar', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'LinearProgressBar');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'LinearProgressBar',
+  });
   const dataHook = 'progress-bar';
   let driver: LinearProgressBarDriver;
 
@@ -43,7 +48,6 @@ describe('LinearProgresBar', () => {
   });
 
   eyes.it('should show empty progress as value less than 0', async () => {
-    const expectedProgress = 0;
     const valueLessThan0 = -1;
 
     await autoExampleDriver.setProps({ value: valueLessThan0 });

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.spec.tsx
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.spec.tsx
@@ -23,37 +23,41 @@ describe('ProgressBar', () => {
 
   describe('[async]', () => {
     runTests(
-      testContainer.createUniRenderer(linearProgressBarUniDriverFactory),
+      testContainer.createUniRendererAsync(linearProgressBarUniDriverFactory),
     );
   });
 
   function runTests(createDriver) {
     it('should exist', async () => {
-      const driver = createDriver(<LinearProgressBar {...defaultProps} />);
+      const driver = await createDriver(
+        <LinearProgressBar {...defaultProps} />,
+      );
       expect(await driver.exists()).toBe(true);
     });
 
     it(`should set the foreground progress bar layer to ${defaultProps.value}%`, async () => {
-      const driver = createDriver(<LinearProgressBar {...defaultProps} />);
+      const driver = await createDriver(
+        <LinearProgressBar {...defaultProps} />,
+      );
       expect(await driver.getWidth()).toBe(`${defaultProps.value}%`);
     });
 
     it('should not show success icon when reaching 100%', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <LinearProgressBar {...{ ...defaultProps, value: 100 }} />,
       );
       expect(await driver.isSuccessIconDisplayed()).toBe(false);
     });
 
     it('should not show percentages value while in progress', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <LinearProgressBar {...{ ...defaultProps, value: 50 }} />,
       );
       expect(await driver.isPercentagesProgressDisplayed()).toBe(false);
     });
 
     it('should not show error icon while in progress', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <LinearProgressBar {...{ ...defaultProps, error: true }} />,
       );
       expect(await driver.isErrorIconDisplayed()).toBe(false);
@@ -62,7 +66,7 @@ describe('ProgressBar', () => {
     describe('testkit methods', () => {
       it('should allow getting numeric value from component', async () => {
         const value = 50;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, value }} />,
         );
         expect(await driver.getNumericValue()).toBe(value);
@@ -78,7 +82,7 @@ describe('ProgressBar', () => {
       });
 
       it('should show success icon when reaching 100%', async () => {
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar
             {...{ ...props, value: 100, successIcon: <div /> }}
           />,
@@ -87,7 +91,7 @@ describe('ProgressBar', () => {
       });
 
       it('should show success icon when reaching 100% and value passed as string', async () => {
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar
             {...{ ...props, value: '100' as any, successIcon: <div /> }}
           />,
@@ -96,14 +100,14 @@ describe('ProgressBar', () => {
       });
 
       it('should show percentages value when reaching 100% and success icon not provided', async () => {
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar {...{ ...props, value: 100 }} />,
         );
         expect(await driver.getValue()).toBe('100%');
       });
 
       it('should show error icon on failure', async () => {
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar
             {...{ ...props, error: true, errorIcon: <div /> }}
           />,
@@ -112,7 +116,7 @@ describe('ProgressBar', () => {
       });
 
       it('should show percentages value when error icon not provided', async () => {
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar
             {...{ ...props, value: 33, error: true, errorIcon: null }}
           />,
@@ -122,21 +126,21 @@ describe('ProgressBar', () => {
       });
 
       it('should show percentages value while in progress', async () => {
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar {...{ ...props, value: 50 }} />,
         );
         expect(await driver.getValue()).toBe('50%');
       });
 
       it('should show percentages value of 0 when passing value lesser than 0', async () => {
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar {...{ ...props, value: -1 }} />,
         );
         expect(await driver.getValue()).toBe('0%');
       });
 
       it('should show percentages value of 0 when not passing a value', async () => {
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar {...{ showProgressIndication: true }} />,
         );
         expect(await driver.getValue()).toBe('0%');
@@ -144,7 +148,7 @@ describe('ProgressBar', () => {
 
       it('should show percentages value of 0 when not passing a value and min is lesser than 0', async () => {
         const min = -8;
-        driver = createDriver(
+        driver = await createDriver(
           <LinearProgressBar {...{ showProgressIndication: true, min }} />,
         );
         expect(await driver.getValue()).toBe('0%');
@@ -155,7 +159,7 @@ describe('ProgressBar', () => {
           const floatValue = 3.9;
           const floatValueRoundDown = Math.floor(floatValue);
 
-          driver = createDriver(
+          driver = await createDriver(
             <LinearProgressBar {...{ ...props, value: floatValue }} />,
           );
           expect(await driver.getValue()).toBe(`${floatValueRoundDown}%`);
@@ -172,7 +176,7 @@ describe('ProgressBar', () => {
             const floatValueFittingPrecision = +`${precision}.${(1)
               .toString()
               .repeat(precision)}`;
-            driver = createDriver(
+            driver = await createDriver(
               <LinearProgressBar
                 {...{ ...props, value: floatValueOverPrecision, precision }}
               />,
@@ -188,21 +192,23 @@ describe('ProgressBar', () => {
     describe('`min` & `max` properties', () => {
       it('should allow setting `min` prop', async () => {
         const min = -5;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, min }} />,
         );
         expect(await driver.getMinValue()).toBe(min);
       });
 
       it('should have default `min` prop value of 0', async () => {
-        const driver = createDriver(<LinearProgressBar {...defaultProps} />);
+        const driver = await createDriver(
+          <LinearProgressBar {...defaultProps} />,
+        );
         expect(await driver.getMinValue()).toBe(0);
       });
 
       it('should visually set progress to minimum if given `value` < `min`', async () => {
         const min = -5;
         const value = -35;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, min, value }} />,
         );
         expect(await driver.getWidth()).toBe(`0%`);
@@ -210,21 +216,23 @@ describe('ProgressBar', () => {
 
       it('should allow setting `max` prop', async () => {
         const max = 50;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, max }} />,
         );
         expect(await driver.getMaxValue()).toBe(max);
       });
 
       it('should have default `max` prop value of 100', async () => {
-        const driver = createDriver(<LinearProgressBar {...defaultProps} />);
+        const driver = await createDriver(
+          <LinearProgressBar {...defaultProps} />,
+        );
         expect(await driver.getMaxValue()).toBe(100);
       });
 
       it('should visually set progress to max if given `value` > `max`', async () => {
         const max = 50;
         const value = 112;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, max, value }} />,
         );
         expect(await driver.getWidth()).toBe(`100%`);
@@ -234,17 +242,17 @@ describe('ProgressBar', () => {
         const max = 200;
         const min = -200;
         const value = 0;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, max, min, value }} />,
         );
         expect(await driver.getWidth()).toBe(`50%`);
       });
     });
 
-    describe('Accessability props', () => {
+    describe('Accessibility props', () => {
       it('should set aria-valuenow based on value prop', async () => {
         const value = 56;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, value }} />,
         );
         expect(await driver.getAriaValueNow()).toBe(value);
@@ -252,32 +260,34 @@ describe('ProgressBar', () => {
       it('should set aria-valuenow based on value prop (not relative to range)', async () => {
         const value = 56;
         const max = 560;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, value, max }} />,
         );
         expect(await driver.getAriaValueNow()).toBe(value);
       });
       it('should set aria-valuemax based on max prop', async () => {
         const max = 56;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, max }} />,
         );
         expect(await driver.getAriaValueMax()).toBe(max);
       });
       it('should set aria-valuemin based on min prop', async () => {
         const min = 56;
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...{ ...defaultProps, min }} />,
         );
         expect(await driver.getAriaValueMin()).toBe(min);
       });
       it('should have role `progressbar`', async () => {
-        const driver = createDriver(<LinearProgressBar {...defaultProps} />);
+        const driver = await createDriver(
+          <LinearProgressBar {...defaultProps} />,
+        );
         expect(await driver.getRoleAttribute()).toBe('progressbar');
       });
       it('should allow passing `aria-valuetext` prop', async () => {
         const valueText = 'Some context';
-        const driver = createDriver(
+        const driver = await createDriver(
           <LinearProgressBar {...defaultProps} aria-valuetext={valueText} />,
         );
         expect(await driver.getAriaValueText()).toBe(valueText);

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.uni.driver.ts
@@ -2,9 +2,9 @@ import {
   BaseUniDriver,
   baseUniDriverFactory,
 } from 'wix-ui-test-utils/base-driver';
-import {UniDriver, StylableUnidriverUtil} from 'wix-ui-test-utils/unidriver';
+import { UniDriver, StylableUnidriverUtil } from 'wix-ui-test-utils/unidriver';
 import styles from './LinearProgressBar.st.css';
-import {ReactBase} from '../../../test/utils/unidriver/ReactBase';
+import { ReactBase } from '../../../test/utils/unidriver/ReactBase';
 import {
   ProgressBarDataHooks,
   ProgressBarDataKeys,
@@ -45,7 +45,7 @@ export interface LinearProgressBarUniDriver extends BaseUniDriver {
 }
 
 export const linearProgressBarUniDriverFactory = (
-  base: UniDriver
+  base: UniDriver,
 ): LinearProgressBarUniDriver => {
   const byDataHook = dataHook => `[data-hook="${dataHook}"]`;
   const stylableUnidriverUtil = new StylableUnidriverUtil(styles);

--- a/packages/wix-ui-core/src/components/loadable/Loadable.tsx
+++ b/packages/wix-ui-core/src/components/loadable/Loadable.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 type Module<LoadableExports> = {
-  [ModuleKey in keyof LoadableExports]: LoadableExports[ModuleKey]
+  [ModuleKey in keyof LoadableExports]: LoadableExports[ModuleKey];
 };
 
 // imported module representation.
@@ -9,12 +9,12 @@ export type LoaderMap<LoadableExports> = {
   [Key in keyof LoadableExports]?: () =>
     | LoadableExports[Key]
     | Module<LoadableExports>
-    | Promise<Module<LoadableExports>>
+    | Promise<Module<LoadableExports>>;
 };
 
 // Resolved module representation, that should be passed into render prop as an argument
 export type LoadedMap<LoadableExports> = {
-  [Key in keyof LoadableExports]?: LoadableExports[Key]
+  [Key in keyof LoadableExports]?: LoadableExports[Key];
 };
 
 export interface LoadableProps<LoadableExports> {
@@ -75,7 +75,7 @@ export class Loadable<LoadableExports> extends React.Component<
     }
   }
 
-  private resolveModule = (moduleItem, key = 'default') => {
+  private readonly resolveModule = (moduleItem, key = 'default') => {
     if (typeof moduleItem === 'function') {
       return moduleItem;
     }
@@ -93,17 +93,17 @@ export class Loadable<LoadableExports> extends React.Component<
    With webpack build (development, e2e) we'll have `import` not transpiled to `require`, which will create
    async flow. We should determine type of flow and according to it sync or async set the state.
   */
-  private loadSyncOrAsync = (): LoadedMap<LoadableExports> => {
+  private readonly loadSyncOrAsync = (): LoadedMap<LoadableExports> => {
     const { loader, namedExports = {} } = this.props;
 
     const resolvedModules: {
-      [Key in keyof LoadableExports]?: LoadableExports[Key]
+      [Key in keyof LoadableExports]?: LoadableExports[Key];
     } = {};
 
     const resolvedAsyncModules: {
       [Key in keyof LoadableExports]?:
         | LoadableExports[Key]
-        | Promise<LoadableExports[Key]>
+        | Promise<LoadableExports[Key]>;
     } = {};
 
     for (const loadableItemKey in loader) {
@@ -133,13 +133,15 @@ export class Loadable<LoadableExports> extends React.Component<
     }
 
     const resolvedKeys = Object.keys(resolvedAsyncModules);
-    Promise.all(resolvedKeys.map(key => resolvedAsyncModules[key])).then(modules => {
-      modules.forEach((resolvedModule, index) => {
-        const moduleName = resolvedKeys[index];
-        resolvedModules[moduleName] = resolvedModule;
-      });
-      this.setState({ loaded: resolvedModules, isLoading: false });
-    });
+    Promise.all(resolvedKeys.map(key => resolvedAsyncModules[key])).then(
+      modules => {
+        modules.forEach((resolvedModule, index) => {
+          const moduleName = resolvedKeys[index];
+          resolvedModules[moduleName] = resolvedModule;
+        });
+        this.setState({ loaded: resolvedModules, isLoading: false });
+      },
+    );
 
     return null;
   };

--- a/packages/wix-ui-core/src/components/media-image/index.ts
+++ b/packages/wix-ui-core/src/components/media-image/index.ts
@@ -1,1 +1,5 @@
-export { MediaImage, MediaPlatformItem, MediaImageScaling } from './media-image';
+export {
+  MediaImage,
+  MediaPlatformItem,
+  MediaImageScaling,
+} from './media-image';

--- a/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
@@ -13,7 +13,9 @@ import { FALLBACK_IMAGE } from '../image';
 
 describe('MediaImage', () => {
   const testContainer = new ReactDOMTestContainer().unmountAfterEachTest();
-  const createDriver = testContainer.createUniRenderer(mediaImageDriverFactory);
+  const createDriver = testContainer.createUniRendererAsync(
+    mediaImageDriverFactory,
+  );
   const sourceWidth = 800,
     sourceHeight = 800;
   const WIDTH = 400,

--- a/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
@@ -38,7 +38,7 @@ describe('MediaImage', () => {
   });
 
   it('displays image with given media platform item when fill scale is selected', async () => {
-    const mediaImageDriver = createDriver(
+    const mediaImageDriver = await createDriver(
       <MediaImage
         mediaPlatformItem={mediaPlatformItem}
         width={WIDTH}
@@ -69,7 +69,7 @@ describe('MediaImage', () => {
       options: fitImageOptions,
     };
 
-    const mediaImageDriver = createDriver(
+    const mediaImageDriver = await createDriver(
       <MediaImage
         mediaPlatformItem={fitMediaPlatformItem}
         width={WIDTH}
@@ -90,7 +90,7 @@ describe('MediaImage', () => {
   });
 
   it('should use mediaPlatformItem width/height if non provided', async () => {
-    const mediaImageDriver = createDriver(
+    const mediaImageDriver = await createDriver(
       <MediaImage mediaPlatformItem={mediaPlatformItem} />,
     );
 
@@ -108,7 +108,7 @@ describe('MediaImage', () => {
   it('displays an alt prop', async () => {
     imageClientSDK.getScaleToFillImageURL.mockReturnValue(BROKEN_SRC);
 
-    const imageDriver = createDriver(
+    const imageDriver = await createDriver(
       <MediaImage
         mediaPlatformItem={mediaPlatformItem}
         alt={'this is an informative text'}
@@ -121,7 +121,7 @@ describe('MediaImage', () => {
   it('should invoke onLoad callback when load successfully', async () => {
     imageClientSDK.getScaleToFillImageURL.mockReturnValue(SRC);
     const onLoadSpy = jest.fn();
-    const mediaImageDriver = createDriver(
+    const mediaImageDriver = await createDriver(
       <MediaImage onLoad={onLoadSpy} mediaPlatformItem={mediaPlatformItem} />,
     );
 
@@ -138,7 +138,9 @@ describe('MediaImage', () => {
   describe('props are not provided', () => {
     it('displays empty pixel when mediaPlatformItem are not provided', async () => {
       const onLoadSpy = jest.fn();
-      const mediaImageDriver = createDriver(<MediaImage onLoad={onLoadSpy} />);
+      const mediaImageDriver = await createDriver(
+        <MediaImage onLoad={onLoadSpy} />,
+      );
 
       await eventually(
         async () => {
@@ -163,7 +165,7 @@ describe('MediaImage', () => {
       imageClientSDK.getScaleToFillImageURL.mockReturnValueOnce(
         ERROR_IMAGE_SRC,
       );
-      const mediaImageDriver = createDriver(
+      const mediaImageDriver = await createDriver(
         <MediaImage
           mediaPlatformItem={mediaPlatformItem}
           errorMediaPlatformItem={mediaPlatformItem}
@@ -183,7 +185,7 @@ describe('MediaImage', () => {
 
     it('displays an empty pixel when both mediaPlatformItem and errorImage are broken', async () => {
       const onErrorSpy = jest.fn();
-      const mediaImageDriver = createDriver(
+      const mediaImageDriver = await createDriver(
         <MediaImage
           mediaPlatformItem={mediaPlatformItem}
           errorMediaPlatformItem={mediaPlatformItem}
@@ -203,7 +205,7 @@ describe('MediaImage', () => {
 
     it('displays an empty pixel when the provided mediaPlatformItem is broken and errorImage is not provided ', async () => {
       const onErrorSpy = jest.fn();
-      const mediaImageDriver = createDriver(
+      const mediaImageDriver = await createDriver(
         <MediaImage
           mediaPlatformItem={mediaPlatformItem}
           onError={onErrorSpy}

--- a/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { ReactDOMTestContainer } from '../../../test/dom-test-container';
 import { mediaImageDriverFactory } from './media-image.uni.driver';
-import { MediaPlatformItem, MediaImage, MediaImageScaling } from './media-image';
+import {
+  MediaPlatformItem,
+  MediaImage,
+  MediaImageScaling,
+} from './media-image';
 import * as imageClientSDK from 'image-client-api/dist/imageClientSDK';
 import * as eventually from 'wix-eventually';
 import { BROKEN_SRC, ERROR_IMAGE_SRC, SRC } from '../image/test-fixtures';
@@ -23,8 +27,12 @@ describe('MediaImage', () => {
   const defaultMediaItemOptions = {};
 
   beforeAll(() => {
-    getScaleToFillImageURL = jest.spyOn(imageClientSDK, 'getScaleToFillImageURL').mockReturnValue(SRC);
-    getScaleToFitImageURL = jest.spyOn(imageClientSDK, 'getScaleToFitImageURL').mockReturnValue(SRC);
+    getScaleToFillImageURL = jest
+      .spyOn(imageClientSDK, 'getScaleToFillImageURL')
+      .mockReturnValue(SRC);
+    getScaleToFitImageURL = jest
+      .spyOn(imageClientSDK, 'getScaleToFitImageURL')
+      .mockReturnValue(SRC);
   });
 
   it('displays image with given media platform item when fill scale is selected', async () => {
@@ -52,10 +60,13 @@ describe('MediaImage', () => {
       focalPoint: {
         x: 0,
         y: 0,
-      }
+      },
     };
-    let fitMediaPlatformItem = { ...mediaPlatformItem, options: fitImageOptions};
-    
+    const fitMediaPlatformItem = {
+      ...mediaPlatformItem,
+      options: fitImageOptions,
+    };
+
     const mediaImageDriver = createDriver(
       <MediaImage
         mediaPlatformItem={fitMediaPlatformItem}

--- a/packages/wix-ui-core/src/components/media-image/media-image.meta.ts
+++ b/packages/wix-ui-core/src/components/media-image/media-image.meta.ts
@@ -11,41 +11,38 @@ mediaImageMetadata.addStyle(style, {
   path: 'src/themes/default/image/style.st.css',
 });
 
-mediaImageMetadata
-  .addSim({
-    title: 'loading image',
-    props: {
-      mediaPlatformItem: SRC,
-      alt: 'This is an image of 2 flamingos',
-    },
-    state: {
-      status: ImageStatus.loading
-    }
-  });
+mediaImageMetadata.addSim({
+  title: 'loading image',
+  props: {
+    mediaPlatformItem: SRC,
+    alt: 'This is an image of 2 flamingos',
+  },
+  state: {
+    status: ImageStatus.loading,
+  },
+});
 
-mediaImageMetadata
-  .addSim({
-    title: 'succeeded with rendering an image',
-    props: {
-      mediaPlatformItem: SRC,
-      alt: 'This is an image of 2 flamingos',
-    },
-    state: {
-      status: ImageStatus.loaded
-    }
-  });
+mediaImageMetadata.addSim({
+  title: 'succeeded with rendering an image',
+  props: {
+    mediaPlatformItem: SRC,
+    alt: 'This is an image of 2 flamingos',
+  },
+  state: {
+    status: ImageStatus.loaded,
+  },
+});
 
-mediaImageMetadata
-  .addSim({
-    title: 'failed with rendering an image',
-    props: {
-      errorMediaPlatformItem: BROKEN_SRC,
-      alt: 'This is a broken image',
-    },
-    state: {
-      status: ImageStatus.error
-    }
-  });
+mediaImageMetadata.addSim({
+  title: 'failed with rendering an image',
+  props: {
+    errorMediaPlatformItem: BROKEN_SRC,
+    alt: 'This is a broken image',
+  },
+  state: {
+    status: ImageStatus.error,
+  },
+});
 
 mediaImageMetadata.exportInfo = {
   path: 'src/components/media-image/media-image',

--- a/packages/wix-ui-core/src/components/media-image/media-image.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { getScaleToFillImageURL, getScaleToFitImageURL } from 'image-client-api/dist/imageClientSDK';
+import {
+  getScaleToFillImageURL,
+  getScaleToFitImageURL,
+} from 'image-client-api/dist/imageClientSDK';
 
 import { Image } from '../image';
 
@@ -22,28 +25,28 @@ export enum MediaImageUpscaleMethod {
 }
 
 export interface FocalPoint {
-  x: number,
-  y: number,
+  x: number;
+  y: number;
 }
 
 export interface MediaItemFilters {
-  blur?: number,
+  blur?: number;
 }
 
 export interface UnsharpMaskOptions {
-  amount?: number,
-  radius?: number,
-  threshold?: number,
+  amount?: number;
+  radius?: number;
+  threshold?: number;
 }
 
 export interface MediaItemOptions {
-  quality?: number,
-  focalPoint?: FocalPoint,
-  filters?: MediaItemFilters,
-  unsharpMask?: UnsharpMaskOptions,
-  upscaleMethod?: MediaImageUpscaleMethod,
-  watermark?: string,
-  isSEOBot?: boolean,
+  quality?: number;
+  focalPoint?: FocalPoint;
+  filters?: MediaItemFilters;
+  unsharpMask?: UnsharpMaskOptions;
+  upscaleMethod?: MediaImageUpscaleMethod;
+  watermark?: string;
+  isSEOBot?: boolean;
   name?: string;
 }
 
@@ -73,7 +76,10 @@ export class MediaImage extends React.Component<MediaProps> {
         uri,
       } = mediaPlatformItem;
       const { options } = mediaPlatformItem;
-      const getScaleToImageURL = scale === MediaImageScaling.FIT ? getScaleToFitImageURL : getScaleToFillImageURL;
+      const getScaleToImageURL =
+        scale === MediaImageScaling.FIT
+          ? getScaleToFitImageURL
+          : getScaleToFillImageURL;
 
       return getScaleToImageURL(
         uri,
@@ -86,14 +92,13 @@ export class MediaImage extends React.Component<MediaProps> {
     }
   }
 
-
   render() {
     const {
       onLoad,
       onError,
       mediaPlatformItem,
       errorMediaPlatformItem,
-      alt
+      alt,
     } = this.props;
 
     return (

--- a/packages/wix-ui-core/src/components/media-image/test-fixtures.ts
+++ b/packages/wix-ui-core/src/components/media-image/test-fixtures.ts
@@ -1,4 +1,4 @@
-import {MediaPlatformItem} from './media-image';
+import { MediaPlatformItem } from './media-image';
 
 // Valid image
 export const SRC: MediaPlatformItem = {

--- a/packages/wix-ui-core/src/components/menu-item/menu-item.tsx
+++ b/packages/wix-ui-core/src/components/menu-item/menu-item.tsx
@@ -18,7 +18,7 @@ export interface MenuItemProps {
   disabled?: boolean;
 }
 
-export const MenuItem: React.SFC<MenuItemProps> = props => {
+export const MenuItem: React.FunctionComponent<MenuItemProps> = props => {
   const { selected, highlighted, disabled, onSelect, ...rest } = props;
 
   return (

--- a/packages/wix-ui-core/src/components/nav-stepper/NavStepper.e2e.ts
+++ b/packages/wix-ui-core/src/components/nav-stepper/NavStepper.e2e.ts
@@ -1,11 +1,17 @@
 import { browser } from 'protractor';
 import * as eyes from 'eyes.it';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { navStepperTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 describe('NavStepper', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'NavStepper');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'NavStepper',
+  });
 
   beforeEach(() => browser.get(storyUrl));
 

--- a/packages/wix-ui-core/src/components/pagination/Pagination.e2e.ts
+++ b/packages/wix-ui-core/src/components/pagination/Pagination.e2e.ts
@@ -1,11 +1,17 @@
 import { paginationTestkitFactory } from '../../testkit/protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { browser } from 'protractor';
 import * as eyes from 'eyes.it';
 import { Category } from '../../../stories/utils';
 
 describe('Pagination', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Pagination');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Pagination',
+  });
 
   beforeEach(() => browser.get(storyUrl));
 

--- a/packages/wix-ui-core/src/components/pagination/Pagination.spec.tsx
+++ b/packages/wix-ui-core/src/components/pagination/Pagination.spec.tsx
@@ -23,6 +23,7 @@ describe('Pagination', () => {
   const render = jsx =>
     container
       .render(jsx)
+      /* tslint:disable-next-line:no-non-null-assertion */
       .then(() => new PaginationDriver(container.componentNode!));
 
   describe('Accessibility', () => {

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -37,7 +37,7 @@ describe('Popover', () => {
   });
 
   describe('[async]', () => {
-    const createDriver = container.createUniRenderer((base, body) => {
+    const createDriver = container.createUniRendererAsync((base, body) => {
       const privateDriver = popoverPrivateDriverFactory({
         element: container.componentNode,
         eventTrigger: Simulate,
@@ -55,7 +55,7 @@ describe('Popover', () => {
 
 function runTests(createDriver, container) {
   it('should render', async () => {
-    const driver = createDriver(
+    const driver = await createDriver(
       popoverWithProps({
         placement: 'bottom',
         shown: false,
@@ -67,7 +67,7 @@ function runTests(createDriver, container) {
 
   describe('Display', () => {
     it(`doesn't display popup when shown={false}`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: false,
@@ -79,7 +79,7 @@ function runTests(createDriver, container) {
     });
 
     it(`displays popup when shown={true}`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: true,
@@ -95,7 +95,7 @@ function runTests(createDriver, container) {
       const onMouseEnter = jest.fn();
       const onMouseLeave = jest.fn();
 
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: false,
@@ -115,7 +115,7 @@ function runTests(createDriver, container) {
       it('should execute onClick callback', async () => {
         const onClick = jest.fn();
 
-        const driver = createDriver(
+        const driver = await createDriver(
           popoverWithProps({
             placement: 'bottom',
             shown: false,
@@ -132,7 +132,7 @@ function runTests(createDriver, container) {
       it('should be triggered when outside of the popover is called', async () => {
         const onClickOutside = jest.fn();
 
-        const driver = createDriver(
+        const driver = await createDriver(
           popoverWithProps({
             placement: 'bottom',
             shown: false,
@@ -154,7 +154,7 @@ function runTests(createDriver, container) {
         it(`should not be triggered when content is clicked and appended to ${value}`, async () => {
           const onClickOutside = jest.fn();
 
-          const driver = createDriver(
+          const driver = await createDriver(
             popoverWithProps({
               placement: 'bottom',
               shown: true,
@@ -182,7 +182,7 @@ function runTests(createDriver, container) {
     });
 
     it(`offsets the popup arrow by specified amount`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: true,
@@ -195,7 +195,7 @@ function runTests(createDriver, container) {
     });
 
     it(`should update popper's position when props are chaning`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps(
           {
             placement: 'bottom',
@@ -205,7 +205,7 @@ function runTests(createDriver, container) {
         ),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps(
           {
             placement: 'bottom',
@@ -220,7 +220,7 @@ function runTests(createDriver, container) {
     });
 
     it(`should not directly update popper's position when the visibillity hasn't changed`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -229,7 +229,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -238,7 +238,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -259,11 +259,11 @@ function runTests(createDriver, container) {
       queryHook<HTMLElement>(document, 'popover-content');
 
     it(`animates on close given a timeout`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({ placement: 'bottom', shown: true, timeout: 10 }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({ placement: 'bottom', shown: false, timeout: 10 }),
       );
 
@@ -277,11 +277,11 @@ function runTests(createDriver, container) {
     });
 
     it(`doesn't animate on close when timeout={0}`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({ placement: 'bottom', shown: true, timeout: 0 }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({ placement: 'bottom', shown: false, timeout: 0 }),
       );
 
@@ -289,7 +289,7 @@ function runTests(createDriver, container) {
     });
 
     it(`doesn't animate on close when timeout is an object with 0 values`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: true,
@@ -297,7 +297,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: false,
@@ -309,7 +309,7 @@ function runTests(createDriver, container) {
     });
 
     it(`should close after hideDelay`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -317,7 +317,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -335,7 +335,7 @@ function runTests(createDriver, container) {
     });
 
     it(`should open after showDelay`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           showDelay: 10,
@@ -343,7 +343,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           showDelay: 10,
@@ -361,7 +361,7 @@ function runTests(createDriver, container) {
     });
 
     it(`should reset timeout when state has changed`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -370,7 +370,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -379,7 +379,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -394,7 +394,7 @@ function runTests(createDriver, container) {
     });
 
     it(`should not update delay until the popover visibillity has fully changed`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -402,7 +402,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 10,
@@ -410,7 +410,7 @@ function runTests(createDriver, container) {
         }),
       );
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 1000,
@@ -427,7 +427,7 @@ function runTests(createDriver, container) {
     });
 
     it(`should show the popover immediately on first render if needed`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           showDelay: 10,
@@ -439,7 +439,7 @@ function runTests(createDriver, container) {
     });
 
     it(`should show the popover immediately when delays are 0`, async () => {
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 0,
@@ -450,7 +450,7 @@ function runTests(createDriver, container) {
 
       expect(queryPopoverContent()).toBeNull();
 
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 0,
@@ -462,7 +462,7 @@ function runTests(createDriver, container) {
       expect(queryPopoverContent()).toBeTruthy();
 
       // Close again the popover
-      createDriver(
+      await createDriver(
         popoverWithProps({
           placement: 'bottom',
           hideDelay: 0,
@@ -479,7 +479,7 @@ function runTests(createDriver, container) {
     const portalContainer = new ReactDOMTestContainer().destroyAfterEachTest();
 
     it(`renders the popup directly into the popover root by default`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: true,
@@ -492,7 +492,7 @@ function runTests(createDriver, container) {
     });
 
     it(`renders the popup into a portal when given appendTo prop`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: true,
@@ -512,7 +512,7 @@ function runTests(createDriver, container) {
     });
 
     it(`renders an empty portal when closed`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: false,
@@ -530,7 +530,7 @@ function runTests(createDriver, container) {
     });
 
     it(`removes the portal on unmount`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: true,
@@ -544,7 +544,7 @@ function runTests(createDriver, container) {
     });
 
     it(`adds the portal to the body when appendTo="window"`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: true,
@@ -558,7 +558,7 @@ function runTests(createDriver, container) {
     });
 
     it(`adds the portal to the closest scrollable element when appendTo="scrollParent"`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <div style={{ overflow: 'scroll' }}>
           <div style={{ overflow: 'visible' }}>
             {popoverWithProps({
@@ -576,7 +576,7 @@ function runTests(createDriver, container) {
     });
 
     it(`adds the portal next to the popover's element when appendTo="parent"`, async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           placement: 'bottom',
           shown: true,
@@ -596,7 +596,7 @@ function runTests(createDriver, container) {
       it(`should update the portal's styles when updated`, async () => {
         // First render without passing the `className` prop, the <Popover/>
         // portal should only have the root class applied.
-        createDriver(
+        await createDriver(
           popoverWithProps({
             placement: 'bottom',
             shown: true,
@@ -606,7 +606,7 @@ function runTests(createDriver, container) {
 
         // Second render with a `className` prop. Stylable `style()` function
         // should apply it.
-        createDriver(
+        await createDriver(
           popoverWithProps({
             placement: 'bottom',
             shown: true,
@@ -619,7 +619,7 @@ function runTests(createDriver, container) {
       });
 
       it(`should not remove styles until unmounted with hideDelay`, async () => {
-        createDriver(
+        await createDriver(
           popoverWithProps({
             placement: 'bottom',
             shown: true,
@@ -628,7 +628,7 @@ function runTests(createDriver, container) {
           }),
         );
 
-        createDriver(
+        await createDriver(
           popoverWithProps({
             placement: 'bottom',
             shown: false,
@@ -648,7 +648,7 @@ function runTests(createDriver, container) {
 
   describe('React <16 compatibility', () => {
     it('should wrap children in a <div/> if provided as strings to support React 15', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Popover shown placement="bottom">
           <Popover.Element>Element</Popover.Element>
           <Popover.Content>Content</Popover.Content>
@@ -810,7 +810,7 @@ function runTests(createDriver, container) {
 
   describe('data-hook', () => {
     it('should be found on target element container', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Popover data-hook="random" appendTo="window" shown placement="bottom">
           <Popover.Element>Element</Popover.Element>
           <Popover.Content>Content</Popover.Content>
@@ -821,7 +821,7 @@ function runTests(createDriver, container) {
     });
 
     it('should construct data-content-hook', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Popover data-hook="random" appendTo="window" shown placement="bottom">
           <Popover.Element>Element</Popover.Element>
           <Popover.Content>Content</Popover.Content>
@@ -834,7 +834,7 @@ function runTests(createDriver, container) {
     });
 
     it('should apply data-content-element on content element', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Popover data-hook="random" appendTo="window" shown placement="bottom">
           <Popover.Element>Element</Popover.Element>
           <Popover.Content>Content</Popover.Content>
@@ -846,7 +846,7 @@ function runTests(createDriver, container) {
       );
     });
     it('should not override portal component data-hook', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         <Popover data-hook="random" appendTo="window" shown placement="bottom">
           <Popover.Element>Element</Popover.Element>
           <Popover.Content>Content</Popover.Content>
@@ -865,7 +865,7 @@ function runTests(createDriver, container) {
     }
 
     it('should display a custom arrow element', async () => {
-      const driver = createDriver(
+      const driver = await createDriver(
         popoverWithProps({
           shown: true,
           showArrow: true,

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -133,8 +133,8 @@ export interface PopoverState {
 }
 
 export type PopoverType = PopoverProps & {
-  Element?: React.SFC<ElementProps>;
-  Content?: React.SFC<ElementProps>;
+  Element?: React.FunctionComponent<ElementProps>;
+  Content?: React.FunctionComponent<ElementProps>;
 };
 
 const shouldAnimatePopover = ({ timeout }: PopoverProps) => {

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PopperJS from 'popper.js';
-import { getScrollParent } from 'popper.js/dist/umd/popper-utils';
 import onClickOutside, {
   OnClickOutProps,
   InjectedOnClickOutProps,
@@ -10,7 +9,11 @@ import { CSSTransition } from 'react-transition-group';
 import { Portal } from 'react-portal';
 import style from './Popover.st.css';
 import { createModifiers } from './modifiers';
-import { AttributeMap } from '../../utils/stylableUtils';
+import {
+  AttributeMap,
+  attachStylesToNode,
+  detachStylesFromNode,
+} from '../../utils/stylableUtils';
 
 import {
   buildChildrenObject,
@@ -18,13 +21,7 @@ import {
   ElementProps,
 } from '../../utils';
 
-import {
-  attachStylesToNode,
-  detachStylesFromNode,
-} from '../../utils/stylableUtils';
-
 import * as classNames from 'classnames';
-const isElement = require('lodash/isElement');
 
 import { popoverTestUtils } from './helpers';
 import { getAppendToElement, Predicate } from './utils/getAppendToElement';

--- a/packages/wix-ui-core/src/components/popover/Popover.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.uni.driver.ts
@@ -11,7 +11,7 @@ export const testkit = (base: UniDriver, body: UniDriver) => {
 
   return {
     ...baseUniDriverFactory(base),
-    click: async () => await byHook('popover-element').click(),
+    click: async () => byHook('popover-element').click(),
     getTargetElement: async () => safeGetNative(byHook('popover-element')),
 
     getPortalElement: async () =>

--- a/packages/wix-ui-core/src/components/popover/modifiers.ts
+++ b/packages/wix-ui-core/src/components/popover/modifiers.ts
@@ -1,6 +1,5 @@
 import PopperJS from 'popper.js';
 
-
 const getUnit = value => {
   if (typeof value === 'string') {
     return value;
@@ -36,7 +35,7 @@ const resolveWidth = ({
   referenceWidth,
 }): styles => {
   return {
-    minWidth: dynamicWidth ? `${referenceWidth}px` : getUnit(minWidth), 
+    minWidth: dynamicWidth ? `${referenceWidth}px` : getUnit(minWidth),
     width: width || 'auto',
   };
 };

--- a/packages/wix-ui-core/src/components/radio-button/RadioButton.e2e.ts
+++ b/packages/wix-ui-core/src/components/radio-button/RadioButton.e2e.ts
@@ -1,11 +1,17 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { radioButtonTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 describe('RadioButton', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'RadioButton');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'RadioButton',
+  });
 
   beforeEach(() => browser.get(storyUrl));
 

--- a/packages/wix-ui-core/src/components/signature-input/docs/index.story.tsx
+++ b/packages/wix-ui-core/src/components/signature-input/docs/index.story.tsx
@@ -105,7 +105,7 @@ export default {
               'A canvas based signature input, it also provides reset button and title',
           }),
           importExample(
-            "import {SignatureInput} from 'wix-ui-core/signature-input';",
+            'import {SignatureInput} from \'wix-ui-core/signature-input\';',
           ),
           divider(),
           title('Examples'),
@@ -113,7 +113,7 @@ export default {
             description({
               title: 'Basic example',
               text:
-                "`SignatureInput` does not render anything, but uses compounding to provide all the component's parts. " +
+                '`SignatureInput` does not render anything, but uses compounding to provide all the component\'s parts. ' +
                 'The `SignatureInput.Title` and `SignatureInput.ClearButton` provide render functions to get needed ' +
                 'props for rendering.',
             }),

--- a/packages/wix-ui-core/src/components/signature-input/docs/index.story.tsx
+++ b/packages/wix-ui-core/src/components/signature-input/docs/index.story.tsx
@@ -11,20 +11,21 @@ import {
   tabs,
   tab,
   divider,
-  code,
+  code as baseCode,
   testkit,
   importExample,
   playground,
   columns,
-  code as baseCode,
 } from 'wix-storybook-utils/Sections';
-import { Category } from '../../../../stories/utils';
-import { baseScope as allComponents } from '../../../../stories/utils';
+import {
+  Category,
+  baseScope as allComponents,
+} from '../../../../stories/utils';
 import compoundReadmeApi from './CompoundComponentsAPI.md';
 import { SigningPadOwnProps } from '../signing-pad/SigningPad';
 
 const liveCode = config =>
-  code({
+  baseCode({
     compact: true,
     components: allComponents,
     ...config,

--- a/packages/wix-ui-core/src/components/signature-input/signing-pad/SigningPad.tsx
+++ b/packages/wix-ui-core/src/components/signature-input/signing-pad/SigningPad.tsx
@@ -273,7 +273,7 @@ class SigningPadComp extends React.Component<SigningPadProps, SigningPadState> {
           aria-hidden
           {...rest}
           onClick={this.invokeIfDefined(!disabled && onClick)}
-        ></canvas>
+        />
       </React.Fragment>
     );
   }

--- a/packages/wix-ui-core/src/components/signature-input/test/SignatureInput.e2e.ts
+++ b/packages/wix-ui-core/src/components/signature-input/test/SignatureInput.e2e.ts
@@ -11,7 +11,7 @@ const createDriver = () =>
 
 const navigateToStory = ({ suffix = '' } = {}) => browser.get(storyUrl(suffix));
 
-const storyUrl = suffix =>
+const storyUrl = (suffix: string) =>
   createStoryUrl({
     kind: Category.TESTS,
     story: SIGNATURE_INPUT_METADATA.displayName + suffix,
@@ -32,14 +32,14 @@ describe('Signature Input', () => {
   eyes.it('should support drawing with black color by default', async () => {
     await navigateToStory();
     const driver = createDriver();
-    const signaturePad = await driver.getChildDriverByHook(TEST_IDS.PAD);
+    const signaturePad = driver.getChildDriverByHook(TEST_IDS.PAD);
     await signaturePad.click();
   });
 
   eyes.it('should support drawing with specific color', async () => {
     await navigateToStory({ suffix: 'Color' });
     const driver = createDriver();
-    const signaturePad = await driver.getChildDriverByHook(TEST_IDS.PAD);
+    const signaturePad = driver.getChildDriverByHook(TEST_IDS.PAD);
     await signaturePad.click();
   });
 
@@ -49,7 +49,7 @@ describe('Signature Input', () => {
       await navigateToStory({ suffix: 'ColorInvalid' });
       const driver = createDriver();
       debugger;
-      const signaturePad = await driver.getChildDriverByHook(TEST_IDS.PAD);
+      const signaturePad = driver.getChildDriverByHook(TEST_IDS.PAD);
       await signaturePad.click();
     },
   );
@@ -57,25 +57,23 @@ describe('Signature Input', () => {
   eyes.it('should support clearing', async () => {
     await navigateToStory();
     const driver = createDriver();
-    const signaturePad = await driver.getChildDriverByHook(TEST_IDS.PAD);
+    const signaturePad = driver.getChildDriverByHook(TEST_IDS.PAD);
     await signaturePad.click();
-    const clearButton = await driver.getChildDriverByHook(
-      TEST_IDS.CLEAR_BUTTON,
-    );
+    const clearButton = driver.getChildDriverByHook(TEST_IDS.CLEAR_BUTTON);
     await clearButton.click();
   });
 
   eyes.it('should not draw if the signature pad is disabled', async () => {
     await navigateToStory({ suffix: 'Disabled' });
     const driver = createDriver();
-    const signaturePad = await driver.getChildDriverByHook(TEST_IDS.PAD);
+    const signaturePad = driver.getChildDriverByHook(TEST_IDS.PAD);
     await signaturePad.click();
   });
 
   eyes.it('should support drawing characters', async () => {
     await navigateToStory();
     const driver = createDriver();
-    const a11yInput = await driver.getA11yInput();
+    const a11yInput = driver.getA11yInput();
     await a11yInput.enterValue('a value');
   });
 });

--- a/packages/wix-ui-core/src/components/signature-input/test/SignatureInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/signature-input/test/SignatureInput.spec.tsx
@@ -26,13 +26,13 @@ describe('SigningPad', () => {
 
   it('should pass props to title component', async () => {
     const driver = createDriver();
-    const title = await driver.getChildDriverByHook(TEST_IDS.TITLE);
+    const title = driver.getChildDriverByHook(TEST_IDS.TITLE);
     expect(await title.exists()).toBe(true);
   });
 
   it('should pass props to clear button component', async () => {
     const driver = createDriver();
-    const label = await driver.getChildDriverByHook(TEST_IDS.CLEAR_BUTTON);
+    const label = driver.getChildDriverByHook(TEST_IDS.CLEAR_BUTTON);
     expect(await label.exists()).toBe(true);
   });
 
@@ -40,9 +40,7 @@ describe('SigningPad', () => {
     it('should invoke onClear callback', async () => {
       const onClearSpy = jest.fn();
       const driver = createDriver({ onClear: onClearSpy });
-      const clearButton = await driver.getChildDriverByHook(
-        TEST_IDS.CLEAR_BUTTON,
-      );
+      const clearButton = driver.getChildDriverByHook(TEST_IDS.CLEAR_BUTTON);
       await clearButton.click();
       expect(onClearSpy).toHaveBeenCalled();
     });
@@ -74,7 +72,7 @@ describe('SigningPad', () => {
     it('should invoke pad onClick', async () => {
       const canvasOnClickSpy = jest.fn();
       const driver = createDriver({ onClick: canvasOnClickSpy });
-      const padDriver = await driver.getChildDriverByHook(TEST_IDS.PAD);
+      const padDriver = driver.getChildDriverByHook(TEST_IDS.PAD);
 
       await padDriver.click();
 
@@ -87,7 +85,7 @@ describe('SigningPad', () => {
         onClick: canvasOnClickSpy,
         disabled: true,
       });
-      const padDriver = await driver.getChildDriverByHook(TEST_IDS.PAD);
+      const padDriver = driver.getChildDriverByHook(TEST_IDS.PAD);
 
       await padDriver.click();
 
@@ -133,7 +131,7 @@ describe('SigningPad', () => {
 
     it('should set a11y input aria-labelledby to title id', async () => {
       const driver = createDriver();
-      const titleDriver = await driver.getChildDriverByHook(TEST_IDS.TITLE);
+      const titleDriver = driver.getChildDriverByHook(TEST_IDS.TITLE);
 
       const a11yInputAriaLabelledBy = await driver
         .getA11yInput()
@@ -155,7 +153,7 @@ describe('SigningPad', () => {
 
     it('should set clear button aria-controls to a11y input id', async () => {
       const driver = createDriver();
-      const clearButtonDriver = await driver.getChildDriverByHook(
+      const clearButtonDriver = driver.getChildDriverByHook(
         TEST_IDS.CLEAR_BUTTON,
       );
 
@@ -169,7 +167,7 @@ describe('SigningPad', () => {
 
     it('should clear a11y input when clear button is clicked', async () => {
       const driver = createDriver();
-      const clearButtonDriver = await driver.getChildDriverByHook(
+      const clearButtonDriver = driver.getChildDriverByHook(
         TEST_IDS.CLEAR_BUTTON,
       );
       const a11yInputDriver = driver.getA11yInput();

--- a/packages/wix-ui-core/src/components/signature-input/test/SignatureInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/signature-input/test/SignatureInput.spec.tsx
@@ -13,25 +13,25 @@ const createDriver = ({
   titleText = 'Enter your signature here:',
   ...rest
 }: SignatureInputTestFixtureProps = {}) =>
-  testContainer.createUniRenderer(signatureInputPrivateUniDriverFactory)(
+  testContainer.createUniRendererAsync(signatureInputPrivateUniDriverFactory)(
     <SignatureInputTestFixture titleText={titleText} {...rest} />,
   );
 
 describe('SigningPad', () => {
   it('should exist', async () => {
-    const driver = createDriver();
+    const driver = await createDriver();
     const doesExist = await driver.exists();
     expect(doesExist).toBe(true);
   });
 
   it('should pass props to title component', async () => {
-    const driver = createDriver();
+    const driver = await createDriver();
     const title = driver.getChildDriverByHook(TEST_IDS.TITLE);
     expect(await title.exists()).toBe(true);
   });
 
   it('should pass props to clear button component', async () => {
-    const driver = createDriver();
+    const driver = await createDriver();
     const label = driver.getChildDriverByHook(TEST_IDS.CLEAR_BUTTON);
     expect(await label.exists()).toBe(true);
   });
@@ -39,7 +39,7 @@ describe('SigningPad', () => {
   describe('callbacks', () => {
     it('should invoke onClear callback', async () => {
       const onClearSpy = jest.fn();
-      const driver = createDriver({ onClear: onClearSpy });
+      const driver = await createDriver({ onClear: onClearSpy });
       const clearButton = driver.getChildDriverByHook(TEST_IDS.CLEAR_BUTTON);
       await clearButton.click();
       expect(onClearSpy).toHaveBeenCalled();
@@ -71,7 +71,7 @@ describe('SigningPad', () => {
 
     it('should invoke pad onClick', async () => {
       const canvasOnClickSpy = jest.fn();
-      const driver = createDriver({ onClick: canvasOnClickSpy });
+      const driver = await createDriver({ onClick: canvasOnClickSpy });
       const padDriver = driver.getChildDriverByHook(TEST_IDS.PAD);
 
       await padDriver.click();
@@ -81,7 +81,7 @@ describe('SigningPad', () => {
 
     it('should not invoke disabled pad onClick', async () => {
       const canvasOnClickSpy = jest.fn();
-      const driver = createDriver({
+      const driver = await createDriver({
         onClick: canvasOnClickSpy,
         disabled: true,
       });
@@ -94,7 +94,7 @@ describe('SigningPad', () => {
 
     it('should invoke onFocus', async () => {
       const inputOnFocusSpy = jest.fn();
-      const driver = createDriver({
+      const driver = await createDriver({
         onFocus: inputOnFocusSpy,
       });
 
@@ -105,7 +105,7 @@ describe('SigningPad', () => {
 
     it('should invoke onBlur', async () => {
       const inputOnBlurSpy = jest.fn();
-      const driver = createDriver({
+      const driver = await createDriver({
         onBlur: inputOnBlurSpy,
       });
 
@@ -118,19 +118,19 @@ describe('SigningPad', () => {
 
   describe('accessibility', () => {
     it('should set disabled for a11y input', async () => {
-      const driver = createDriver({ disabled: true });
+      const driver = await createDriver({ disabled: true });
       const hasDisabled = await driver.getA11yInput().attr('disabled');
       expect(hasDisabled).not.toBe(null);
     });
 
     it('should set required for a11y input', async () => {
-      const driver = createDriver({ required: true });
+      const driver = await createDriver({ required: true });
       const hasRequired = await driver.getA11yInput().attr('required');
       expect(hasRequired).not.toBe(null);
     });
 
     it('should set a11y input aria-labelledby to title id', async () => {
-      const driver = createDriver();
+      const driver = await createDriver();
       const titleDriver = driver.getChildDriverByHook(TEST_IDS.TITLE);
 
       const a11yInputAriaLabelledBy = await driver
@@ -142,7 +142,7 @@ describe('SigningPad', () => {
     });
 
     it('should not set a11y input aria-labelledby when title is not rendered', async () => {
-      const driver = createDriver({ titleText: '' });
+      const driver = await createDriver({ titleText: '' });
 
       const a11yInputAriaLabelledBy = await driver
         .getA11yInput()
@@ -152,7 +152,7 @@ describe('SigningPad', () => {
     });
 
     it('should set clear button aria-controls to a11y input id', async () => {
-      const driver = createDriver();
+      const driver = await createDriver();
       const clearButtonDriver = driver.getChildDriverByHook(
         TEST_IDS.CLEAR_BUTTON,
       );
@@ -166,7 +166,7 @@ describe('SigningPad', () => {
     });
 
     it('should clear a11y input when clear button is clicked', async () => {
-      const driver = createDriver();
+      const driver = await createDriver();
       const clearButtonDriver = driver.getChildDriverByHook(
         TEST_IDS.CLEAR_BUTTON,
       );

--- a/packages/wix-ui-core/src/components/signature-input/title/Title.tsx
+++ b/packages/wix-ui-core/src/components/signature-input/title/Title.tsx
@@ -50,7 +50,7 @@ class TitleComp extends React.Component<TitleProps> {
 
   render() {
     const { children = null } = this.props;
-    <div />;
+
     return (
       children &&
       children({

--- a/packages/wix-ui-core/src/components/slider/Slider.e2e.ts
+++ b/packages/wix-ui-core/src/components/slider/Slider.e2e.ts
@@ -1,7 +1,6 @@
 import { sliderTestkitFactory } from '../../testkit/protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import { getStoryUrl } from 'wix-ui-test-utils/protractor';
 import { browser } from 'protractor';
-import * as eyes from 'eyes.it';
 import { Category } from '../../../stories/utils';
 
 describe('Slider', () => {
@@ -51,7 +50,7 @@ describe('Slider', () => {
   });
 
   async function assertTooltipValueApproximately(approxValue) {
-    const value = parseInt(await driver.getTooltipValue());
+    const value = parseInt(await driver.getTooltipValue(), 10);
     expect(value).toBeGreaterThanOrEqual(approxValue - 1);
     expect(value).toBeLessThanOrEqual(approxValue + 1);
   }

--- a/packages/wix-ui-core/src/components/slider/Slider.e2e.ts
+++ b/packages/wix-ui-core/src/components/slider/Slider.e2e.ts
@@ -1,12 +1,15 @@
 import { sliderTestkitFactory } from '../../testkit/protractor';
-import { getStoryUrl } from 'wix-ui-test-utils/protractor';
+import { createStoryUrl } from 'wix-ui-test-utils/protractor';
 import { browser } from 'protractor';
 import { Category } from '../../../stories/utils';
 
 describe('Slider', () => {
   let driver;
 
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Slider');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Slider',
+  });
 
   beforeEach(() => browser.get(storyUrl));
 

--- a/packages/wix-ui-core/src/components/slider/Slider.meta.ts
+++ b/packages/wix-ui-core/src/components/slider/Slider.meta.ts
@@ -5,6 +5,6 @@ const sliderMetadata = Registry.getComponentMetadata(Slider);
 sliderMetadata.addSim({
   title: 'sliderSim',
   props: {
-    'aria-label': 'slider'
+    'aria-label': 'slider',
   },
 });

--- a/packages/wix-ui-core/src/components/slider/Slider.spec.tsx
+++ b/packages/wix-ui-core/src/components/slider/Slider.spec.tsx
@@ -552,7 +552,7 @@ describe('Slider', () => {
 
     it('should pass aria-label prop onto root element', async () => {
       const ariaLabel = 'slider-test';
-      const driver = render({'aria-label': ariaLabel});
+      const driver = render({ 'aria-label': ariaLabel });
       expect(driver.ariaLabel()).toEqual(ariaLabel);
     });
   });

--- a/packages/wix-ui-core/src/components/slider/Slider.tsx
+++ b/packages/wix-ui-core/src/components/slider/Slider.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { Ticks } from './Ticks';
 import { Thumb, getThumbSize } from './Thumb';
 import pStyle from './Slider.st.css';
-const noop = require('lodash/noop');
+
+const noop = () => {};
 
 export interface SliderProps {
   min?: number;
@@ -305,7 +306,7 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
       ev = ev.touches[0];
     }
 
-    const { min, max, disabled, readOnly, dir } = this.props;
+    const { min, max, disabled, readOnly } = this.props;
     const rtl = this.isRtl();
 
     if (disabled || readOnly) {
@@ -375,7 +376,6 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
 
   calcThumbPosition() {
     const progressVal = this.calcThumbProgressPosition();
-    const crossVal = this.calcThumbCrossPosition();
 
     if (this.isVertical()) {
       return { bottom: progressVal, left: 0 };
@@ -426,7 +426,7 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
     const tickSize = this.props.tickMarksShape === 'line' ? 10 : 3;
     const tickMarksPos = this.props.tickMarksPosition;
     const tickMarksGap = 12;
-    let offsetWidth, offsetHeight, offsetLeft, offsetTop;
+    let offsetHeight, offsetTop;
 
     if (tickMarksPos === 'normal') {
       offsetHeight = tickSize + tickMarksGap;

--- a/packages/wix-ui-core/src/components/tags-list/Tag.tsx
+++ b/packages/wix-ui-core/src/components/tags-list/Tag.tsx
@@ -27,7 +27,8 @@ export const Tag: React.FunctionComponent<TagProps> = ({
     className={classNames(style.tag, className)}
     title={children}
     htmlFor={value}
-    {...rest}>
+    {...rest}
+  >
     <input
       data-hook={DataHooks.TagInput}
       className={style.tagInput}

--- a/packages/wix-ui-core/src/components/tags-list/TagsList.tsx
+++ b/packages/wix-ui-core/src/components/tags-list/TagsList.tsx
@@ -23,7 +23,8 @@ export const TagsList: React.FunctionComponent<TagsListProps> = ({
     data-hook={DataHooks.TagsList}
     onChange={onChange}
     role="group"
-    {...rest}>
+    {...rest}
+  >
     {children}
   </div>
 );

--- a/packages/wix-ui-core/src/components/tags-list/test/TagsList.spec.tsx
+++ b/packages/wix-ui-core/src/components/tags-list/test/TagsList.spec.tsx
@@ -29,7 +29,7 @@ describe('TagsList', () => {
           <Tag label="name" value="value">
             Some tag
           </Tag>
-        </TagsList>
+        </TagsList>,
       );
 
       const tagsCount = await driver.getTagCount();
@@ -45,7 +45,7 @@ describe('TagsList', () => {
           <Tag label="name" value="value">
             Some tag
           </Tag>
-        </TagsList>
+        </TagsList>,
       );
 
       await driver.clickOnTagByIndex();
@@ -59,7 +59,7 @@ describe('TagsList', () => {
             <Tag label="name" value="value">
               Some tag
             </Tag>
-          </TagsList>
+          </TagsList>,
         );
 
         await driver.clickOnTagByIndex();
@@ -80,7 +80,7 @@ describe('TagsList', () => {
       const driver = await createDriver(
         <Tag label="name" value="value">
           {tagText}
-        </Tag>
+        </Tag>,
       );
 
       const text = await driver.getText();

--- a/packages/wix-ui-core/src/components/thumbnail/Thumbnail.e2e.ts
+++ b/packages/wix-ui-core/src/components/thumbnail/Thumbnail.e2e.ts
@@ -2,7 +2,7 @@ import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
 import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
 import { thumbnailTestkitFactory } from '../../testkit/protractor';
-import {Category} from '../../../stories/utils';
+import { Category } from '../../../stories/utils';
 
 describe('Thumbnail', () => {
   const storyUrl = getStoryUrl(Category.COMPONENTS, 'Thumbnail');

--- a/packages/wix-ui-core/src/components/thumbnail/Thumbnail.e2e.ts
+++ b/packages/wix-ui-core/src/components/thumbnail/Thumbnail.e2e.ts
@@ -1,11 +1,17 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { thumbnailTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 describe('Thumbnail', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Thumbnail');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Thumbnail',
+  });
 
   beforeEach(() => browser.get(storyUrl));
   eyes.it('should exist', () => {

--- a/packages/wix-ui-core/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/wix-ui-core/src/components/thumbnail/Thumbnail.tsx
@@ -14,7 +14,7 @@ export interface ThumbnailProps {
   disabled?: boolean;
 }
 
-export const Thumbnail: React.SFC<ThumbnailProps> = props => {
+export const Thumbnail: React.FunctionComponent<ThumbnailProps> = props => {
   const children = React.Children.only(props.children);
   const { selected, selectedIcon, onClick, disabled } = props;
 

--- a/packages/wix-ui-core/src/components/time-picker/TimePicker.e2e.ts
+++ b/packages/wix-ui-core/src/components/time-picker/TimePicker.e2e.ts
@@ -1,11 +1,17 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { timePickerTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 describe('TimePicker', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'TimePicker');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'TimePicker',
+  });
   const dataHook = 'storybook-timepicker';
 
   beforeEach(async () => browser.get(storyUrl));

--- a/packages/wix-ui-core/src/components/time-picker/TimePicker.e2e.ts
+++ b/packages/wix-ui-core/src/components/time-picker/TimePicker.e2e.ts
@@ -2,7 +2,7 @@ import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
 import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
 import { timePickerTestkitFactory } from '../../testkit/protractor';
-import {Category} from '../../../stories/utils';
+import { Category } from '../../../stories/utils';
 
 describe('TimePicker', () => {
   const storyUrl = getStoryUrl(Category.COMPONENTS, 'TimePicker');

--- a/packages/wix-ui-core/src/components/time-picker/TimePicker.tsx
+++ b/packages/wix-ui-core/src/components/time-picker/TimePicker.tsx
@@ -145,13 +145,13 @@ export class TimePicker extends React.PureComponent<
     input.setSelectionRange(startPos, startPos + 2);
   }
 
-  _onMouseDown(e) {
+  _onMouseDown() {
     this._shouldHighlightOnFocus = false;
     this._hasStartedTyping = false;
     this._mouseDown = true;
   }
 
-  _onMouseUp(e) {
+  _onMouseUp() {
     this._mouseDown = false;
   }
 
@@ -461,7 +461,8 @@ export class TimePicker extends React.PureComponent<
       );
     }
 
-    let { value, focus } = this.state;
+    let { value } = this.state;
+    const { focus } = this.state;
     if (useAmPm !== AmPmOptions.None) {
       value = convertToAmPm({ value, strings: AmPmStrings[useAmPm] });
     }

--- a/packages/wix-ui-core/src/components/time-picker/index.ts
+++ b/packages/wix-ui-core/src/components/time-picker/index.ts
@@ -1,4 +1,4 @@
 export { TimePicker, TimePickerProps } from './TimePicker';
 import * as TimePickerConstants from './constants';
 import * as TimePickerUtils from './utils';
-export {TimePickerConstants, TimePickerUtils};
+export { TimePickerConstants, TimePickerUtils };

--- a/packages/wix-ui-core/src/components/time-picker/utils.ts
+++ b/packages/wix-ui-core/src/components/time-picker/utils.ts
@@ -1,6 +1,6 @@
-import { FIELD, BLANK, NULL_TIME } from './constants';
+import { FIELD, BLANK } from './constants';
 
-export const leftpad = str => ('00' + str).slice(-2);
+export const leftpad = (str: string | number) => ('00' + str).slice(-2);
 
 export const getFieldFromPos = (pos: number) => Math.floor(pos / 3) + 1;
 
@@ -16,7 +16,7 @@ export const isValidTime = (timeStr: string, useAmPm: boolean = false) => {
   return useAmPm ? test12.test(timeStr) : test24.test(timeStr);
 };
 
-const parseIntOrZero = str => parseInt(str) || 0;
+const parseIntOrZero = str => parseInt(str, 10) || 0;
 
 const changeTime = ({ value, field, step = 1 }) => {
   let { hour, minute } = parseTime(value);
@@ -70,10 +70,12 @@ export const decrement = ({ value, field, step = 1 }) =>
   });
 
 export const convertToAmPm = ({ value, strings = { am: 'AM', pm: 'PM' } }) => {
-  let { hour, minute } = parseTime(value);
+  const parsedTime = parseTime(value);
+  let hour = parsedTime.hour;
+  const minute = parsedTime.minute;
   let ampm = strings.am;
   if (hour !== BLANK) {
-    let nHour = parseInt(hour);
+    let nHour = parseInt(hour, 10);
     if (nHour > 11) {
       ampm = strings.pm;
     }

--- a/packages/wix-ui-core/src/components/toggle-switch/ToggleSwitch.e2e.tsx
+++ b/packages/wix-ui-core/src/components/toggle-switch/ToggleSwitch.e2e.tsx
@@ -1,12 +1,18 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { toggleSwitchTestkitFactory } from '../../testkit/protractor';
 import { Key } from 'selenium-webdriver';
 import { Category } from '../../../stories/utils';
 
 describe('ToggleSwitch', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'ToggleSwitch');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'ToggleSwitch',
+  });
   const dataHook = 'story-toggleswitch';
 
   beforeEach(() => browser.get(storyUrl));

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.e2e.ts
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.e2e.ts
@@ -1,14 +1,20 @@
 import * as eyes from 'eyes.it';
 import * as eventually from 'wix-eventually';
 import { browser } from 'protractor';
-import { getStoryUrl, waitForVisibilityOf } from 'wix-ui-test-utils/protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
 import { tooltipTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 const movedX = 10;
 
 describe('Tooltip', () => {
-  const storyUrl = getStoryUrl(Category.COMPONENTS, 'Tooltip Custom');
+  const storyUrl = createStoryUrl({
+    kind: Category.COMPONENTS,
+    story: 'Tooltip Custom',
+  });
 
   beforeEach(() => browser.get(storyUrl));
 

--- a/packages/wix-ui-core/src/components/video/Video.spec.tsx
+++ b/packages/wix-ui-core/src/components/video/Video.spec.tsx
@@ -6,7 +6,7 @@ import { videoPrivateDriverFactory } from './Video.driver.private';
 describe('Video', () => {
   const createDriver = new ReactDOMTestContainer()
     .unmountAfterEachTest()
-    .createUniRenderer(videoPrivateDriverFactory);
+    .createUniRendererAsync(videoPrivateDriverFactory);
 
   const VIDEO_ID = 'my-video';
   const VIDEO_SRC = 'data:video/mp4,never-gonna-give-you-up.mp4';
@@ -22,14 +22,16 @@ describe('Video', () => {
   describe('Wrapper', () => {
     describe('width prop', () => {
       it('should not be present by default', async () => {
-        const driver = createDriver(<Video src={VIDEO_SRC} id={VIDEO_ID} />);
+        const driver = await createDriver(
+          <Video src={VIDEO_SRC} id={VIDEO_ID} />,
+        );
         const native = await driver.getNative();
 
         expect(native.style.width).toBeFalsy();
       });
 
       it('should set given value', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video width={400} src={VIDEO_SRC} id={VIDEO_ID} />,
         );
         const native = await driver.getNative();
@@ -40,14 +42,16 @@ describe('Video', () => {
 
     describe('height prop', () => {
       it('should not be present by default', async () => {
-        const driver = createDriver(<Video src={VIDEO_SRC} id={VIDEO_ID} />);
+        const driver = await createDriver(
+          <Video src={VIDEO_SRC} id={VIDEO_ID} />,
+        );
         const native = await driver.getNative();
 
         expect(native.style.height).toBeFalsy();
       });
 
       it('should set given value', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video height={225} src={VIDEO_SRC} id={VIDEO_ID} />,
         );
         const native = await driver.getNative();
@@ -58,7 +62,7 @@ describe('Video', () => {
 
     describe('fillAllSpace prop', () => {
       it('should set width and height as 100%', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video fillAllSpace src={VIDEO_SRC} id={VIDEO_ID} />,
         );
         const native = await driver.getNative();
@@ -70,7 +74,7 @@ describe('Video', () => {
 
     describe('fillAllSpace prop', () => {
       it('should set width and height as 100%', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video fillAllSpace src={VIDEO_SRC} id={VIDEO_ID} />,
         );
         const native = await driver.getNative();
@@ -95,7 +99,7 @@ describe('Video', () => {
         }
 
         let wrapper;
-        const driver = createDriver(
+        const driver = await createDriver(
           <VideoWrapper ref={ref => (wrapper = ref)} />,
         );
 
@@ -111,7 +115,7 @@ describe('Video', () => {
   describe('Playable', () => {
     describe('player name', () => {
       it('should set video url to Playable player', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video src={PLAYABLE_LINK} id={VIDEO_ID} />,
         );
 
@@ -119,7 +123,7 @@ describe('Video', () => {
       });
 
       it('should set array of video source to Playable player', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video src={[PLAYABLE_LINK]} id={VIDEO_ID} />,
         );
 
@@ -129,7 +133,7 @@ describe('Video', () => {
 
     describe('cover', () => {
       it('should exist', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video
             config={{
               playable: {
@@ -145,7 +149,7 @@ describe('Video', () => {
       });
 
       it('should not render if hideOverlay is provided', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video
             config={{
               playable: {
@@ -162,7 +166,7 @@ describe('Video', () => {
       });
 
       it('should not render if autoplay is enabled', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video
             config={{
               playable: {
@@ -182,7 +186,7 @@ describe('Video', () => {
     describe('title', () => {
       it('should has appropriate title', async () => {
         const TITLE = 'Awesome';
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video
             config={{
               playable: {
@@ -202,7 +206,7 @@ describe('Video', () => {
 
     describe('playButton', () => {
       it('should exist', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video
             config={{
               playable: {
@@ -224,7 +228,7 @@ describe('Video', () => {
   describe('DailyMotion', () => {
     describe('player name', () => {
       it('should set DailyMotion link to appropriate player', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video src={DAILYMOTION_LINK} id={VIDEO_ID} />,
         );
 
@@ -236,7 +240,7 @@ describe('Video', () => {
   describe('Facebook', () => {
     describe('player type', () => {
       it('should set Facebook link to appropriate player', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video src={FACEBOOK_LINK} id={VIDEO_ID} />,
         );
 
@@ -246,7 +250,7 @@ describe('Video', () => {
 
     describe('width and height props', () => {
       it('should set appropriate width and height attr to player container', async () => {
-        const driver = createDriver(
+        const driver = await createDriver(
           <Video
             fillAllSpace
             width={480}
@@ -269,7 +273,9 @@ describe('Video', () => {
   describe('Twitch', () => {
     describe('player type', () => {
       it('should set Twitch link to appropriate player', async () => {
-        const driver = createDriver(<Video src={TWITCH_LINK} id={VIDEO_ID} />);
+        const driver = await createDriver(
+          <Video src={TWITCH_LINK} id={VIDEO_ID} />,
+        );
 
         expect(await driver.getPlayerName()).toBe('Twitch');
       });
@@ -279,7 +285,9 @@ describe('Video', () => {
   describe('Vimeo', () => {
     describe('player type', () => {
       it('should set Vimeo link to appropriate player', async () => {
-        const driver = createDriver(<Video src={VIMEO_LINK} id={VIDEO_ID} />);
+        const driver = await createDriver(
+          <Video src={VIMEO_LINK} id={VIDEO_ID} />,
+        );
 
         expect(await driver.getPlayerName()).toBe('Vimeo');
       });
@@ -289,7 +297,9 @@ describe('Video', () => {
   describe('Youtube', () => {
     describe('player type', () => {
       it('should set Youtube link to appropriate player', async () => {
-        const driver = createDriver(<Video src={YOUTUBE_LINK} id={VIDEO_ID} />);
+        const driver = await createDriver(
+          <Video src={YOUTUBE_LINK} id={VIDEO_ID} />,
+        );
 
         expect(await driver.getPlayerName()).toBe('YouTube');
       });

--- a/packages/wix-ui-core/src/components/video/Video.spec.tsx
+++ b/packages/wix-ui-core/src/components/video/Video.spec.tsx
@@ -22,14 +22,16 @@ describe('Video', () => {
   describe('Wrapper', () => {
     describe('width prop', () => {
       it('should not be present by default', async () => {
-        const driver = createDriver(<Video src={VIDEO_SRC} id={VIDEO_ID}/>);
+        const driver = createDriver(<Video src={VIDEO_SRC} id={VIDEO_ID} />);
         const native = await driver.getNative();
 
         expect(native.style.width).toBeFalsy();
       });
 
       it('should set given value', async () => {
-        const driver = createDriver(<Video width={400} src={VIDEO_SRC} id={VIDEO_ID}/>);
+        const driver = createDriver(
+          <Video width={400} src={VIDEO_SRC} id={VIDEO_ID} />,
+        );
         const native = await driver.getNative();
 
         expect(native.style.width).toBe('400px');
@@ -38,14 +40,16 @@ describe('Video', () => {
 
     describe('height prop', () => {
       it('should not be present by default', async () => {
-        const driver = createDriver(<Video src={VIDEO_SRC} id={VIDEO_ID}/>);
+        const driver = createDriver(<Video src={VIDEO_SRC} id={VIDEO_ID} />);
         const native = await driver.getNative();
 
         expect(native.style.height).toBeFalsy();
       });
 
       it('should set given value', async () => {
-        const driver = createDriver(<Video height={225} src={VIDEO_SRC} id={VIDEO_ID}/>);
+        const driver = createDriver(
+          <Video height={225} src={VIDEO_SRC} id={VIDEO_ID} />,
+        );
         const native = await driver.getNative();
 
         expect(native.style.height).toBe('225px');
@@ -54,7 +58,9 @@ describe('Video', () => {
 
     describe('fillAllSpace prop', () => {
       it('should set width and height as 100%', async () => {
-        const driver = createDriver(<Video fillAllSpace src={VIDEO_SRC} id={VIDEO_ID}/>);
+        const driver = createDriver(
+          <Video fillAllSpace src={VIDEO_SRC} id={VIDEO_ID} />,
+        );
         const native = await driver.getNative();
 
         expect(native.style.width).toBe('100%');
@@ -64,7 +70,9 @@ describe('Video', () => {
 
     describe('fillAllSpace prop', () => {
       it('should set width and height as 100%', async () => {
-        const driver = createDriver(<Video fillAllSpace src={VIDEO_SRC} id={VIDEO_ID}/>);
+        const driver = createDriver(
+          <Video fillAllSpace src={VIDEO_SRC} id={VIDEO_ID} />,
+        );
         const native = await driver.getNative();
 
         expect(native.style.width).toBe('100%');
@@ -82,7 +90,7 @@ describe('Video', () => {
           }
 
           render() {
-            return <Video src={this.state.src} id={VIDEO_ID}/>;
+            return <Video src={this.state.src} id={VIDEO_ID} />;
           }
         }
 
@@ -103,13 +111,17 @@ describe('Video', () => {
   describe('Playable', () => {
     describe('player name', () => {
       it('should set video url to Playable player', async () => {
-        const driver = createDriver(<Video src={PLAYABLE_LINK} id={VIDEO_ID}/>);
+        const driver = createDriver(
+          <Video src={PLAYABLE_LINK} id={VIDEO_ID} />,
+        );
 
         expect(await driver.getPlayerName()).toBe('Playable');
       });
 
       it('should set array of video source to Playable player', async () => {
-        const driver = createDriver(<Video src={[PLAYABLE_LINK]} id={VIDEO_ID}/>);
+        const driver = createDriver(
+          <Video src={[PLAYABLE_LINK]} id={VIDEO_ID} />,
+        );
 
         expect(await driver.getPlayerName()).toBe('Playable');
       });
@@ -212,7 +224,9 @@ describe('Video', () => {
   describe('DailyMotion', () => {
     describe('player name', () => {
       it('should set DailyMotion link to appropriate player', async () => {
-        const driver = createDriver(<Video src={DAILYMOTION_LINK} id={VIDEO_ID}/>);
+        const driver = createDriver(
+          <Video src={DAILYMOTION_LINK} id={VIDEO_ID} />,
+        );
 
         expect(await driver.getPlayerName()).toBe('DailyMotion');
       });
@@ -222,7 +236,9 @@ describe('Video', () => {
   describe('Facebook', () => {
     describe('player type', () => {
       it('should set Facebook link to appropriate player', async () => {
-        const driver = createDriver(<Video src={FACEBOOK_LINK} id={VIDEO_ID}/>);
+        const driver = createDriver(
+          <Video src={FACEBOOK_LINK} id={VIDEO_ID} />,
+        );
 
         expect(await driver.getPlayerName()).toBe('Facebook');
       });
@@ -231,7 +247,13 @@ describe('Video', () => {
     describe('width and height props', () => {
       it('should set appropriate width and height attr to player container', async () => {
         const driver = createDriver(
-          <Video fillAllSpace width={480} height={200} src={FACEBOOK_LINK} id={VIDEO_ID}/>,
+          <Video
+            fillAllSpace
+            width={480}
+            height={200}
+            src={FACEBOOK_LINK}
+            id={VIDEO_ID}
+          />,
         );
         const native = await driver.getNative();
         const widthAttr = await driver.getWidthDataAttr();
@@ -247,7 +269,7 @@ describe('Video', () => {
   describe('Twitch', () => {
     describe('player type', () => {
       it('should set Twitch link to appropriate player', async () => {
-        const driver = createDriver(<Video src={TWITCH_LINK} id={VIDEO_ID}/>);
+        const driver = createDriver(<Video src={TWITCH_LINK} id={VIDEO_ID} />);
 
         expect(await driver.getPlayerName()).toBe('Twitch');
       });
@@ -257,7 +279,7 @@ describe('Video', () => {
   describe('Vimeo', () => {
     describe('player type', () => {
       it('should set Vimeo link to appropriate player', async () => {
-        const driver = createDriver(<Video src={VIMEO_LINK} id={VIDEO_ID}/>);
+        const driver = createDriver(<Video src={VIMEO_LINK} id={VIDEO_ID} />);
 
         expect(await driver.getPlayerName()).toBe('Vimeo');
       });
@@ -267,7 +289,7 @@ describe('Video', () => {
   describe('Youtube', () => {
     describe('player type', () => {
       it('should set Youtube link to appropriate player', async () => {
-        const driver = createDriver(<Video src={YOUTUBE_LINK} id={VIDEO_ID}/>);
+        const driver = createDriver(<Video src={YOUTUBE_LINK} id={VIDEO_ID} />);
 
         expect(await driver.getPlayerName()).toBe('YouTube');
       });

--- a/packages/wix-ui-core/src/components/video/Video.story.tsx
+++ b/packages/wix-ui-core/src/components/video/Video.story.tsx
@@ -59,10 +59,11 @@ export default {
               'https://images-wixmp-01bd43eabd844aac9eab64f5.wixmp.com/images/White+Wix+logo+Assets+Transparent.png/v1/fit/w_475,h_150/White+Wix+logo+Assets+Transparent.png',
             alwaysShowLogo: true,
             texts: {
-              'live-indicator-text': ({ isEnded }) => !isEnded ? 'Live' : 'Live Ended',
+              'live-indicator-text': ({ isEnded }) =>
+                !isEnded ? 'Live' : 'Live Ended',
               'logo-tooltip': 'Watch On Site',
               'mute-control-tooltip': 'Mute Video',
-            }
+            },
           },
         },
       },

--- a/packages/wix-ui-core/src/components/video/players/Playable.tsx
+++ b/packages/wix-ui-core/src/components/video/players/Playable.tsx
@@ -26,7 +26,7 @@ export const verifier: VerifierType = url => {
     return URL_REGEX.test(url as string);
   }
   if (isArray(url)) {
-    return (url as Array<string>).some(item => URL_REGEX.test(item));
+    return (url as string[]).some(item => URL_REGEX.test(item));
   }
 
   return false;
@@ -241,8 +241,15 @@ class PlayablePlayer extends React.PureComponent<
   }
 
   _renderCover() {
-    const {showTitle, title, poster, hideOverlay, playButton, playing} = this.props;
-    const {hasBeenPlayed} = this.state;
+    const {
+      showTitle,
+      title,
+      poster,
+      hideOverlay,
+      playButton,
+      playing,
+    } = this.props;
+    const { hasBeenPlayed } = this.state;
     const coverStyles = { backgroundImage: poster ? `url(${poster})` : 'none' };
     if (hideOverlay || playing || hasBeenPlayed) {
       return null;

--- a/packages/wix-ui-core/src/components/video/players/playerHOC.spec.tsx
+++ b/packages/wix-ui-core/src/components/video/players/playerHOC.spec.tsx
@@ -3,11 +3,7 @@ import { EventEmitter } from 'eventemitter3';
 import * as eventually from 'wix-eventually';
 import { ReactDOMTestContainer } from '../../../../test/dom-test-container';
 import playerHOC from './playerHOC';
-import {
-  IEventEmitter,
-  IMethodsToPlayer,
-  IPropsToPlayer,
-} from '../types';
+import { IEventEmitter, IMethodsToPlayer, IPropsToPlayer } from '../types';
 import { EVENTS } from '../constants';
 
 const mapPropsToPlayer: IPropsToPlayer = {

--- a/packages/wix-ui-core/src/components/video/utils/getSDK.spec.ts
+++ b/packages/wix-ui-core/src/components/video/utils/getSDK.spec.ts
@@ -110,7 +110,7 @@ describe('Video/getSDK', () => {
         expect((window as any).require).toHaveBeenCalled();
         expect(loadjs).not.toHaveBeenCalled();
       });
-    })
+    });
   });
 
   describe('failure pass', () => {

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/EllipsedTooltip.e2e.ts
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/EllipsedTooltip.e2e.ts
@@ -1,7 +1,7 @@
 import * as eyes from 'eyes.it';
 import { $, browser } from 'protractor';
 import {
-  getStoryUrl,
+  createStoryUrl,
   hasEllipsis,
   mouseEnter,
   mouseLeave,
@@ -11,7 +11,10 @@ import { tooltipTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 describe('EllipsedTooltip', () => {
-  const storyUrl = getStoryUrl(Category.HOCS, 'EllipsedTooltip');
+  const storyUrl = createStoryUrl({
+    kind: Category.HOCS,
+    story: 'EllipsedTooltip',
+  });
 
   beforeEach(() => browser.get(storyUrl));
 
@@ -49,7 +52,10 @@ describe('EllipsedTooltip', () => {
   eyes.it(
     'should not show any styles on the text inside the tooltip',
     async () => {
-      const testsStoryUrl = getStoryUrl(Category.TESTS, 'EllipsedTooltip');
+      const testsStoryUrl = createStoryUrl({
+        kind: Category.TESTS,
+        story: 'EllipsedTooltip',
+      });
       await browser.get(testsStoryUrl);
 
       const dataHook = 'custom-ellipsedTooltip-with-tooltip';

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/EllipsedTooltip.e2e.ts
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/EllipsedTooltip.e2e.ts
@@ -8,7 +8,7 @@ import {
   waitForVisibilityOf,
 } from 'wix-ui-test-utils/protractor';
 import { tooltipTestkitFactory } from '../../testkit/protractor';
-import {Category} from '../../../stories/utils';
+import { Category } from '../../../stories/utils';
 
 describe('EllipsedTooltip', () => {
   const storyUrl = getStoryUrl(Category.HOCS, 'EllipsedTooltip');

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -13,7 +13,7 @@ class LoadableTooltip extends Loadable<{
 }> {}
 
 interface EllipsedTooltipProps {
-  component: React.ReactElement<any>;
+  component: React.ReactElement;
   showTooltip?: boolean;
   shouldLoadAsync?: boolean;
   style?: object;

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -152,7 +152,9 @@ export const withEllipsedTooltip = ({
   shouldLoadAsync?: boolean;
   tooltipProps?: object;
 } = {}) => Comp => {
-  const WrapperComponent: React.SFC<WrapperComponentProps> = props => (
+  const WrapperComponent: React.FunctionComponent<
+    WrapperComponentProps
+  > = props => (
     <EllipsedTooltip
       {...props}
       component={React.createElement(Comp, props)}

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.e2e.ts
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.e2e.ts
@@ -1,6 +1,6 @@
 import { $, browser } from 'protractor';
 import {
-  getStoryUrl,
+  createStoryUrl,
   waitForVisibilityOf,
   isFocused,
 } from 'wix-ui-test-utils/protractor';
@@ -8,7 +8,10 @@ import { buttonNextTestkitFactory } from '../../testkit/protractor';
 import { Category } from '../../../stories/utils';
 
 describe('FocusableHOC', () => {
-  const testsStoryUrl = getStoryUrl(Category.TESTS, 'FocusableHOC');
+  const testsStoryUrl = createStoryUrl({
+    kind: Category.TESTS,
+    story: 'FocusableHOC',
+  });
 
   beforeEach(() => browser.get(testsStoryUrl));
 

--- a/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/FocusableHOC.tsx
@@ -3,7 +3,7 @@ import hoistNonReactMethods from 'hoist-non-react-methods';
 
 import { getDisplayName } from '../utils';
 import styles from './Focusable.st.css';
-import {isStatelessComponent} from '../../utils';
+import { isStatelessComponent } from '../../utils';
 
 type SubscribeCb = () => void;
 
@@ -109,7 +109,10 @@ export const withFocusable = Component => {
     onFocus = event => {
       const { onFocus } = this.props;
       onFocus
-        ? onFocus(event, { blur: this.markAsBlurred, focus: this.markAsFocused })
+        ? onFocus(event, {
+            blur: this.markAsBlurred,
+            focus: this.markAsFocused,
+          })
         : this.markAsFocused();
     };
 

--- a/packages/wix-ui-core/src/hocs/Focusable/test/FocusableHOCTestFixture.tsx
+++ b/packages/wix-ui-core/src/hocs/Focusable/test/FocusableHOCTestFixture.tsx
@@ -3,36 +3,44 @@ import { withFocusable } from '../FocusableHOC';
 import { ButtonNext } from '../../../components/button-next/button-next';
 
 export enum DataHook {
-    FirstButton = 'first-button',
-    SecondButton = 'second-button',
+  FirstButton = 'first-button',
+  SecondButton = 'second-button',
 }
 
 const ButtonElement = withFocusable(ButtonNext);
 
 export class FocusableHOCTestFixture extends React.Component {
-    private readonly firstButtonRef: React.RefObject<React.Component>;
-    private readonly secondButtonRef: React.RefObject<React.Component>;
+  private readonly firstButtonRef: React.RefObject<React.Component>;
+  private readonly secondButtonRef: React.RefObject<React.Component>;
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.firstButtonRef = React.createRef();
-        this.secondButtonRef = React.createRef();
-    }
+    this.firstButtonRef = React.createRef();
+    this.secondButtonRef = React.createRef();
+  }
 
-    private readonly _onFirstButtonClick = () => {
-        (this.secondButtonRef.current as any).focus()
-    };
+  private readonly _onFirstButtonClick = () => {
+    (this.secondButtonRef.current as any).focus();
+  };
 
-    render() {
-        return (
-            <div>
-                <ButtonElement data-hook={DataHook.FirstButton}
-                               ref={this.firstButtonRef}
-                               onClick={this._onFirstButtonClick}>First Button</ButtonElement>
-                <ButtonElement data-hook={DataHook.SecondButton}
-                               ref={this.secondButtonRef}>Second Button</ButtonElement>
-            </div>
-        );
-    }
+  render() {
+    return (
+      <div>
+        <ButtonElement
+          data-hook={DataHook.FirstButton}
+          ref={this.firstButtonRef}
+          onClick={this._onFirstButtonClick}
+        >
+          First Button
+        </ButtonElement>
+        <ButtonElement
+          data-hook={DataHook.SecondButton}
+          ref={this.secondButtonRef}
+        >
+          Second Button
+        </ButtonElement>
+      </div>
+    );
+  }
 }

--- a/packages/wix-ui-core/src/mixins/hexToRgb/hexToRgb.spec.ts
+++ b/packages/wix-ui-core/src/mixins/hexToRgb/hexToRgb.spec.ts
@@ -1,24 +1,22 @@
 import * as hexToRgb from './index';
 
-
 describe('HexToRgb', () => {
+  const redHex = '#FF0000';
+  const opacity = 0.3;
 
-    const redHex =  '#FF0000';
-    const opacity = 0.3;
+  it('should convert color from hex to rgba without opacity', () => {
+    const redRgbaWithoutOpacity = 'rgba(255,0,0,1)';
+    expect(hexToRgb(redHex)).toEqual(redRgbaWithoutOpacity);
+  });
 
-    it('should convert color from hex to rgba without opacity', () => {
-        const redRgbaWithoutOpacity = 'rgba(255,0,0,1)';
-        expect(hexToRgb(redHex)).toEqual(redRgbaWithoutOpacity);
-    });
+  it('should convert color from hex to rgba with opacity', () => {
+    const redRgbaWithOpacity = 'rgba(255,0,0,0.3)';
+    expect(hexToRgb(redHex, opacity)).toEqual(redRgbaWithOpacity);
+  });
 
-    it('should convert color from hex to rgba with opacity', () => {
-        const redRgbaWithOpacity = 'rgba(255,0,0,0.3)';
-        expect(hexToRgb(redHex, opacity)).toEqual(redRgbaWithOpacity);
-    });
-
-    it('should throw an error when given incorrect hex color', () => {
-        const badColorHex = 'FF0000';
-        const errorMsg = 'Bad Hex Color';
-        expect(() => hexToRgb(badColorHex , opacity)).toThrow(errorMsg);
-    });
+  it('should throw an error when given incorrect hex color', () => {
+    const badColorHex = 'FF0000';
+    const errorMsg = 'Bad Hex Color';
+    expect(() => hexToRgb(badColorHex, opacity)).toThrow(errorMsg);
+  });
 });

--- a/packages/wix-ui-core/src/testkit/puppeteer.ts
+++ b/packages/wix-ui-core/src/testkit/puppeteer.ts
@@ -5,7 +5,7 @@ import {
   AvatarDriver,
 } from '../components/avatar/avatar.uni.driver';
 export const avatarTestkitFactory = puppeteerUniTestkitFactoryCreator(
-  avatarDriverFactory
+  avatarDriverFactory,
 );
 export { AvatarDriver };
 
@@ -14,7 +14,7 @@ import {
   ButtonNextDriver,
 } from '../components/button-next/button-next.uni.driver';
 export const buttonNextTestkitFactory = puppeteerUniTestkitFactoryCreator(
-  buttonNextDriverFactory
+  buttonNextDriverFactory,
 );
 export { ButtonNextDriver };
 
@@ -32,7 +32,7 @@ import {
   FilePickerButtonUniDriver,
 } from '../components/file-picker-button/test/FilePickerButton.uni.driver';
 export const filePickerButtonTestkitFactory = puppeteerUniTestkitFactoryCreator(
-  filePickerButtonUniDriverFactory
+  filePickerButtonUniDriverFactory,
 );
 export { FilePickerButtonUniDriver };
 
@@ -59,7 +59,7 @@ import {
   SignatureInputDriver,
 } from '../components/signature-input/SignatureInput.uni.driver';
 export const signatureInputTestkitFactory = puppeteerUniTestkitFactoryCreator(
-  signatureInputUniDriverFactory
+  signatureInputUniDriverFactory,
 );
 export { SignatureInputDriver };
 
@@ -68,6 +68,6 @@ import {
   TagsListUniDriver,
 } from '../components/tags-list/TagsList.uni.driver';
 export const tagsListTestkitFactory = puppeteerUniTestkitFactoryCreator(
-  makeTagsListUniDriver
+  makeTagsListUniDriver,
 );
 export { TagsListUniDriver };

--- a/packages/wix-ui-core/src/themes/backoffice/index.ts
+++ b/packages/wix-ui-core/src/themes/backoffice/index.ts
@@ -6,8 +6,8 @@ import IconButton from './icon-button/icon-button.st.css';
 import TextButton from './text-button/text-button.st.css';
 import CloseButton from './close-button/close-button.st.css';
 import BackofficeTheme from './theme.st.css';
-import Opacity from './opacity.st.css'
-import Border from './border.st.css'
+import Opacity from './opacity.st.css';
+import Border from './border.st.css';
 
 export const opacity = Opacity;
 export const border = Border;

--- a/packages/wix-ui-core/src/utils/index.ts
+++ b/packages/wix-ui-core/src/utils/index.ts
@@ -23,7 +23,7 @@ export interface ElementProps {
   children: any;
 }
 export const createComponentThatRendersItsChildren = (displayName: string) => {
-  const Element: React.SFC<ElementProps> = ({ children }) =>
+  const Element: React.FunctionComponent<ElementProps> = ({ children }) =>
     typeof children === 'string'
       ? React.createElement('div', {}, children)
       : children;

--- a/packages/wix-ui-core/src/utils/index.ts
+++ b/packages/wix-ui-core/src/utils/index.ts
@@ -43,5 +43,4 @@ export const isReactElement = <T>(
 };
 
 export const isStatelessComponent = Component =>
-    !(Component.prototype && Component.prototype.render);
-
+  !(Component.prototype && Component.prototype.render);

--- a/packages/wix-ui-core/src/utils/withStylable/withStylable.tsx
+++ b/packages/wix-ui-core/src/utils/withStylable/withStylable.tsx
@@ -30,6 +30,7 @@ function withStylableStateful<CoreProps, ExtendedProps = {}>(
         return null;
       }
       const className = (root.props && root.props.className) || '';
+      /* tslint:disable-next-line:deprecation */
       const statesMap = getState(this.props, this.state, this.context);
       const props = stylesheet(
         `root ${className ? className : ''}`.trim(),

--- a/packages/wix-ui-core/src/utils/withStylable/withStylable.tsx
+++ b/packages/wix-ui-core/src/utils/withStylable/withStylable.tsx
@@ -41,12 +41,12 @@ function withStylableStateful<CoreProps, ExtendedProps = {}>(
 }
 
 function withStylableStateless<CoreProps, ExtendedProps = {}>(
-  Component: React.SFC<CoreProps>,
+  Component: React.FunctionComponent<CoreProps>,
   stylesheet: RuntimeStylesheet,
   getState: (p?: any) => StateMap,
   extendedDefaultProps: object,
-): React.SFC<CoreProps & ExtendedProps> {
-  const WrapperComponent: React.SFC<CoreProps & ExtendedProps> = (
+): React.FunctionComponent<CoreProps & ExtendedProps> {
+  const WrapperComponent: React.FunctionComponent<CoreProps & ExtendedProps> = (
     props: CoreProps & ExtendedProps,
   ) => {
     const root = Component(props);
@@ -83,20 +83,22 @@ export function withStylable<CoreProps, ExtendedProps = {}>(
 ): React.ComponentClass<CoreProps & ExtendedProps>;
 
 export function withStylable<CoreProps, ExtendedProps = {}>(
-  Component: React.SFC<CoreProps>,
+  Component: React.FunctionComponent<CoreProps>,
   stylesheet: RuntimeStylesheet,
   getState: (p?: any) => StateMap,
   extendedDefaultProps?: object,
-): React.SFC<CoreProps & ExtendedProps>;
+): React.FunctionComponent<CoreProps & ExtendedProps>;
 
 export function withStylable<CoreProps, ExtendedProps = {}>(
-  Component: React.ComponentClass<CoreProps> | React.SFC<CoreProps>,
+  Component:
+    | React.ComponentClass<CoreProps>
+    | React.FunctionComponent<CoreProps>,
   stylesheet: RuntimeStylesheet,
   getState: (p?: any, s?: any, c?: any) => StateMap = () => ({}),
   extendedDefaultProps: object = {},
 ):
   | React.ComponentClass<CoreProps & ExtendedProps>
-  | React.SFC<CoreProps & ExtendedProps> {
+  | React.FunctionComponent<CoreProps & ExtendedProps> {
   if (isReactClassComponent(Component)) {
     return withStylableStateful<CoreProps, ExtendedProps>(
       Component as React.ComponentClass<CoreProps>,
@@ -106,7 +108,7 @@ export function withStylable<CoreProps, ExtendedProps = {}>(
     );
   }
   return withStylableStateless<CoreProps, ExtendedProps>(
-    Component as React.SFC<CoreProps>,
+    Component as React.FunctionComponent<CoreProps>,
     stylesheet,
     getState,
     extendedDefaultProps,

--- a/packages/wix-ui-core/stories/AddressInput/E2E.tsx
+++ b/packages/wix-ui-core/stories/AddressInput/E2E.tsx
@@ -4,7 +4,7 @@ import { AddressInput } from '../../src/components/address-input';
 import { GoogleMapsClientStub } from '../../src/components/address-input/GoogleMapsClientStub';
 import { MapsClientConstructor } from '../../src/clients/GoogleMaps/types';
 import * as helper from '../../src/components/address-input/AddressInputTestHelper';
-import {Category} from '../utils';
+import { Category } from '../utils';
 
 export const DataHooks = {
   resetStub: 'reset-stub',

--- a/packages/wix-ui-core/stories/Loadable/loadable-story.tsx
+++ b/packages/wix-ui-core/stories/Loadable/loadable-story.tsx
@@ -15,7 +15,7 @@ import * as AsyncLoadableWithManualLoadExample from '!raw-loader!./AsyncLoadable
 import SyncLoadableWithManualLoad from './SyncLoadableWithManualLoad';
 import * as SyncLoadableWithManualLoadExample from '!raw-loader!./SyncLoadableWithManualLoad';
 
-export const LoadableStory: React.SFC = () => (
+export const LoadableStory: React.FunctionComponent = () => (
   <div>
     <Markdown source={Readme} />
 

--- a/packages/wix-ui-core/test/dom-test-container.ts
+++ b/packages/wix-ui-core/test/dom-test-container.ts
@@ -71,7 +71,10 @@ export class ReactDOMTestContainer {
 
   public destroyAfterEachTest(): this {
     beforeEach(() => this.create());
-    afterEach(() => (this.unmount(), this.destroy()));
+    afterEach(() => {
+      this.unmount();
+      this.destroy();
+    });
     return this;
   }
 

--- a/packages/wix-ui-core/tslint.json
+++ b/packages/wix-ui-core/tslint.json
@@ -1,16 +1,38 @@
 {
-  "extends": ["tslint-config-yoshi"],
+  "extends": [
+    "tslint-config-yoshi"
+  ],
   "rules": {
     "prefer-object-spread": false,
-    "comma-dangle": ["error", "never"],
+    "comma-dangle": [
+      "error",
+      "never"
+    ],
     "jsx-no-multiline-js": false,
     "jsx-no-lambda": false,
-    "jsx-boolean-value": [true, "never"],
+    "jsx-boolean-value": [
+      true,
+      "never"
+    ],
     "jsx-alignment": true,
     "jsx-wrap-multiline": true,
-    "space-in-brackets": ["error", "always"],
-    "arrow-parens": [true, "ban-single-arg-parens"],
-    "array-bracket-spacing": [true, "never"],
-    "quotemark": [true, "single", "jsx-double"]
+    "space-in-brackets": [
+      "error",
+      "always"
+    ],
+    "arrow-parens": [
+      true,
+      "ban-single-arg-parens"
+    ],
+    "array-bracket-spacing": [
+      true,
+      "never"
+    ],
+    "quotemark": [
+      true,
+      "single",
+      "jsx-double"
+    ],
+    "no-floating-promises": false
   }
 }

--- a/packages/wix-ui-core/tslint.json
+++ b/packages/wix-ui-core/tslint.json
@@ -33,6 +33,11 @@
       "single",
       "jsx-double"
     ],
-    "no-floating-promises": false
+    "no-floating-promises": {
+      "severity": "warn"
+    },
+    "restrict-plus-operands": {
+      "severity": "warn"
+    }
   }
 }


### PR DESCRIPTION
Quite surprisingly a core library currently does not have lint as part
of build process.

Time to time we get strange but easily fixable issues or explode bundle
size with unused imports

This PR:

* adds `"pretest"` npm script which runs `yoshi lint`.
* commits changes from `yoshi lint --fix`
* includes manual fixes for most tslint errors:
  * use `createStoryUrl` instead of deprecated `getStoryUrl`
  * use `createUniRendererAsync` instead of deprecated `createUniRenderer`
* degrades some of tslint errors to warnings (with rule setting in `tslint.json`):
  ```json
    "no-floating-promises": {
      "severity": "warn"
    },
    "restrict-plus-operands": {
      "severity": "warn"
    }
  ```