### PR TITLE
wix-ui-framework/generator sequential codemods

### DIFF
--- a/packages/wix-ui-framework/CHANGELOG.md
+++ b/packages/wix-ui-framework/CHANGELOG.md
@@ -11,6 +11,10 @@ Types of changes:
 1. **Fixed** for any bug fixes.
 1. **Security** in case of vulnerabilities.
 
+# 3.5.1 - 2020-01-20
+## Fixed
+- `wuf generate` - make codemods run in sequence (and not concurrently)
+
 # 3.5.0 - 2020-01-10
 ## Added
 - `wuf generate` - support EJS in component generator templates

--- a/packages/wix-ui-framework/package.json
+++ b/packages/wix-ui-framework/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "wuf": "./bin/wuf.js"
   },
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": {
     "name": "Wix",
     "email": "fed-infra@wix.com"

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-codemods.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-codemods.ts
@@ -49,7 +49,7 @@ const runCodemod: ({
     });
   });
 
-export const runCodemods: (a: Options) => Promise<void[]> = options => {
+export const runCodemods: (options: Options) => Promise<void> = options => {
   const { ComponentName, description, codemods } = options;
 
   const codemodsIndex: CodemodConfig[] = require(path.resolve(
@@ -62,13 +62,15 @@ export const runCodemods: (a: Options) => Promise<void[]> = options => {
     description,
   });
 
-  return Promise.all(
-    codemodsIndex.map((codemodConfig: CodemodConfig) =>
-      runCodemod({
-        options,
-        codemodValues,
-        codemodConfig,
-      }),
-    ),
+  return codemodsIndex.reduce(
+    (promise, codemodConfig) =>
+      promise.then(() =>
+        runCodemod({
+          options,
+          codemodValues,
+          codemodConfig,
+        }),
+      ),
+    Promise.resolve(),
   );
 };


### PR DESCRIPTION
This PR fixes `wuf generate`.

Previously codemods would run concurrently, which can lead to issues if
one codemod depends on another and order at which they run is not
guaranteed.

This PR makes codemods run sequentially, in order they are defined in
`codemods/index.js` by `wuf` user.

CC @TalZa1810 