### PR TITLE
Infra: unify stylable@1 versions

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -73,7 +73,7 @@
     "update-components-standalone": "bash .wuf/update-components-standalone.sh"
   },
   "dependencies": {
-    "@stylable/dom-test-kit": "^0.1.0",
+    "@stylable/dom-test-kit": "^1.0.7",
     "classnames": "^2.2.5",
     "eventemitter3": "^3.1.0",
     "grapheme-splitter": "^1.0.4",
@@ -97,8 +97,8 @@
   },
   "devDependencies": {
     "@storybook/react": "5.0.0",
-    "@stylable/cli": "^2.2.8-alpha.0",
-    "@stylable/core": "^2.1.5-alpha.0",
+    "@stylable/cli": "^1.2.11",
+    "@stylable/core": "^1.0.7",
     "@types/classnames": "^2.2.3",
     "@types/enzyme": "^3.1.9",
     "@types/jest": "^22.1.1",

--- a/packages/wix-ui-test-utils/package.json
+++ b/packages/wix-ui-test-utils/package.json
@@ -38,7 +38,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@stylable/runtime": "^1.0.3",
+    "@stylable/runtime": "^1.0.4",
     "@types/enzyme": "3.1.14",
     "@types/express": "^4.0.39",
     "@types/jest": "^22.1.1",
@@ -86,6 +86,6 @@
     "@unidriver/jsdom-react": "^1.2.1",
     "@unidriver/protractor": "^1.1.5",
     "@unidriver/puppeteer": "^1.1.2",
-    "@stylable/uni-driver": "^2.1.0"
+    "@stylable/uni-driver": "^2.4.1"
   }
 }


### PR DESCRIPTION
- the older `@stylable/dom-test-kit` is causing *multiple* stylable versions for each `wix-ui-core`/`wix-style-react` user.
- the `2.2.8-alpha.0` is an abandoned effort. reverting to currently compatible v1.
- `@stylable/uni-driver` only has v2, but is compatible with both v1 and v2 of stylable, and has no dependencies (so doesn't bring along v2).

~~- tests passed locally, except for the re-captcha test, which fails for master as well.~~