### PR TITLE
Make NavStepperDriver compatible with typescript < 3.6

### DIFF
--- a/packages/wix-ui-core/src/components/nav-stepper/NavStepper.driver.ts
+++ b/packages/wix-ui-core/src/components/nav-stepper/NavStepper.driver.ts
@@ -19,7 +19,7 @@ export class NavStepperDriver implements BaseDriver {
   constructor(private readonly element: Element) {}
 
   /**  returns the root element */
-  get root() {
+  root() {
     return this.element;
   }
 
@@ -46,7 +46,7 @@ export class NavStepperDriver implements BaseDriver {
   clickOnStep = (index: number) => Simulate.click(this.stepAt(index));
 
   /** returns the active step element */
-  get activeStep() {
+  activeStep() {
     return Array.from<HTMLLIElement>(
       this.element.getElementsByTagName('li'),
     ).find(step => this.hasStyleState(step, 'active'));

--- a/packages/wix-ui-core/src/components/nav-stepper/NavStepper.spec.tsx
+++ b/packages/wix-ui-core/src/components/nav-stepper/NavStepper.spec.tsx
@@ -18,8 +18,8 @@ describe('NavStepper', () => {
       </NavStepper>,
     );
 
-    expect(driver.root.tagName).toBe('NAV');
-    expect(driver.root.firstElementChild.tagName).toBe('OL');
+    expect(driver.root().tagName).toBe('NAV');
+    expect(driver.root().firstElementChild.tagName).toBe('OL');
     expect(driver.stepContentAt(0)).toBe('First Step');
   });
 
@@ -40,7 +40,7 @@ describe('NavStepper', () => {
         <NavStepper.Step>First Step</NavStepper.Step>
       </NavStepper>,
     );
-    expect(driver.activeStep.attributes['aria-current'].value).toBe('page');
+    expect(driver.activeStep().attributes['aria-current'].value).toBe('page');
   });
 
   it('should pass disabled state to disabled children', async () => {
@@ -81,7 +81,7 @@ describe('NavStepper', () => {
         <NavStepper.Step value={5}>First Step</NavStepper.Step>
       </NavStepper>,
     );
-    expect(driver.activeStep.value).toBe(5);
+    expect(driver.activeStep().value).toBe(5);
   });
 
   it('notifies on step click', async () => {


### PR DESCRIPTION
compiled .d.ts files aren't allowed to contain getters /
setters in typescript below version 3.6, so this PR
removes getters and setters from drivers