### PR TITLE
wix-storybook-utils: chore(CodeShowcase): remove stylable usage

### DIFF
--- a/packages/wix-storybook-utils/src/CodeShowcase/CodeShowcase.scss
+++ b/packages/wix-storybook-utils/src/CodeShowcase/CodeShowcase.scss
@@ -12,13 +12,12 @@
 } 
 
 .demoItems {
-  -st-states: inverted;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
 }
 
-.demoItems:inverted {
+.inverted {
   background: linear-gradient(45deg, #eff2f6 25%, transparent 25%, transparent 75%, #eff2f6 75%, #eff2f6 0), linear-gradient(45deg, #eff2f6 25%, transparent 5%, transparent 75%, #eff2f6 75%, #eff2f6 0), #fff;
   background-position: 0 0, 10px 10px;
   background-size: 20px 20px;

--- a/packages/wix-storybook-utils/src/CodeShowcase/components/List.js
+++ b/packages/wix-storybook-utils/src/CodeShowcase/components/List.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import styleclass from '../CodeShowcase.st.css';
+import classnames from 'classnames';
 import { node, bool } from 'prop-types';
+
+import styles from '../CodeShowcase.scss';
 
 const spacing = {
   marginRight: '8px',
@@ -11,7 +13,9 @@ const spacing = {
 };
 
 const List = ({ children, inverted }) => (
-  <div {...styleclass('demoItems', { inverted })}>
+  <div
+    className={classnames(styles.demoItems, { [styles.inverted]: inverted })}
+  >
     {Array.isArray(children)
       ? children.map((child, index) => (
           <div key={index} style={spacing}>

--- a/packages/wix-storybook-utils/src/CodeShowcase/index.js
+++ b/packages/wix-storybook-utils/src/CodeShowcase/index.js
@@ -5,8 +5,9 @@ import SyntaxHighlighter, {
 } from 'react-syntax-highlighter/prism-light';
 import jsx from 'react-syntax-highlighter/languages/prism/jsx';
 import vs from 'react-syntax-highlighter/styles/prism/vs';
+import classnames from 'classnames';
 
-import styleclass from './CodeShowcase.st.css';
+import styles from './CodeShowcase.scss';
 import List from './components/List';
 import { iconShow } from './components/Show';
 import { iconHide } from './components/Hide';
@@ -45,23 +46,23 @@ class CodeShowcase extends React.Component {
     } = this.props;
     const { show } = this.state;
     return (
-      <div style={style} {...styleclass('root', {}, { className: theme })}>
-        <section className={styleclass.demo}>
+      <div style={style} className={classnames(styles.root, theme)}>
+        <section className={styles.demo}>
           <List inverted={inverted}>{children}</List>
         </section>
-        <section className={styleclass.meta}>
-          <a href={link} className={styleclass.title}>
+        <section className={styles.meta}>
+          <a href={link} className={styles.title}>
             {title}
           </a>
-          <div className={styleclass.description}>{description}</div>
+          <div className={styles.description}>{description}</div>
           <span
-            className={show ? styleclass.iconHide : styleclass.iconShow}
+            className={show ? styles.iconHide : styles.iconShow}
             onClick={this.toggleCodeShow}
           >
             {show ? iconHide : iconShow}
           </span>
         </section>
-        <section className={show ? styleclass.code : styleclass.codeHide}>
+        <section className={show ? styles.code : styles.codeHide}>
           <SyntaxHighlighter
             customStyle={customHighlighterStyle}
             language="jsx"


### PR DESCRIPTION
in order to allow consumers of wix-storybook-utils to use either
stylable v1 or stylable v3

required for https://github.com/wix/wix-ui/pull/1833