### PR TITLE
fix(wsr-types): incorrect `images` prop

### DIFF
--- a/packages/wsr-types/__tests__/Carousel-tests.tsx
+++ b/packages/wsr-types/__tests__/Carousel-tests.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
-import Carousel from "wix-style-react/Carousel";
-import { carouselTestkitFactory } from "wix-style-react/dist/testkit";
-import { carouselTestkitFactory as carouselEnzymeTestkitFactory } from "wix-style-react/dist/testkit/enzyme";
-import { carouselTestkitFactory as carouselPuppeteerTestkitFactory } from "wix-style-react/dist/testkit/puppeteer";
-import * as enzyme from "enzyme";
-import * as puppeteer from "puppeteer";
+import * as React from 'react';
+import Carousel from 'wix-style-react/Carousel';
+import { carouselTestkitFactory } from 'wix-style-react/dist/testkit';
+import { carouselTestkitFactory as carouselEnzymeTestkitFactory } from 'wix-style-react/dist/testkit/enzyme';
+import { carouselTestkitFactory as carouselPuppeteerTestkitFactory } from 'wix-style-react/dist/testkit/puppeteer';
+import * as enzyme from 'enzyme';
+import * as puppeteer from 'puppeteer';
 
 function CarouselWithMandatoryProps() {
   return <Carousel />;
@@ -20,29 +20,29 @@ function CarouselWithAllProps() {
       className="cls"
       dataHook="hook"
       dots
-      images={["a"]}
+      images={[{ src: 'a' }]}
       infinite
       initialSlideIndex={1}
       variableWidth
     />
   );
 }
-document.querySelectorAll
+document.querySelectorAll;
 async function testkits() {
   const testkit = carouselTestkitFactory({
-    dataHook: "hook",
-    wrapper: document.createElement("div")
+    dataHook: 'hook',
+    wrapper: document.createElement('div')
   });
 
   const enzymeTestkit = carouselEnzymeTestkitFactory({
-    dataHook: "hook",
+    dataHook: 'hook',
     wrapper: enzyme.mount(<div />)
   });
 
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   const puppeteerTestkit = await carouselPuppeteerTestkitFactory({
-    dataHook: "hook",
+    dataHook: 'hook',
     page
   });
 }

--- a/packages/wsr-types/src/components/Carousel.d.ts
+++ b/packages/wsr-types/src/components/Carousel.d.ts
@@ -3,7 +3,7 @@ declare namespace __WSR {
     export interface CarouselProps {
       dataHook?: string;
       className?: string;
-      images?: string[];
+      images?: CarouselImage[];
       buttonSkin?: CarouselButtonSkin;
       infinite?: boolean;
       autoplay?: boolean;
@@ -16,16 +16,18 @@ declare namespace __WSR {
 
     export class Carousel extends React.Component<CarouselProps> {}
 
-    export type CarouselButtonSkin = "standard" | "inverted";
+    export type CarouselButtonSkin = 'standard' | 'inverted';
+
+    export type CarouselImage = { src: string };
   }
 }
 
-declare module "wix-style-react" {
+declare module 'wix-style-react' {
   export import Carousel = __WSR.Carousel.Carousel;
   export import CarouselProps = __WSR.Carousel.CarouselProps;
 }
 
-declare module "wix-style-react/Carousel" {
+declare module 'wix-style-react/Carousel' {
   export interface CarouselProps extends __WSR.Carousel.CarouselProps {}
   export default __WSR.Carousel.Carousel;
 }


### PR DESCRIPTION
This PR aligns the `images` prop of the `<Carousel/>` to the correct API structure