### PR TITLE
`<ButtonNext />` - content width inherit, so ellipsis could be added

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.st.css
+++ b/packages/wix-ui-core/src/components/button-next/button-next.st.css
@@ -11,7 +11,9 @@
   cursor: pointer;
 }
 
-.content {}
+.content {
+  width: inherit;
+}
 
 .prefix {
   flex-shrink: 0;


### PR DESCRIPTION
This change is needed so I could add Text element with ellipsis in wix-style-react button