### PR TITLE
wix-storybook-utils: chore(package.json): remove `eslint-config-wix` & `eslintConfig`

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -85,7 +85,6 @@
     "@types/react-dom": "~16.8.1",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.5",
-    "eslint-config-wix": "latest",
     "identity-obj-proxy": "^3.0.0",
     "import-path": "latest",
     "node-sass": "^4.9.4",
@@ -102,29 +101,6 @@
     "wix-ui-test-utils": "^1.0.120",
     "yoshi": "^4.16.4",
     "yoshi-style-dependencies": "^4.11.1"
-  },
-  "eslintConfig": {
-    "extends": "yoshi",
-    "env": {
-      "jest": true
-    },
-    "rules": {
-      "react/jsx-closing-bracket-location": [
-        "error",
-        {
-          "nonEmpty": "tag-aligned",
-          "selfClosing": false
-        }
-      ],
-      "react/jsx-handler-names": 0,
-      "react/no-find-dom-node": 0,
-      "react/no-string-refs": 0,
-      "react/jsx-boolean-value": 2,
-      "comma-dangle": [
-        "error",
-        "never"
-      ]
-    }
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
since this project has `tslint.json`, yoshi considers that and during
`yoshi build` it runs only tslint. Therefore, any eslint errors would
not break the build. They would only annoy author in the IDE or even
fight between tslint.

Thus, removing eslint is simply a cleanup