### PR TITLE
<EllipsedTooltip/> - Revert line-height inherit value

### DIFF
--- a/packages/wix-ui-core/src/components/ellipsis-tooltip/EllipsisTooltip.st.css
+++ b/packages/wix-ui-core/src/components/ellipsis-tooltip/EllipsisTooltip.st.css
@@ -11,4 +11,5 @@
 
 .root::popoverElement {
   max-width: 100%;
+  line-height: initial;
 }

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/EllipsedTooltip.st.css
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/EllipsedTooltip.st.css
@@ -11,4 +11,5 @@
 
 .root::popoverElement {
   max-width: 100%;
+  line-height: initial;
 }


### PR DESCRIPTION
Property `line-height` is automatically inherited, therefore there's a bug when `<EllipsedTooltip/>` content `line-height` is smaller than it's parent.