### PR TITLE
`<Tooltip/>`- disable onShow and onHide executions when tooltip is disabled

### DIFF
--- a/packages/wix-ui-core/src/components/tooltip-next/tooltip-next.tsx
+++ b/packages/wix-ui-core/src/components/tooltip-next/tooltip-next.tsx
@@ -158,8 +158,8 @@ export class TooltipNext extends React.PureComponent<
         placement={placement}
         shown={disabled ? false : this.state.isOpen}
         showArrow={showArrow}
-        onMouseEnter={this.open}
-        onMouseLeave={this.close}
+        onMouseEnter={disabled ? undefined : this.open}
+        onMouseLeave={disabled ? undefined : this.close}
         timeout={timeout}
         hideDelay={hideDelay}
         showDelay={showDelay}

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
@@ -124,6 +124,21 @@ function runTests(render, tooltip) {
       await driver.mouseLeave();
       expect(onHide).toHaveBeenCalled();
     });
+
+    it('should not call onShow when tooltip is disabled', async () => {
+      const onShow = jest.fn();
+      const { driver } = render(tooltip({ onShow , disabled: true }));
+      await driver.mouseEnter();
+      expect(onShow).not.toHaveBeenCalled()
+    });
+
+    it('should not call onHide when tooltip is disabled', async () => {
+      const onHide = jest.fn();
+      const { driver } = render(tooltip({ onHide,  disabled: true }));
+      await driver.mouseEnter();
+      await driver.mouseLeave();
+      expect(onHide).not.toHaveBeenCalled();
+    });
   });
 
   describe('`content` prop', () => {

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import style from './Tooltip.st.css';
 import { Popover, Placement, AppendTo } from '../popover';
-import {PopoverNext} from "../popover-next";
 
 export interface Point {
   x: number;

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import style from './Tooltip.st.css';
 import { Popover, Placement, AppendTo } from '../popover';
+import {PopoverNext} from "../popover-next";
 
 export interface Point {
   x: number;
@@ -153,8 +154,8 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
         placement={placement}
         shown={disabled ? false : this.state.isOpen}
         showArrow={showArrow}
-        onMouseEnter={this.open}
-        onMouseLeave={this.close}
+        onMouseEnter={disabled ? undefined : this.open}
+        onMouseLeave={disabled ? undefined : this.close}
         timeout={timeout}
         hideDelay={hideDelay}
         showDelay={showDelay}


### PR DESCRIPTION
Prevent `onShow` and `onHide` executions when `Tooltip` is disabled.

Related issue: https://github.com/wix/wix-style-react/issues/5367