### PR TITLE
Missing props and fixing types

### DIFF
--- a/packages/wsr-types/src/components/CalendarPanel.d.ts
+++ b/packages/wsr-types/src/components/CalendarPanel.d.ts
@@ -8,6 +8,7 @@ declare namespace __WSR {
       excludePastDates?: boolean;
       filterDate?: (date: Date) => boolean;
       value?: SelectedDaysType;
+      numOfMonths?: number;
       selectionMode?: SelectionModeType;
       showYearDropdown?: boolean;
       showMonthDropdown?: boolean;

--- a/packages/wsr-types/src/components/Slider.d.ts
+++ b/packages/wsr-types/src/components/Slider.d.ts
@@ -8,8 +8,8 @@ declare namespace __WSR {
       id?: string;
       max?: number;
       min?: number;
-      onAfterChange?: (value: number) => void;
-      onChange: (value: number) => void;
+      onAfterChange?: (value: number[] | number) => void;
+      onChange: (value: number[] | number) => void;
       rtl?: boolean;
       step?: number;
       pushable?: boolean | number;

--- a/packages/wsr-types/src/components/Tabs.d.ts
+++ b/packages/wsr-types/src/components/Tabs.d.ts
@@ -15,7 +15,7 @@ declare namespace __WSR {
     export type Item = {
       id: string | number;
       title: React.ReactNode;
-      dataHook: string;
+      dataHook?: string;
     }
 
     export class Tabs extends React.PureComponent<TabsProps> {}


### PR DESCRIPTION
1. Tabs Item - making dataHook as optional.
2. CalendarPanel - missing numOfMonths prop.
3. Slider - fixed argument type for onChange() and onAfterChange() handlers 