### PR TITLE
react-autodocs-utils: chore(component-resolve): update `resolveHOC` function

### DIFF
--- a/packages/react-autodocs-utils/src/metadata-parser/tests/index.test.js
+++ b/packages/react-autodocs-utils/src/metadata-parser/tests/index.test.js
@@ -537,4 +537,43 @@ describe('metadataParser()', () => {
       });
     });
   });
+
+  describe('given component exported with wrapped HOCs', () => {
+    it('should resolve component', () => {
+      const fakeFs = cista({
+        'Component.js': `
+          const PropTypes = require("prop-types");
+          const React = require("react");
+          const compose = require("../hoc/compose");
+          const { withValidation } = requre("../hoc/withValidation");
+
+          class NumericInput extends React.Component {
+            render() {
+              return <div/>;
+            }
+          }
+
+          NumericInput.displayName = "NumericInput"
+          NumericInput.propTypes = {
+            value: PropTypes.number.isRequired,
+          }
+
+          module.exports = compose(NumericInput, [withValidation]);
+        `,
+      });
+
+      return expect(metadataParser(fakeFs.dir + '/Component.js')).resolves.toEqual({
+        description: '',
+        methods: [],
+        displayName: 'NumericInput',
+        props: {
+          value: {
+            required: true,
+            description: '',
+            type: { name: 'number' },
+          },
+        },
+      });
+    });
+  });
 });

--- a/packages/react-autodocs-utils/src/parser/component-resolve.js
+++ b/packages/react-autodocs-utils/src/parser/component-resolve.js
@@ -53,12 +53,26 @@ const resolveHOC = path => {
 
   if (n.CallExpression.check(node) && !isReactCreateClassCall(path)) {
     if (node.arguments.length) {
-      return resolveHOC(path.get('arguments', node.arguments.length - 1));
+      const inner = path.get('arguments', 0);
+
+      if (
+        node.arguments.length > 1 &&
+        (n.Literal.check(inner.node) ||
+          n.ObjectExpression.check(inner.node) ||
+          n.ArrayExpression.check(inner.node) ||
+          n.SpreadElement.check(inner.node))
+      ) {
+        return resolveHOC(
+          resolveToValue(path.get('arguments', node.arguments.length - 1)),
+        );
+      }
+
+      return resolveHOC(resolveToValue(inner));
     }
   }
 
   return path;
-};
+}
 
 const resolveDefinition = definition => {
   if (isReactCreateClassCall(definition)) {


### PR DESCRIPTION
this is to support cases likes `compose(Component, [something])`
before this change only `compose(Component)` would be supported