### PR TITLE
Update testkit TypeScript type exports

### DIFF
--- a/packages/wsr-types/src/testkits/enzyme.d.ts
+++ b/packages/wsr-types/src/testkits/enzyme.d.ts
@@ -132,7 +132,6 @@ declare module "wix-style-react/dist/testkit/enzyme" {
   export const autoCompleteWithLabelTestkitFactory: any;
   export const dividerTestkitFactory: any;
   export const labelledElementTestkitFactory: any;
-  export const previewWidgetTestkitFactory: any;
   export const mediaOverlayTestkitFactory: any;
   export const infoIconTestkitFactory: any;
   export const socialButtonTestkitFactory: any;
@@ -148,7 +147,8 @@ declare module "wix-style-react/dist/testkit/enzyme" {
   export const cardSubheaderTestkitFactory: any;
   export const tooltipTestkitFactory: any;
   export const TooltipTestkit: any;
-  export const previewWidgetTestkit: any;
-  export const mobilePreviewWidgetTestkit: any;
-  export const browserPreviewWidgetTestkit: any;
+  export const previewWidgetTestkitFactory: any;
+  export const mobilePreviewWidgetTestkitFactory: any;
+  export const browserPreviewWidgetTestkitFactory: any;
+  export const timeTableTestkitFactory: any;
 }

--- a/packages/wsr-types/src/testkits/puppeteer.d.ts
+++ b/packages/wsr-types/src/testkits/puppeteer.d.ts
@@ -117,7 +117,6 @@ declare module "wix-style-react/dist/testkit/puppeteer" {
   export const autoCompleteWithLabelTestkitFactory: any;
   export const dividerTestkitFactory: any;
   export const labelledElementTestkitFactory: any;
-  export const previewWidgetTestkitFactory: any;
   export const mediaOverlayTestkitFactory: any;
   export const infoIconTestkitFactory: any;
   export const socialButtonTestkitFactory: any;
@@ -134,7 +133,8 @@ declare module "wix-style-react/dist/testkit/puppeteer" {
   export const cardSubheaderTestkitFactory: any;
   export const tooltipTestkitFactory: any;
   export const TooltipTestkit: any;
-  export const previewWidgetTestkit: any;
-  export const mobilePreviewWidgetTestkit: any;
-  export const browserPreviewWidgetTestkit: any;
+  export const previewWidgetTestkitFactory: any;
+  export const mobilePreviewWidgetTestkitFactory: any;
+  export const browserPreviewWidgetTestkitFactory: any;
+  export const timeTableTestkitFactory: any;
 }

--- a/packages/wsr-types/src/testkits/vanilla.d.ts
+++ b/packages/wsr-types/src/testkits/vanilla.d.ts
@@ -131,7 +131,6 @@ declare module "wix-style-react/dist/testkit" {
   export const autoCompleteWithLabelTestkitFactory: any;
   export const dividerTestkitFactory: any;
   export const labelledElementTestkitFactory: any;
-  export const previewWidgetTestkitFactory: any;
   export const mediaOverlayTestkitFactory: any;
   export const infoIconTestkitFactory: any;
   export const socialButtonTestkitFactory: any;
@@ -147,7 +146,8 @@ declare module "wix-style-react/dist/testkit" {
   export const cardSubheaderTestkitFactory: any;
   export const tooltipTestkitFactory: any;
   export const TooltipTestkit: any;
-  export const previewWidgetTestkit: any;
-  export const mobilePreviewWidgetTestkit: any;
-  export const browserPreviewWidgetTestkit: any;
+  export const previewWidgetTestkitFactory: any;
+  export const mobilePreviewWidgetTestkitFactory: any;
+  export const browserPreviewWidgetTestkitFactory: any;
+  export const timeTableTestkitFactory: any;
 }


### PR DESCRIPTION
- Add TimeTable exports.
- Fix mobile/preview widget exports (were missing `Factory`).