### PR TITLE
makes value optional in tag

### DIFF
--- a/packages/wix-ui-core/src/components/tags-list/Tag.tsx
+++ b/packages/wix-ui-core/src/components/tags-list/Tag.tsx
@@ -11,7 +11,7 @@ import style from './Tag.st.css';
 export interface TagProps {
   className?: string;
   checked?: boolean;
-  value: string;
+  value?: string;
   label?: string;
   onChange?: React.FormEventHandler<HTMLInputElement>;
   children: string;
@@ -21,8 +21,8 @@ export const Tag: React.FunctionComponent<TagProps> = ({
   children,
   className,
   checked,
-  value,
-  label,
+  value = '',
+  label = '',
   onChange = noop,
   ...rest
 }) => (
@@ -53,7 +53,7 @@ Tag.propTypes = {
   children: PropTypes.string,
   className: PropTypes.string,
   checked: PropTypes.bool,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   label: PropTypes.string,
   onChange: PropTypes.func,
 };


### PR DESCRIPTION
In general, `Tag` can miss `value` or `label`, but not both. But this validation will be handled by wix-code wrapper.

![image](https://user-images.githubusercontent.com/2997359/69536355-82a35d00-0f86-11ea-9d9b-f7eb4b1afebe.png)
