### PR TITLE
wix-storybook-utils: chore(AutoExample): fallback prop controller for non-enum types

### DIFF
--- a/packages/wix-storybook-utils/src/AutoExample/index.js
+++ b/packages/wix-storybook-utils/src/AutoExample/index.js
@@ -217,9 +217,12 @@ export default class extends Component {
 
     {
       types: ['enum'],
-      controller: ({ type }) => (
-        <List values={type.value.map(({ value }) => stripQuotes(value))} />
-      ),
+      controller: ({ type }) =>
+        typeof type === 'string' ? (
+          <Input />
+        ) : (
+          <List values={type.value.map(({ value }) => stripQuotes(value))} />
+        ),
     },
 
     {
@@ -251,7 +254,7 @@ export default class extends Component {
 
   renderPropControllers = ({ props, allProps }) =>
     Object.entries(props)
-      .filter(([key, prop]) => prop)
+      .filter(([, prop]) => prop)
       .map(([key, prop]) => (
         <Option
           key={key}


### PR DESCRIPTION
for types that are marked as enum, but do not have enum value, fallback
to input. Otherwise story page crashes entirely