### PR TITLE
#EE-22229| bug-fix - TAB on dropdown throws exception

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -177,7 +177,7 @@ export class DropdownComponent extends React.PureComponent<
 
   onKeyboardSelect() {
     const selectedOption = this.getSelectedOption();
-    this.onOptionClick(selectedOption);
+    selectedOption && this.onOptionClick(selectedOption);
   }
 
   isClosingKey(key) {


### PR DESCRIPTION
bug occurs on trying to reach `id` of `selectedOption` that is `null`

https://jira.wixpress.com/browse/EE-22229