### PR TITLE
<Pagination/> - Fix TypeScript typings compatibility issue

### DIFF
--- a/packages/wix-ui-core/src/components/pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/pagination/Pagination.tsx
@@ -110,7 +110,7 @@ export class Pagination extends React.Component<
     return getId(this.props.id, elementName);
   }
 
-  private get maxPagesToShow(): number {
+  private readonly getMaxPagesToShow = (): number => {
     if (this.props.maxPagesToShow) {
       return this.props.maxPagesToShow;
     }
@@ -118,7 +118,7 @@ export class Pagination extends React.Component<
       return 20;
     }
     return 7;
-  }
+  };
 
   public state = {
     pageInputValue: String(this.props.currentPage),
@@ -131,7 +131,7 @@ export class Pagination extends React.Component<
         id={this.props.id}
         totalPages={this.props.totalPages}
         currentPage={this.props.currentPage}
-        maxPagesToShow={this.maxPagesToShow}
+        maxPagesToShow={this.getMaxPagesToShow()}
         showFirstPage={this.props.showFirstPage}
         showLastPage={this.props.showLastPage}
         responsive={this.props.responsive}


### PR DESCRIPTION
It seems `wix-ui-core` package was recently updated to TypeScript 3.7.x. There seems to be a breaking change in the way TypeScript 3.7.x emits definitions for accessor methods (getters/setters). Previously a getter would be emitted as a readonly prop and now its emitted as a proper `get`.

This basically means that now `wix-ui-core` Pagination component definitions are only compatible with TypeScript 3.7.x. The issue is described here: https://github.com/microsoft/TypeScript/issues/33939

Instead of downgrading TypeScript version I suggest this fix to rewrite this single prop as a method instead of a getter (it was marked as private so the risk should be low..). There are other getters in the codebase but they seem to be used in private drivers and should not affect consumers.

