### PR TITLE
withEllipsedTooltip: Avoid unnecessary re-renders

### DIFF
--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltip.tsx
@@ -79,9 +79,12 @@ class EllipsedTooltip extends React.Component<
       this.props.showTooltip &&
       this.textNode &&
       this.textNode.offsetWidth < this.textNode.scrollWidth;
-    this.setState({
-      isEllipsisActive,
-    });
+
+    if (isEllipsisActive !== this.state.isEllipsisActive) {
+      this.setState({
+        isEllipsisActive,
+      });
+    }
   };
 
   _debouncedUpdate = debounce(this._updateEllipsisState, 100);

--- a/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltipNext.tsx
+++ b/packages/wix-ui-core/src/hocs/EllipsedTooltip/withEllipsedTooltipNext.tsx
@@ -79,9 +79,12 @@ class EllipsedTooltip extends React.Component<
       this.props.showTooltip &&
       this.textNode &&
       this.textNode.offsetWidth < this.textNode.scrollWidth;
-    this.setState({
-      isEllipsisActive,
-    });
+
+    if (isEllipsisActive !== this.state.isEllipsisActive) {
+      this.setState({
+        isEllipsisActive,
+      });
+    }
   };
 
   _debouncedUpdate = debounce(this._updateEllipsisState, 100);


### PR DESCRIPTION
While profiling Table performance issues found this culprit. This caused one extra re-render for elements that do not need to show an ellipsis on initial mounting.

The flow before this fix was:
1. `render()` is called (initial render)
2. `componentDidMount()` is called
3. `setState()` is called with the same value as default state - even if we do not need to show ellipsis
4. another unnecessary `render()` is called (fixed now)