### PR TITLE
Fix issue where mouseleave event is not fired for a disabled button

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.st.css
+++ b/packages/wix-ui-core/src/components/button-next/button-next.st.css
@@ -24,3 +24,12 @@
 .root:disabled {
   cursor: default;
 }
+
+/*
+  NOTE: This fixes issues when disabled button is used with a Tooltip. The root issue
+  is that browsers do not fire a mouseleave event for a disabled button. More details:
+  https://github.com/facebook/react/issues/4251
+*/
+.root[disabled] {
+  pointer-events: none;
+}


### PR DESCRIPTION
Fixing a weird issue reproducible with the following wix-style-react example:

```jsx
<Tooltip
  upgrade
  content="Testing"
  disabled={false}
>
  <Button disabled>Update</Button>
</Tooltip>
```

The tooltip will appear and will be stuck when mouse is hovered out. The reason seems to be that browsers do not fire `mouseleave` events for disabled buttons/input. There is a weird workaround with `pointer-events: none` that seems to fix this however (very counterintuitive).