### PR TITLE
(wix-storybook-utils) - Expose transparent background prop for code example

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.js
@@ -36,6 +36,7 @@ export default class LiveCodeExample extends Component {
     previewProps: PropTypes.object,
     autoRender: PropTypes.bool,
     darkBackground: PropTypes.bool,
+    transparentBackground: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -44,6 +45,7 @@ export default class LiveCodeExample extends Component {
     previewProps: {},
     autoRender: true,
     darkBackground: false,
+    transparentBackground: false,
   };
 
   constructor(props) {
@@ -126,7 +128,7 @@ export default class LiveCodeExample extends Component {
   };
 
   render() {
-    const { compact, previewRow, previewProps, autoRender } = this.props;
+    const { compact, previewRow, previewProps, autoRender, transparentBackground } = this.props;
     const {
       code,
       isRtl,
@@ -178,7 +180,7 @@ export default class LiveCodeExample extends Component {
               className={classnames(styles.preview, previewProps.className, {
                 rtl: isRtl,
                 [styles.darkPreview]: isDarkBackground,
-                [styles.compactPreview]: compact,
+                [styles.compactPreview]: compact && !transparentBackground,
               })}
               dir={isRtl ? 'rtl' : ''}
             >

--- a/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.js
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.js
@@ -36,7 +36,7 @@ export default class LiveCodeExample extends Component {
     previewProps: PropTypes.object,
     autoRender: PropTypes.bool,
     darkBackground: PropTypes.bool,
-    transparentBackground: PropTypes.bool,
+    noBackground: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -45,7 +45,7 @@ export default class LiveCodeExample extends Component {
     previewProps: {},
     autoRender: true,
     darkBackground: false,
-    transparentBackground: false,
+    noBackground: false,
   };
 
   constructor(props) {
@@ -128,7 +128,7 @@ export default class LiveCodeExample extends Component {
   };
 
   render() {
-    const { compact, previewRow, previewProps, autoRender, transparentBackground } = this.props;
+    const { compact, previewRow, previewProps, autoRender, noBackground } = this.props;
     const {
       code,
       isRtl,
@@ -180,7 +180,7 @@ export default class LiveCodeExample extends Component {
               className={classnames(styles.preview, previewProps.className, {
                 rtl: isRtl,
                 [styles.darkPreview]: isDarkBackground,
-                [styles.compactPreview]: compact && !transparentBackground,
+                [styles.compactPreview]: compact && !noBackground,
               })}
               dir={isRtl ? 'rtl' : ''}
             >

--- a/packages/wix-storybook-utils/src/Sections/views/code.tsx
+++ b/packages/wix-storybook-utils/src/Sections/views/code.tsx
@@ -11,7 +11,7 @@ export const code: (a: CodeSection) => React.ReactNode = ({
   interactive = true,
   autoRender,
   darkBackground = false,
-  transparentBackground = false,
+  noBackground = false,
 }) => {
   if (interactive) {
     const LiveCodeExample = React.lazy(() => import('../../LiveCodeExample'));
@@ -23,7 +23,7 @@ export const code: (a: CodeSection) => React.ReactNode = ({
             compact,
             autoRender,
             darkBackground,
-            transparentBackground,
+            noBackground,
             scope: components,
             initialCode: source.trim(),
           }}

--- a/packages/wix-storybook-utils/src/Sections/views/code.tsx
+++ b/packages/wix-storybook-utils/src/Sections/views/code.tsx
@@ -11,6 +11,7 @@ export const code: (a: CodeSection) => React.ReactNode = ({
   interactive = true,
   autoRender,
   darkBackground = false,
+  transparentBackground = false,
 }) => {
   if (interactive) {
     const LiveCodeExample = React.lazy(() => import('../../LiveCodeExample'));
@@ -22,6 +23,7 @@ export const code: (a: CodeSection) => React.ReactNode = ({
             compact,
             autoRender,
             darkBackground,
+            transparentBackground,
             scope: components,
             initialCode: source.trim(),
           }}

--- a/packages/wix-storybook-utils/src/typings/story-section.ts
+++ b/packages/wix-storybook-utils/src/typings/story-section.ts
@@ -119,8 +119,8 @@ export interface CodeSection extends StorySection {
   /** set to `true` if dark background should be enabled by default */
   darkBackground?: boolean;
 
-  /** set to `true` if transparent background should be enabled (override darkBackground) */
-  transparentBackground?: boolean;
+  /** set to `true` if background should be transparent (override darkBackground) */
+  noBackground?: boolean;
 }
 
 /** Tab section is used to nest other sections. It is useful when author desires to, for example, split story page into

--- a/packages/wix-storybook-utils/src/typings/story-section.ts
+++ b/packages/wix-storybook-utils/src/typings/story-section.ts
@@ -118,6 +118,9 @@ export interface CodeSection extends StorySection {
 
   /** set to `true` if dark background should be enabled by default */
   darkBackground?: boolean;
+
+  /** set to `true` if transparent background should be enabled (override darkBackground) */
+  transparentBackground?: boolean;
 }
 
 /** Tab section is used to nest other sections. It is useful when author desires to, for example, split story page into


### PR DESCRIPTION
@argshook 
Motivation is to allow also non-compact examples to be displayed with a transparent background, for `wix-base-ui` per @Zohar-Telor request