### PR TITLE
eslint-plugin-wix-components-library

### DIFF
--- a/packages/eslint-plugin-wix-components-library/.gitignore
+++ b/packages/eslint-plugin-wix-components-library/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+!tests/fixtures/**/node_modules

--- a/packages/eslint-plugin-wix-components-library/README.md
+++ b/packages/eslint-plugin-wix-components-library/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-wix-components-library
 
-Wix Componets Library ESLint Plugin
+Wix Components Library ESLint Plugin
 
 ## Installation
 

--- a/packages/eslint-plugin-wix-components-library/README.md
+++ b/packages/eslint-plugin-wix-components-library/README.md
@@ -1,0 +1,44 @@
+# eslint-plugin-wix-components-library
+
+Wix Componets Library ESLint Plugin
+
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org):
+
+```
+$ npm i eslint --save-dev
+```
+
+Next, install `eslint-plugin-wix-components-library`:
+
+```
+$ npm install eslint-plugin-wix-components-library --save-dev
+```
+
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-wix-components-library` globally.
+
+## Usage
+
+Add `wix-components-library` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+
+```json
+{
+    "plugins": [
+        "wix-components-library"
+    ]
+}
+```
+
+
+Then configure the rules you want to use under the rules section.
+## Supported Rules
+
+#### prop-types-restrict-to-default-import
+```json
+{
+    "rules": {
+        "wix-components-library/prop-types-restrict-to-default-import": 2
+    }
+}
+```

--- a/packages/eslint-plugin-wix-components-library/docs/rules/prop-types-restrict-to-default-import.md
+++ b/packages/eslint-plugin-wix-components-library/docs/rules/prop-types-restrict-to-default-import.md
@@ -1,0 +1,39 @@
+# Restrict to default import when using prop-types (prop-types-restrict-to-default-import)
+
+Using non default imports from prop-types is not recommended, names are confusing.
+This rule makes sure using only the default import.
+You can fix your code using the --fix flag.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+import { string, number, object } from 'prop-types';
+
+class MyClass {
+  static propTypes = {
+    myString: string,
+    myNumber: number,
+    myObject: object,
+  };
+}
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+import PropTypes from 'prop-types';
+
+class MyClass {
+  static propTypes = {
+    myString: PropTypes.string,
+    myNumber: PropTypes.number,
+    myObject: PropTypes.object,
+  };
+}
+
+```

--- a/packages/eslint-plugin-wix-components-library/lib/index.js
+++ b/packages/eslint-plugin-wix-components-library/lib/index.js
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview Wix components library eslint plugin
+ * @author Components team
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var requireIndex = require("requireindex");
+
+//------------------------------------------------------------------------------
+// Plugin Definition
+//------------------------------------------------------------------------------
+
+
+// import all rules in lib/rules
+module.exports.rules = requireIndex(__dirname + "/rules");
+
+
+

--- a/packages/eslint-plugin-wix-components-library/lib/rules/prop-types-restrict-to-default-import.js
+++ b/packages/eslint-plugin-wix-components-library/lib/rules/prop-types-restrict-to-default-import.js
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Restrict using only the default import with 'prop-types'
+ * @author Egozi
+ */
+'use strict';
+
+module.exports = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: "Restrict using only the default import with 'prop-types'",
+            category: 'Best Practices',
+            recommended: true,
+        },
+        fixable: 'code',
+        schema: [],
+    },
+
+    create: function(context) {
+        return {
+            ImportDeclaration(node) {
+                if (node.source.value === 'prop-types') {
+                    propTypesImport(node, context);
+                }
+            },
+        };
+    },
+};
+
+function propTypesImport(node, context) {
+    const specifiers = node.specifiers.filter(specifier => specifier.type === 'ImportSpecifier');
+
+    if (specifiers.length > 0) {
+        context.report({
+            node,
+            message: "Use 'prop-types' default import only",
+            fix(fixer) {
+                // Code changes to be done
+                const fixes = [];
+
+                // Iterate over each non default import
+                specifiers.forEach(specifier => {
+
+                    // Add `PropTypes.` prefix to all references
+                    let allRefs = context.getDeclaredVariables(specifier)[0].references;
+                    allRefs.forEach(token => {
+                        fixes.push(fixer.insertTextBefore(token.identifier, 'PropTypes.'));
+                    });
+                });
+
+                // Replace the import with the default
+                fixes.push(
+                    fixer.replaceText(node, "import PropTypes from 'prop-types';"),
+                );
+                return fixes;
+            },
+        });
+    }
+}

--- a/packages/eslint-plugin-wix-components-library/package.json
+++ b/packages/eslint-plugin-wix-components-library/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "eslint-plugin-wix-components-library",
+  "version": "1.0.0",
+  "description": "Dunno",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "author": "Egozi",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "mocha tests --recursive"
+  },
+  "dependencies": {
+    "requireindex": "~1.1.0"
+  },
+  "devDependencies": {
+    "eslint": "~3.9.1",
+    "mocha": "^3.1.2"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "license": "ISC"
+}

--- a/packages/eslint-plugin-wix-components-library/package.json
+++ b/packages/eslint-plugin-wix-components-library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-wix-components-library",
   "version": "1.0.0",
-  "description": "Dunno",
+  "description": "Wix Components Library ESLint Plugin",
   "keywords": [
     "eslint",
     "eslintplugin",

--- a/packages/eslint-plugin-wix-components-library/pom.xml
+++ b/packages/eslint-plugin-wix-components-library/pom.xml
@@ -2,10 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wixpress.infra</groupId>
-    <artifactId>prop-types-restrict-to-default-import</artifactId>
+    <artifactId>eslint-plugin-wix-components-library</artifactId>
     <packaging>pom</packaging>
     <name>eslint-plugin-wix-components-library</name>
-    <description>eslint-plugin-wix-components-library</description>
+    <description>Wix Components Library ESLint Plugin</description>
     <version>1.0.0-SNAPSHOT</version>
 
     <parent>

--- a/packages/eslint-plugin-wix-components-library/pom.xml
+++ b/packages/eslint-plugin-wix-components-library/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>prop-types-restrict-to-default-import</artifactId>
     <packaging>pom</packaging>
     <name>prop-types-restrict-to-default-import</name>
-    <description>eslint rule for wix-style-react</description>
+    <description>eslint rule for wix components libraries</description>
     <version>1.0.0-SNAPSHOT</version>
 
     <parent>

--- a/packages/eslint-plugin-wix-components-library/pom.xml
+++ b/packages/eslint-plugin-wix-components-library/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.wixpress.infra</groupId>
+    <artifactId>prop-types-restrict-to-default-import</artifactId>
+    <packaging>pom</packaging>
+    <name>prop-types-restrict-to-default-import</name>
+    <description>eslint rule for wix-style-react</description>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <parent>
+        <groupId>com.wixpress.common</groupId>
+        <artifactId>wix-master-parent</artifactId>
+        <version>100.0.0-SNAPSHOT</version>
+    </parent>
+
+    <developers>
+        <developer>
+            <name>Egozi</name>
+            <email>egozi@wix.com</email>
+            <roles>
+                <role>owner</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <mailingLists>
+        <mailingList>
+            <name>slack</name>
+            <subscribe>wix-ui</subscribe>
+        </mailingList>
+    </mailingLists>
+</project>

--- a/packages/eslint-plugin-wix-components-library/pom.xml
+++ b/packages/eslint-plugin-wix-components-library/pom.xml
@@ -4,8 +4,8 @@
     <groupId>com.wixpress.infra</groupId>
     <artifactId>prop-types-restrict-to-default-import</artifactId>
     <packaging>pom</packaging>
-    <name>prop-types-restrict-to-default-import</name>
-    <description>eslint rule for wix components libraries</description>
+    <name>eslint-plugin-wix-components-library</name>
+    <description>eslint-plugin-wix-components-library</description>
     <version>1.0.0-SNAPSHOT</version>
 
     <parent>


### PR DESCRIPTION
Created an eslint plugin for components libraries - **eslint-plugin-wix-components-library**

With a rule for prop-types:
Restrict to default import when using prop-types (**prop-types-restrict-to-default-import**)