### PR TITLE
chore(wix-ui-mocha-runner): upgrade dependencies and support stylable v3

### DIFF
--- a/packages/wix-ui-mocha-runner/package.json
+++ b/packages/wix-ui-mocha-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wix-ui-mocha-runner",
   "description": "wix-ui-mocha-runner",
-  "version": "0.1.8",
+  "version": "1.0.0",
   "private": false,
   "author": {
     "name": "Wix",
@@ -19,18 +19,20 @@
     "wix-ui-mocha-runner": "bin/runner.js"
   },
   "dependencies": {
-    "awesome-typescript-loader": "^5.1.1",
+    "@stylable/webpack-plugin": "^3.4.1",
+    "awesome-typescript-loader": "^5.2.1",
     "chalk": "^2.4.1",
     "css-loader": "^0.28.11",
     "html-webpack-plugin": "^3.2.0",
     "mocha-teamcity-reporter": "^2.4.0",
     "puppeteer": "^1.5.0",
     "source-map-support": "^0.5.6",
-    "stylable": "^5.3.9",
-    "stylable-webpack-plugin": "^1.0.18",
     "style-loader": "^0.21.0",
-    "typescript": "~2.8.3",
+    "typescript": "^3.8.3",
     "webpack": "^4.9.1",
     "webpack-serve": "^1.0.4"
+  },
+  "peerDependencies": {
+    "@stylable/core": "^3.4.1"
   }
 }

--- a/packages/wix-ui-mocha-runner/src/server.js
+++ b/packages/wix-ui-mocha-runner/src/server.js
@@ -5,7 +5,7 @@ const chalk = require('chalk');
 const webpack = require('webpack');
 const serve = require('webpack-serve');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const StylableWebpackPlugin = require('stylable-webpack-plugin');
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
 const runTestsInPuppeteer = require('./run-in-puppeteer');
 
 const watchMode = process.argv.some(arg => arg === '--watch');


### PR DESCRIPTION
the purpose is to upgrade some dependencies to allow `wix-ui-mocha-runner` to be run with projects using stylable v3.

this change is under a major `1.0.0` version release, to not break existing users (which is only wix-ui-core)

this is required for https://github.com/wix/wix-ui/pull/1833

