### PR TITLE
`<Popover/>` - improve bundle size

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PopperJS from 'popper.js';
 import { Manager, Reference, Popper } from 'react-popper';
 import * as CSSTransition from 'react-transition-group/CSSTransition';
-import Portal from 'react-portal/es/Portal';
+import Portal from 'react-portal/lib/Portal';
 import style from './Popover.st.css';
 import { createModifiers } from './modifiers';
 import {

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PopperJS from 'popper.js';
 import { Manager, Reference, Popper } from 'react-popper';
 import * as CSSTransition from 'react-transition-group/CSSTransition';
-import { Portal } from 'react-portal';
+import Portal from 'react-portal/es/Portal';
 import style from './Popover.st.css';
 import { createModifiers } from './modifiers';
 import {

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PopperJS from 'popper.js';
 import { Manager, Reference, Popper } from 'react-popper';
-import { CSSTransition } from 'react-transition-group';
+import * as CSSTransition from 'react-transition-group/CSSTransition';
 import { Portal } from 'react-portal';
 import style from './Popover.st.css';
 import { createModifiers } from './modifiers';

--- a/packages/wix-ui-core/src/components/popover/utils/getAppendToElement.spec.ts
+++ b/packages/wix-ui-core/src/components/popover/utils/getAppendToElement.spec.ts
@@ -1,5 +1,5 @@
 import { getAppendToElement } from './getAppendToElement';
-import { getScrollParent } from 'popper.js/dist/umd/popper-utils';
+import { getScrollParent } from './utils';
 
 describe('getAppendToElement', () => {
   it('should return document.body [when] given `viewport` ', () => {

--- a/packages/wix-ui-core/src/components/popover/utils/getAppendToElement.ts
+++ b/packages/wix-ui-core/src/components/popover/utils/getAppendToElement.ts
@@ -1,5 +1,4 @@
-import { getScrollParent } from 'popper.js/dist/umd/popper-utils';
-import { getParentNode } from './utils';
+import { getParentNode, getScrollParent } from './utils';
 const isElement = require('lodash/isElement');
 
 export type Predicate = (s: Element) => boolean;

--- a/packages/wix-ui-core/src/components/popover/utils/utils.ts
+++ b/packages/wix-ui-core/src/components/popover/utils/utils.ts
@@ -1,6 +1,38 @@
 export function getParentNode(element) {
   if (element.nodeName === 'HTML') {
-    return;
+    return element;
   }
-  return element.parentNode;
+  return element.parentNode || element.host;
+}
+
+function getStyleComputedProperty(element) {
+  if (element.nodeType !== 1) {
+    return [];
+  }
+  // NOTE: 1 DOM access here
+  const window = element.ownerDocument.defaultView;
+  return window.getComputedStyle(element, null);
+}
+
+export function getScrollParent(element) {
+  // Return body, `getScroll` will take care to get the correct `scrollTop` from it
+  if (!element) {
+    return document.body;
+  }
+
+  switch (element.nodeName) {
+    case 'HTML':
+    case 'BODY':
+      return element.ownerDocument.body;
+    case '#document':
+      return element.body;
+  }
+
+  // Firefox want us to check `-x` and `-y` variations as well
+  const { overflow, overflowX, overflowY } = getStyleComputedProperty(element);
+  if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) {
+    return element;
+  }
+
+  return getScrollParent(getParentNode(element));
 }

--- a/packages/wix-ui-core/src/components/popover/utils/utils.ts
+++ b/packages/wix-ui-core/src/components/popover/utils/utils.ts
@@ -26,6 +26,7 @@ export function getScrollParent(element) {
       return element.ownerDocument.body;
     case '#document':
       return element.body;
+    default:
   }
 
   // Firefox want us to check `-x` and `-y` variations as well


### PR DESCRIPTION
This is part of initiative to decrease bundle size of one most popular used component: Popover.