### PR TITLE
Migrate `<Dropdown/>` to the new `<ClickOutside/>`

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
@@ -329,9 +329,9 @@ describe('Dropdown', () => {
       });
 
       expect(driver.isContentElementExists()).toBeFalsy();
-      (wrapper.instance() as any).getInstance().open();
+      (wrapper.instance() as any).open();
       expect(driver.isContentElementExists()).toBeTruthy();
-      (wrapper.instance() as any).getInstance().close();
+      (wrapper.instance() as any).close();
       expect(driver.isContentElementExists()).toBeFalsy();
     });
   });

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -1,8 +1,4 @@
 import * as React from 'react';
-import onClickOutside, {
-  InjectedOnClickOutProps,
-  OnClickOutProps,
-} from 'react-onclickoutside';
 import style from './Dropdown.st.css';
 import { Popover, Placement, PopoverProps } from '../popover';
 import { DropdownContent } from '../dropdown-content';
@@ -60,13 +56,13 @@ export interface DropdownState {
  * Dropdown
  */
 export class DropdownComponent extends React.PureComponent<
-  DropdownProps & InjectedOnClickOutProps,
+  DropdownProps,
   DropdownState
 > {
   static displayName = 'Dropdown';
   private dropdownContentRef: DropdownContent | null = null;
 
-  constructor(props: DropdownProps & InjectedOnClickOutProps) {
+  constructor(props: DropdownProps) {
     super(props);
 
     this.close = this.close.bind(this);
@@ -125,10 +121,6 @@ export class DropdownComponent extends React.PureComponent<
     });
 
     onInitialSelectedOptionsSet && onInitialSelectedOptionsSet(selectedOptions);
-  }
-
-  handleClickOutside() {
-    this.close();
   }
 
   open(onOpen: () => void = () => null) {
@@ -299,6 +291,7 @@ export class DropdownComponent extends React.PureComponent<
         flip={flip}
         fixed={fixed}
         moveBy={moveBy}
+        onClickOutside={this.close}
       >
         <Popover.Element>{children}</Popover.Element>
         <Popover.Content>
@@ -319,6 +312,4 @@ export class DropdownComponent extends React.PureComponent<
   }
 }
 
-export const Dropdown: React.ComponentClass<
-  OnClickOutProps<DropdownProps & InjectedOnClickOutProps>
-> = onClickOutside(DropdownComponent);
+export const Dropdown: React.ComponentClass<DropdownProps> = DropdownComponent;

--- a/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
@@ -85,12 +85,11 @@ export class InputWithOptions extends React.PureComponent<
   isEditing: boolean = false;
 
   open() {
-    // Using getInstance() is here because closeOutside HOC
-    this.dropDownRef.getInstance().open();
+    this.dropDownRef.open();
   }
 
   close() {
-    this.dropDownRef.getInstance().close();
+    this.dropDownRef.close();
   }
 
   _filterOptions(): Option[] {

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
@@ -164,6 +164,7 @@ describe('Tooltip', () => {
     it('should call onClickOutside when clicked outside', async () => {
       const onClickOutside = jest.fn();
       const { driver } = render(tooltip({ onClickOutside }));
+      await driver.mouseEnter();
       await driver.clickOutside();
       expect(onClickOutside).toHaveBeenCalled();
     });


### PR DESCRIPTION
Migrate `<Dropdown/>` to the new `<ClickOutside/>`
Blocked by:
1. https://github.com/wix/wix-ui/pull/1589
2. https://github.com/wix/wix-ui/pull/1590

Part of - https://github.com/wix/wix-ui/issues/1561