### PR TITLE
wix-ui-core: wix-ui-icons-common to dependencies

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -102,6 +102,7 @@
     "tslib": "^1.9.3",
     "type-zoo": "3.1.1",
     "wix-eventually": "^2.2.0",
+    "wix-ui-icons-common": "^2.0.0",
     "wix-ui-test-utils": "^1.0.151"
   },
   "devDependencies": {
@@ -144,7 +145,6 @@
     "webpack-dev-middleware": "3.6.0",
     "wix-storybook-utils": "^3.0.7",
     "wix-ui-framework": "^3.3.1",
-    "wix-ui-icons-common": "^2.0.0",
     "wix-ui-mocha-runner": "^0.1.6",
     "yoshi": "^3.28.0",
     "yoshi-style-dependencies": "^3.16.0"


### PR DESCRIPTION
used by `popover-next` as a direct dependency (importing `Refresh`)
https://github.com/wix/wix-ui/blob/8b936622aa27cad198aa4b5766fcaefcedd538d1/packages/wix-ui-core/src/components/popover-next/components/ErrorBoundary.tsx#L2

cc @mykas 