### PR TITLE
wsr-types: Add new Image component testkit factory types

### DIFF
--- a/packages/wsr-types/src/testkits/enzyme.d.ts
+++ b/packages/wsr-types/src/testkits/enzyme.d.ts
@@ -161,4 +161,5 @@ declare module "wix-style-react/dist/testkit/enzyme" {
   export const browserPreviewWidgetTestkitFactory: any;
   export const timeTableTestkitFactory: any;
   export const marketingLayoutTestkitFactory: any;
+  export const imageTestkitFactory: any;
 }

--- a/packages/wsr-types/src/testkits/puppeteer.d.ts
+++ b/packages/wsr-types/src/testkits/puppeteer.d.ts
@@ -135,4 +135,5 @@ declare module "wix-style-react/dist/testkit/puppeteer" {
   export const browserPreviewWidgetTestkitFactory: any;
   export const timeTableTestkitFactory: any;
   export const marketingLayoutTestkitFactory: any;
+  export const imageTestkitFactory: any;
 }

--- a/packages/wsr-types/src/testkits/vanilla.d.ts
+++ b/packages/wsr-types/src/testkits/vanilla.d.ts
@@ -160,4 +160,5 @@ declare module "wix-style-react/dist/testkit" {
   export const browserPreviewWidgetTestkitFactory: any;
   export const timeTableTestkitFactory: any;
   export const marketingLayoutTestkitFactory: any;
+  export const imageTestkitFactory: any;
 }


### PR DESCRIPTION
Adding `any` types to new Image component testkits since `wsr-types` overrides these 3 files.
WSR project already has proper types for Image component testkits.