### PR TITLE
`<Popover/>` - add fluid prop for trigger element

### DIFF
--- a/packages/wix-ui-core/src/components/popover-next/popover-next.tsx
+++ b/packages/wix-ui-core/src/components/popover-next/popover-next.tsx
@@ -118,6 +118,8 @@ export interface PopoverNextProps {
   customArrow?(placement: Placement, arrowProps: object): React.ReactNode;
   /** target element role value */
   role?: string;
+  /* stretch trigger element to the width of its container. */
+  fluid?: boolean;
   /** popover z-index */
   zIndex?: number;
   /**
@@ -405,6 +407,7 @@ export class PopoverNext extends React.Component<
       id,
       excludeClass,
       timeout,
+      fluid,
     } = this.props;
     const { isMounted, shown } = this.state;
 
@@ -433,7 +436,7 @@ export class PopoverNext extends React.Component<
               style={inlineStyles}
               data-hook={this.props['data-hook']}
               data-content-hook={this.contentHook}
-              {...style('root', {}, this.props)}
+              {...style('root', { fluid }, this.props)}
               onMouseEnter={onMouseEnter}
               onMouseLeave={onMouseLeave}
               id={id}

--- a/packages/wix-ui-core/src/components/popover/Popover.st.css
+++ b/packages/wix-ui-core/src/components/popover/Popover.st.css
@@ -21,10 +21,16 @@
 }
 
 .root {
+  -st-states: fluid;
   /*popper sets tooltip in absolute position according to this container*/
   position: relative;
   /*popper adds an extra div that needs to be measured without stretching*/
   display: inline-block;
+}
+
+.root:fluid {
+  /* for stretching the container alongside the positioning mechanism */
+  display: block;
 }
 
 .popoverAnimation {}
@@ -110,3 +116,4 @@
 }
 
 .popoverElement {}
+

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -97,6 +97,8 @@ export interface PopoverProps {
   style?: object;
   /** Id */
   id?: string;
+  /* stretch trigger element to the width of its container. */
+  fluid?: boolean;
   /** Custom arrow element */
   customArrow?(placement: Placement, arrowProps: object): React.ReactNode;
   /** target element role value */
@@ -508,6 +510,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       style: inlineStyles,
       id,
       excludeClass,
+      fluid,
     } = this.props;
     const { isMounted, shown } = this.state;
 
@@ -529,7 +532,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
             style={inlineStyles}
             data-hook={this.props['data-hook']}
             data-content-hook={this.contentHook}
-            {...style('root', {}, this.props)}
+            {...style('root', { fluid }, this.props)}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             id={id}

--- a/packages/wix-ui-core/src/components/popover/docs/Popover.story.tsx
+++ b/packages/wix-ui-core/src/components/popover/docs/Popover.story.tsx
@@ -11,7 +11,7 @@ import {
   tab,
   tabs,
   example as baseExample,
-  title
+  title,
 } from 'wix-storybook-utils/Sections';
 import { Popover } from '../Popover';
 import { Category, baseScope } from '../../../../stories/utils';
@@ -22,7 +22,7 @@ import * as examples from './examples';
 
 const children = [
   <Popover.Element key="1">This is the Popover.Element</Popover.Element>,
-  <Popover.Content key="2">Content</Popover.Content>
+  <Popover.Content key="2">Content</Popover.Content>,
 ];
 
 export default {
@@ -34,29 +34,29 @@ export default {
     'data-hook': 'storybook-popover',
     children: [
       <Popover.Element key="1">This is the Popover.Element</Popover.Element>,
-      <Popover.Content key="2">Content</Popover.Content>
+      <Popover.Content key="2">Content</Popover.Content>,
     ],
     appendTo: 'window',
     showArrow: true,
     timeout: 150,
     shown: false,
     fluid: false,
-    placement: 'top'
+    placement: 'top',
   },
 
   exampleProps: {
     children: [
       {
         label: 'Default example',
-        value: children
-      }
+        value: children,
+      },
     ],
     appendTo: [
       { label: 'window', value: window },
       { label: 'scrollParent', value: 'scrollParent' },
       { label: 'viewport', value: 'viewport' },
       { label: 'parent', value: 'parent' },
-      { label: 'null', value: null }
+      { label: 'null', value: null },
     ],
     placement: [
       'auto-start',
@@ -73,8 +73,8 @@ export default {
       'bottom-start',
       'left-end',
       'left',
-      'left-start'
-    ]
+      'left-start',
+    ],
   },
 
   sections: [
@@ -87,14 +87,14 @@ export default {
           <Popover.Element>Popover Element</Popover.Element>,
           <Popover.Content>Content</Popover.Content>
         </Popover>
-      )
+      ),
     }),
     tabs([
       tab({
         title: 'Description',
         sections: [
           columns([
-            description('The floating card popped by clicking or hovering.')
+            description('The floating card popped by clicking or hovering.'),
           ]),
 
           importExample(),
@@ -106,27 +106,34 @@ export default {
           example({
             title: 'Simple',
             text: 'A simple example of Popover usage',
-            source: examples.simple
+            source: examples.simple,
           }),
 
           example({
             title: 'Placement',
             text: 'There is a variety of options for placement selection.',
-            source: examples.placement
+            source: examples.placement,
           }),
 
           example({
             title: 'MoveBy',
             text:
               '<em>x</em> and <em>y</em> axis orientation is relative to the placement of the popover.',
-            source: examples.moveBy
+            source: examples.moveBy,
+          }),
+
+          example({
+            title: 'Fluid',
+            text:
+              'To allow trigger element to stretch to its parent container.',
+            source: examples.fluid,
           }),
 
           example({
             title: 'zIndex',
             text:
               'If some container got higher zIndex then Popover content - the zIndex of Popover content can be controlled',
-            source: examples.zIndex
+            source: examples.zIndex,
           }),
 
           title('Floating Behaviour'),
@@ -135,14 +142,14 @@ export default {
             title: 'Flip:Enabled & Fixed: Disabled',
             text:
               'Focus target element (TAB) and scroll viewport to see behaviour',
-            source: examples.flip
+            source: examples.flip,
           }),
 
           example({
             title: 'Flip: Disabled & Fixed: Enabled',
             text:
               'Focus target element (TAB) and scroll viewport to see behaviour',
-            source: examples.fixed
+            source: examples.fixed,
           }),
 
           title('Handling Overflow'),
@@ -150,34 +157,34 @@ export default {
           example({
             title: 'appendTo="window"',
             text: `If you inspect the content, you'll see it is attached to a new div under the body.`,
-            source: examples.window
+            source: examples.window,
           }),
 
           example({
             title: 'appendTo="scrollParent"',
             text: `If you inspect the content, you'll see it is attached to a new div under the list container.`,
-            source: examples.scrollParent
+            source: examples.scrollParent,
           }),
 
           example({
             title: 'appendTo="viewport"',
             text: `If you inspect the content, you'll see it is attached to a document.body but the popvoer content element reacts to screen viewport.`,
-            source: examples.viewPort
+            source: examples.viewPort,
           }),
 
           example({
             title: `appendTo={elm => elm.getAttribute('attribute') === 'value'}`,
             text: `Sometimes we want a to target certain overflow element. A function can be passed that will be run against all parent elements until found.If you inspect the content, you'll see it is attached to a document.body but the popvoer content element reacts to screen viewport.`,
-            source: examples.predicate
-          })
-        ]
+            source: examples.predicate,
+          }),
+        ],
       }),
 
       ...[
         { title: 'API', sections: [api()] },
         { title: 'Testkit', sections: [testkit()] },
-        { title: 'Playground', sections: [playground()] }
-      ].map(tab)
-    ])
-  ]
+        { title: 'Playground', sections: [playground()] },
+      ].map(tab),
+    ]),
+  ],
 };

--- a/packages/wix-ui-core/src/components/popover/docs/examples.ts
+++ b/packages/wix-ui-core/src/components/popover/docs/examples.ts
@@ -54,6 +54,27 @@ export const moveBy = `
 }
 `;
 
+export const fluid = `
+() => {
+  return (
+  <div style={{ display: 'flex'}}>
+    <div style={{ width: '50%', border: '1px solid black'}} >
+      <Popover shown placement="top" showArrow>
+        <Popover.Element><ButtonNext style={{ width: '100%' }}>inline</ButtonNext></Popover.Element>
+        <Popover.Content>The content</Popover.Content>
+      </Popover>
+    </div>
+    <div style={{ width: '50%', border: '1px solid black', marginLeft: '15px'}} >
+      <Popover shown placement="top" showArrow fluid>
+        <Popover.Element><ButtonNext style={{ width: '100%' }}>fluid</ButtonNext></Popover.Element>
+        <Popover.Content>The content</Popover.Content>
+      </Popover>
+    </div>
+  </div>
+  )
+}
+`;
+
 export const zIndex = `
 () => {
   const [shown, setShown] = React.useState(true)

--- a/packages/wix-ui-core/src/components/popover/tests/Popover.visual.tsx
+++ b/packages/wix-ui-core/src/components/popover/tests/Popover.visual.tsx
@@ -24,6 +24,29 @@ visualize('Popover', () => {
     ));
   });
 
+  story('trigger element fluid', () => {
+    snap('fluid=disabled', () => (
+      <div style={{ border: '1px solid black' }}>
+        <Popover shown placement="top" showArrow>
+          <Popover.Element>
+            <button style={{ width: '100%' }}>inline</button>
+          </Popover.Element>
+          <Popover.Content>The content</Popover.Content>
+        </Popover>
+      </div>
+    ));
+    snap('fluid=enabled', () => (
+      <div style={{ border: '1px solid black' }}>
+        <Popover fluid shown placement="top" showArrow>
+          <Popover.Element>
+            <button style={{ width: '100%' }}>inline</button>
+          </Popover.Element>
+          <Popover.Content>The content</Popover.Content>
+        </Popover>
+      </div>
+    ));
+  });
+
   story('zIndex', () => {
     snap('should set zindex', () => (
       <div


### PR DESCRIPTION
This PR is adding a `fluid` prop which will control the way the popover trigger element reacts to its trigger element. 

* When `fluid` is disabeld and it is by default - it assumes that the trigger element is inline-block based.
* When `fluid` is enabled it changes its container to flow with its container width and so letting trigger element grow too.

This solves a problem, where users would like wrap their ellipsis based components which shows ellipsis based on whats available. Since now popover only supported inline so ellipsis never actually worked.