### PR TITLE
<PopoverNext/> - make sure to support clickoutside only when content is shown && remove chunk wait feature for our testkits

### DIFF
--- a/packages/wix-ui-core/src/components/popover-next/popover-next.tsx
+++ b/packages/wix-ui-core/src/components/popover-next/popover-next.tsx
@@ -115,11 +115,6 @@ export interface PopoverNextProps {
    * - `string` value that contains `px`
    */
   width?: number | string;
-  /**
-   * Breaking change:
-   * When true - onClickOutside will be called only when popover content is shown
-   */
-  disableClickOutsideWhenClosed?: boolean;
 }
 
 export interface PopoverNextState {
@@ -177,10 +172,8 @@ export class PopoverNext extends React.Component<
   }
 
   _handleClickOutside = () => {
-    const { onClickOutside, shown, disableClickOutsideWhenClosed } = this.props;
-    if (onClickOutside && !(disableClickOutsideWhenClosed && !shown)) {
-      onClickOutside();
-    }
+    const { onClickOutside } = this.props;
+    onClickOutside && onClickOutside();
   };
 
   renderPopperContent(childrenObject) {

--- a/packages/wix-ui-core/src/components/popover-next/popover-next.uni.driver.tsx
+++ b/packages/wix-ui-core/src/components/popover-next/popover-next.uni.driver.tsx
@@ -10,28 +10,6 @@ export const popoverNextDriverFactory = (base: UniDriver, body: UniDriver) => {
   const reactBase = ReactBase(base);
   const commonDriver = CommonDriver(base, body);
 
-  const isChunkLoaded = async () => {
-    if (base.type === 'react') {
-      return true;
-    }
-
-    let response = false;
-    const options = { timeout: 2000, interval: 200 };
-
-    try {
-      await eventually(async () => {
-        if ((await base.attr('data-loaded')) === `true`) {
-          response = true;
-          return true;
-        }
-        throw new Error('err');
-      }, options);
-      return response;
-    } catch {
-      return response;
-    }
-  };
-
   return {
     ...baseUniDriverFactory(base),
     click: async () => byHook('popover-element').click(),
@@ -45,18 +23,14 @@ export const popoverNextDriverFactory = (base: UniDriver, body: UniDriver) => {
      * Returns the content element (`<Popover.Content/>`)
      * @returns null if element is not found
      */
-    getContentElement: async () => {
-      return (await isChunkLoaded())
-        ? safeGetNative(await commonDriver.getContentElement())
-        : null;
-    },
+    getContentElement: async () =>
+      safeGetNative(await commonDriver.getContentElement()),
 
     /** Returns `true` whether the target element (`<Popover.Element/>`) exists */
     isTargetElementExists: async () => byHook('popover-element').exists(),
 
     /** Returns `true` whether the content element (`<Popover.Content/>`) exists */
     isContentElementExists: async () =>
-      (await isChunkLoaded()) &&
       (await commonDriver.getContentElement()).exists(),
 
     mouseEnter: () => base.hover(),

--- a/packages/wix-ui-core/src/components/popover-next/test/popover-next.dynamic.test.ts
+++ b/packages/wix-ui-core/src/components/popover-next/test/popover-next.dynamic.test.ts
@@ -63,29 +63,8 @@ describe('PopoverNext - Dynamic Loading', () => {
   });
 
   /**
-   * This test is running against Popvoer that has shown={true} by default
-   */
-  it('should simulate dynamically loaded assets without chunk await', async () => {
-    // Navigate
-    await page.goto(`http://localhost:${port}/${storyUrl}`);
-
-    const testkit = await popoverNextTestkitFactory({
-      dataHook: 'storybook-popover',
-      page,
-    });
-
-    expect(await testkit.isTargetElementExists()).toBe(true);
-    expect(await testkit.isContentElementExistsWithoutChunkAwait()).toBe(false);
-
-    await eventually(async () => {
-      expect(await testkit.isContentElementExistsWithoutChunkAwait()).toBe(
-        true,
-      );
-    });
-  });
-
-  /**
-   * This test is running against Popvoer that has shown={true} by default
+   * This test represents a situation where content chunk is not yet loaded
+   *  and our testkit method that tries to find the content will return false if asked immediately
    */
   it('should simulate dynamically loaded assets with testkit chunk await', async () => {
     // Navigate
@@ -97,6 +76,27 @@ describe('PopoverNext - Dynamic Loading', () => {
     });
 
     expect(await testkit.isTargetElementExists()).toBe(true);
-    expect(await testkit.isContentElementExists()).toBe(true);
+    expect(await testkit.isContentElementExists()).toBe(false);
+  });
+
+  /**
+   * This test represents a recommended pattern testing against production
+   *
+   */
+  it('should simulate dynamically loaded assets without chunk await', async () => {
+    // Navigate
+    await page.goto(`http://localhost:${port}/${storyUrl}`);
+
+    const testkit = await popoverNextTestkitFactory({
+      dataHook: 'storybook-popover',
+      page,
+    });
+
+    expect(await testkit.isTargetElementExists()).toBe(true);
+    expect(await testkit.isContentElementExists()).toBe(false);
+
+    await eventually(async () => {
+      expect(await testkit.isContentElementExists()).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
So after talking with Shlomi, we decided that our testkit should not provide awaiting mechanisms for our users. Instead we should document and explain our users how to properly test against production.