### PR TITLE
<Popover/> - Added upgrade prop to use the new <ClickOutside/>

### DIFF
--- a/packages/wix-ui-core/src/components/click-outside/ClickOutside.tsx
+++ b/packages/wix-ui-core/src/components/click-outside/ClickOutside.tsx
@@ -48,6 +48,7 @@ export class ClickOutside extends React.PureComponent<ClickOutsideProps> {
       this._registerEvents();
     }
   }
+
   componentDidUpdate(prevProps) {
     if (this.props.onClickOutside !== prevProps.onClickOutside) {
       if (this.props.onClickOutside) {

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -143,6 +143,40 @@ function runTests(createDriver, container) {
         await driver.clickOutside();
         expect(onClickOutside).toBeCalled();
       });
+    });
+
+    describe('onClickOutside + upgrade', () => {
+      it('should be triggered when outside of the popover is called', async () => {
+        const onClickOutside = jest.fn();
+
+        const driver = await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: true,
+            onClickOutside,
+            upgrade: true,
+          }),
+        );
+
+        await driver.clickOutside();
+        expect(onClickOutside).toBeCalled();
+      });
+
+      it('should *not* be triggered when outside of the popover is called and the popover is *not* shown', async () => {
+        const onClickOutside = jest.fn();
+
+        const driver = await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: false,
+            onClickOutside,
+            upgrade: true,
+          }),
+        );
+
+        await driver.clickOutside();
+        expect(onClickOutside).not.toBeCalled();
+      });
 
       const appendToValues: AppendTo[] = [
         'parent',

--- a/packages/wix-ui-core/src/components/popover/Popover.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.uni.driver.ts
@@ -39,7 +39,6 @@ export const testkit = (base: UniDriver, body: UniDriver) => {
       (await body.getNative()).ownerDocument.dispatchEvent(
         new Event('mousedown'),
       );
-
       (await body.getNative()).ownerDocument.dispatchEvent(
         new Event('mouseup'),
       );


### PR DESCRIPTION
Migrate `<Popover/>` to the new `< ClickOutside/>`
Blocked by - https://github.com/wix/wix-ui/pull/1589
Part of - https://github.com/wix/wix-ui/issues/1561