### PR TITLE
<ClickOutside/> - remove disableOnClickOutside prop

### DIFF
--- a/packages/wix-ui-core/src/components/click-outside/ClickOutside.spec.tsx
+++ b/packages/wix-ui-core/src/components/click-outside/ClickOutside.spec.tsx
@@ -24,7 +24,6 @@ describe('ClickOutside', () => {
       clickOutsideCallback,
       handleClickInside,
       excludeClass,
-      disableOnClickOutside,
     } = options;
     const ref = React.createRef<HTMLButtonElement>();
     ReactDOM.render(
@@ -40,7 +39,6 @@ describe('ClickOutside', () => {
           rootRef={ref}
           onClickOutside={clickOutsideCallback}
           excludeClass={excludeClass}
-          disableOnClickOutside={disableOnClickOutside}
         >
           <button id="inside" ref={ref} onClick={handleClickInside}>
             Inside
@@ -129,10 +127,9 @@ describe('ClickOutside', () => {
 
   it('should try to outside when listeners are stopped unsuccessfully', async () => {
     const clickOutsideCallback = jest.fn();
-    const disableOnClickOutside = true;
 
     act(() => {
-      render({ clickOutsideCallback, disableOnClickOutside });
+      render({});
     });
 
     // Nothing is clicked yet

--- a/packages/wix-ui-core/src/components/click-outside/ClickOutside.tsx
+++ b/packages/wix-ui-core/src/components/click-outside/ClickOutside.tsx
@@ -5,13 +5,10 @@ export interface ClickOutsideProps {
   rootRef: React.RefObject<HTMLElement>;
 
   /** A callback to be triggered when all requirements for "outside click" are met */
-  onClickOutside: Function;
+  onClickOutside?: Function;
 
   /** Elements with this class will not trigger onClickOutside callback */
   excludeClass?: string;
-
-  /** If true, click events listeners will be removed from document */
-  disableOnClickOutside?: boolean;
 }
 
 /**
@@ -47,16 +44,16 @@ export class ClickOutside extends React.PureComponent<ClickOutsideProps> {
   }
 
   componentDidMount() {
-    if (!this.props.disableOnClickOutside) {
+    if (this.props.onClickOutside) {
       this._registerEvents();
     }
   }
   componentDidUpdate(prevProps) {
-    if (this.props.disableOnClickOutside !== prevProps.disableOnClickOutside) {
-      if (this.props.disableOnClickOutside) {
-        this._unregisterEvents();
-      } else {
+    if (this.props.onClickOutside !== prevProps.onClickOutside) {
+      if (this.props.onClickOutside) {
         this._registerEvents();
+      } else {
+        this._unregisterEvents();
       }
     }
   }

--- a/packages/wix-ui-core/stories/ClickOutside/ClickOutside-story.tsx
+++ b/packages/wix-ui-core/stories/ClickOutside/ClickOutside-story.tsx
@@ -20,14 +20,13 @@ export class ClickOutsideStory extends React.Component<any, any> {
   };
 
   render() {
-    const { excludeClass, disableOnClickOutside } = this.props;
+    const { excludeClass } = this.props;
     return (
       <div>
         <ClickOutside
           rootRef={this.rootRef}
           onClickOutside={this._clickOutside}
           excludeClass={excludeClass}
-          disableOnClickOutside={disableOnClickOutside}
         >
           <div
             style={{ backgroundColor: 'lightskyblue', padding: '5px' }}

--- a/packages/wix-ui-core/stories/ClickOutside/index.story.tsx
+++ b/packages/wix-ui-core/stories/ClickOutside/index.story.tsx
@@ -11,7 +11,6 @@ export default {
   componentProps: setState => ({
     clickOutsideCallback: () => {},
     excludeClass: '',
-    disableOnClickOutside: false,
   }),
 
   exampleProps: {},


### PR DESCRIPTION
I removed disableOnClickOutside to make it more clear.
Now the `onClickOutside` prop is optional, and listeners will be **registered to document** only when its defined.
Therefore when you want to "disableOnClickOutside" just don't pass `onClickOutside` prop.

It's better to understand it this way, and we avoid redundant code.