### PR TITLE
wix-ui-core: bump playable 2.10.4

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -89,7 +89,7 @@
     "image-client-api": "^1.3581.0",
     "loadjs": "^3.5.4",
     "lodash": "^4.17.5",
-    "playable": "2.9.3",
+    "playable": "2.10.4",
     "popper.js": "^1.14.5",
     "react-onclickoutside": "^6.8.0",
     "react-popper": "^1.3.0",


### PR DESCRIPTION
https://github.com/wix/playable/releases/tag/v2.10.4

Includes a highly requested fix for some android devices playback issues - dropped frames, low fps. 
https://jira.wixpress.com/browse/WV-317