### PR TITLE
<Popover/> - Add excludeClass prop

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -143,6 +143,22 @@ function runTests(createDriver, container) {
         await driver.clickOutside();
         expect(onClickOutside).toBeCalled();
       });
+
+      it('should not trigger onClickOutside when clicking inside with an excluded class', async () => {
+        const onClickOutside = jest.fn();
+
+        const driver = await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: false,
+            onClickOutside,
+            excludeClass: 'excludeClass',
+          }),
+        );
+
+        await driver.click();
+        expect(onClickOutside).not.toBeCalled();
+      });
     });
 
     describe('onClickOutside + upgrade', () => {

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -58,6 +58,10 @@ export interface PopoverProps {
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   /** Provides callback to invoke when clicked outside of the popover */
   onClickOutside?: Function;
+  /**
+   * Clicking on elements with this excluded class will will not trigger onClickOutside callback
+   */
+  excludeClass?: string;
   /** onMouseEnter on the component */
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   /** onMouseLeave on the component */
@@ -121,7 +125,6 @@ export interface PopoverProps {
    * - `string` value that contains `px`
    */
   width?: number | string;
-
   /**
    * Breaking change:
    * When true - onClickOutside will be called only when popover content is shown
@@ -503,6 +506,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       children,
       style: inlineStyles,
       id,
+      excludeClass,
     } = this.props;
     const { isMounted, shown } = this.state;
 
@@ -518,7 +522,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       <Manager>
         <ClickOutsideWrapper
           handleClickOutside={this._handleClickOutside}
-          outsideClickIgnoreClass={style.popover}
+          outsideClickIgnoreClass={excludeClass || style.popover}
         >
           <div
             style={inlineStyles}


### PR DESCRIPTION
`<Popover/>` - Add excludeClass prop
Clicking on elements with this excluded class will will not trigger onClickOutside callback