### PR TITLE
export d-ts for the icons

### DIFF
--- a/packages/wix-ui-icons-common/.gitignore
+++ b/packages/wix-ui-icons-common/.gitignore
@@ -15,6 +15,7 @@ storybook-e2e
 
 # Ignore all generated *.js and *.svg files in root and /system folders
 /*.js
+/*.d.ts
 /*.svg
 /system
 

--- a/packages/wix-ui-icons-common/scripts/create-aliases.js
+++ b/packages/wix-ui-icons-common/scripts/create-aliases.js
@@ -1,21 +1,35 @@
-const path = require('path');
-const fse = require('fs-extra');
+const path = require("path");
+const fse = require("fs-extra");
 const [from, to, indexPath] = process.argv.slice(2);
 
-if (to && to !== '.' ) {
+if (to && to !== ".") {
   fse.removeSync(to);
   fse.ensureDirSync(to);
 }
-fse.readdirSync(from)
-  .filter(file => file.endsWith('.js'))
-  .forEach(file => fse.writeFileSync(
-    `${to}/${file}`,
-    `module.exports = require('./${path.relative(to, from)}/${file}');\n`
-  ));
+fse
+  .readdirSync(from)
+  .filter(file => file.endsWith(".js"))
+  .forEach(file => {
+    const fileName = file.split(".").shift();
+    const tsFile = `${fileName}.d.ts`;
+    fse.writeFileSync(
+      `${to}/${tsFile}`,
+      [
+        `export * from './${path.relative(to, from)}/${fileName}';`,
+        `import defaultExport from './${path.relative(to, from)}/${fileName}';`,
+        `export default defaultExport`
+      ].join("\n")
+    );
+
+    return fse.writeFileSync(
+      `${to}/${file}`,
+      `module.exports = require('./${path.relative(to, from)}/${file}');\n`
+    );
+  });
 
 if (indexPath) {
   fse.writeFileSync(
     `${to}/index.js`,
     `module.exports = require('./${path.relative(to, indexPath)}');\n`
-  )
+  );
 }


### PR DESCRIPTION
This script populates JS for the icons
The addition is populating the equivalent d.ts
Now users will be able to import the icons and get them with types.
Tested on a ts Yoshi project.
@shlomitc @mykas 