### PR TITLE
Fix Notification.ActionButton link prop type

### DIFF
--- a/packages/wsr-types/src/components/Notification.d.ts
+++ b/packages/wsr-types/src/components/Notification.d.ts
@@ -23,7 +23,7 @@ declare namespace __WSR {
     const TextLabel: React.SFC;
     const ActionButton: React.SFC<ActionButtonProps>;
     type ActionButtonProps = Button.ButtonWithAsProp<{
-      link?: boolean;
+      link?: string;
       type?: string;
       target?: string;
     }>;


### PR DESCRIPTION
According to https://github.com/wix/wix-style-react/blob/master/src/Notification/README.md, the `link` prop type is string, as it is a "url to navigate to on click".