### PR TITLE
`<ModalPreviewLayout/>`- adding props modal tooltips

### DIFF
--- a/packages/wsr-types/__tests__/ModalPreviewLayout-tests.tsx
+++ b/packages/wsr-types/__tests__/ModalPreviewLayout-tests.tsx
@@ -17,6 +17,9 @@ function ModalPreviewLayoutWithAllProps() {
       actions={<div />}
       dataHook="hook"
       title="title"
+      closeButtonTooltipText="Close"
+      prevButtonTooltipText="Previous"
+      nextButtonTooltipText="Next"
       shouldCloseOnOverlayClick>
       asd
     </ModalPreviewLayout>

--- a/packages/wsr-types/src/components/ModalPreviewLayout.d.ts
+++ b/packages/wsr-types/src/components/ModalPreviewLayout.d.ts
@@ -7,6 +7,9 @@ declare namespace __WSR {
       children: React.ReactNode;
       onClose: () => void;
       shouldCloseOnOverlayClick?: boolean;
+      closeButtonTooltipText: string;
+      prevButtonTooltipText: string;
+      nextButtonTooltipText: string;
     }
 
     export class ModalPreviewLayout extends React.PureComponent<

--- a/packages/wsr-types/src/components/ModalPreviewLayout.d.ts
+++ b/packages/wsr-types/src/components/ModalPreviewLayout.d.ts
@@ -7,9 +7,9 @@ declare namespace __WSR {
       children: React.ReactNode;
       onClose: () => void;
       shouldCloseOnOverlayClick?: boolean;
-      closeButtonTooltipText: string;
-      prevButtonTooltipText: string;
-      nextButtonTooltipText: string;
+      closeButtonTooltipText?: string;
+      prevButtonTooltipText?: string;
+      nextButtonTooltipText?: string;
     }
 
     export class ModalPreviewLayout extends React.PureComponent<


### PR DESCRIPTION
Should be merged after https://github.com/wix/wix-style-react/pull/4965 is merged 