### PR TITLE
wsr-types: Add missing types for exported TableToolbar items

### DIFF
--- a/packages/wsr-types/src/components/TableToolbar.d.ts
+++ b/packages/wsr-types/src/components/TableToolbar.d.ts
@@ -56,4 +56,10 @@ declare module 'wix-style-react' {
 declare module 'wix-style-react/TableToolbar' {
   export import TableToolbar = __WSR.TableToolbar.TableToolbar;
   export import TableToolbarProps = __WSR.TableToolbar.TableToolbarProps;
+  export import ItemGroup = __WSR.TableToolbar.ItemGroup;
+  export import Item = __WSR.TableToolbar.Item;
+  export import Title = __WSR.TableToolbar.Title;
+  export import Label = __WSR.TableToolbar.Label;
+  export import Divider = __WSR.TableToolbar.Divider;
+  export import SelectedCount = __WSR.TableToolbar.SelectedCount;
 }


### PR DESCRIPTION
We do reexport more items from `wix-style-react/TableToolbar`:
https://github.com/wix/wix-style-react/blob/180020600474351c648ce32a3a8be8ac32181fed/src/TableToolbar/index.js#L1-L2