### PR TITLE
`<Popover/>` - make sure that popover potal does not bubble up the events to its parent

### DIFF
--- a/packages/wix-ui-core/src/components/popover-next/popover-next.tsx
+++ b/packages/wix-ui-core/src/components/popover-next/popover-next.tsx
@@ -273,6 +273,7 @@ export class PopoverNext extends React.Component<
 
     if (this.appendToNode) {
       this.portalNode = document.createElement('div');
+      this.portalNode.addEventListener('click', e => e.stopPropagation());
       this.portalNode.setAttribute('data-hook', 'popover-portal');
       this.portalNode.setAttribute('data-loaded', 'false');
       /**

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -387,6 +387,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     this.appendToNode = getAppendToElement(appendTo, this.targetRef);
     if (this.appendToNode) {
       this.portalNode = document.createElement('div');
+      this.portalNode.addEventListener('click', e => e.stopPropagation());
       this.portalNode.setAttribute('data-hook', 'popover-portal');
       /**
        * reset overlay wrapping layer


### PR DESCRIPTION
This PR is suppose to fix the issue where Popover portal for some unknown reason gets a noop function on onClick method coming from React itself. Could not find the reason for it, but this causes issues like this for our users: 
![click](https://user-images.githubusercontent.com/8919190/78121834-8c493f80-7414-11ea-9e95-be85177b76be.gif)
> I have a FloatingHelper on a TableActionCell in that table I also have onRowClick
the problem that I get onRowClick when I click on the FloatingHelper as well.. is there a way to prevent it?




