### PR TITLE
fix(migrate-wsr8): add Card.Divider only if Card.Header lacks withoutDivider

### DIFF
--- a/packages/wix-ui-codemod/src/wix-style-react/__testfixtures__/migrate-wsr8/card-header.input.js
+++ b/packages/wix-ui-codemod/src/wix-style-react/__testfixtures__/migrate-wsr8/card-header.input.js
@@ -3,7 +3,7 @@ import { Card } from 'wix-style-react';
 
 const component = () => (
   <Card>
-    <Card.Header withoutDivider title="insert divider here" />
+    <Card.Header withoutDivider title="no divider" />
     <Card.Content>touch me</Card.Content>
 
     <Card.Header title="insert divider here" />

--- a/packages/wix-ui-codemod/src/wix-style-react/__testfixtures__/migrate-wsr8/card-header.output.js
+++ b/packages/wix-ui-codemod/src/wix-style-react/__testfixtures__/migrate-wsr8/card-header.output.js
@@ -3,10 +3,10 @@ import { Card } from 'wix-style-react';
 
 const component = () => (
   <Card>
-    <Card.Header title="insert divider here" />
-    <Card.Divider />
+    <Card.Header title="no divider" />
     <Card.Content>touch me</Card.Content>
     <Card.Header title="insert divider here" />
+    <Card.Divider />
     <Card.Content>Dont touch me</Card.Content>
   </Card>
 );

--- a/packages/wix-ui-codemod/src/wix-style-react/__testfixtures__/migrate-wsr8/components.input.js
+++ b/packages/wix-ui-codemod/src/wix-style-react/__testfixtures__/migrate-wsr8/components.input.js
@@ -18,7 +18,7 @@ import {
 
 export default class extends React.Component {
   render() {
-    const otherProps = { one: 1, two: 2, three: 3 };
+    const otherProps = { one: 1, two: 2, three: 3, withoutDivider: false };
     return (
       <Page upgrade dataHook="shipping-label-page">
         <Page.Header title="header title" showBackButton={true} />
@@ -56,11 +56,22 @@ export default class extends React.Component {
               </Tooltip>
 
               <Card>
-                <Card.Header title="Dont touch me" />
+                <Card.Header title="Add divider" />
               </Card>
 
               <Card>
-                <Card.Header withoutDivider title="Insert divider here" />
+                <Card.Header withoutDivider title="No divider" />
+              </Card>
+
+              <Card>
+                <Card.Header title="Add divider" />
+                <div>something</div>
+                <Card.Header title="Add divider" />
+                <Card.Header withoutDivider title="no divider" />
+                <Card.Header
+                  withoutDivider={withoutDivider}
+                  title="no divider"
+                />
               </Card>
             </Card.Content>
           </Card>

--- a/packages/wix-ui-codemod/src/wix-style-react/__testfixtures__/migrate-wsr8/components.output.js
+++ b/packages/wix-ui-codemod/src/wix-style-react/__testfixtures__/migrate-wsr8/components.output.js
@@ -18,15 +18,15 @@ import {
 
 export default class extends React.Component {
   render() {
-    const otherProps = { one: 1, two: 2, three: 3 };
+    const otherProps = { one: 1, two: 2, three: 3, withoutDivider: false };
     return (
       <Page dataHook="shipping-label-page">
         <Page.Header title="header title" showBackButton={true} />
         <Page.Content>
           <Card>
             <Card.Header />
-            <Card.Divider />
             <InputWithOptions />
+
             <Card.Content>
               <Tooltip
                 appendTo="window"
@@ -47,21 +47,31 @@ export default class extends React.Component {
 
           <Card>
             <Card.Header />
-            <Card.Divider />
             <Text>Awesome text #2</Text>
             <BarChart />
+
             <Card.Content>
               <Tooltip appendTo="window" content={<div>content</div>}>
                 <DropdownLayout />
               </Tooltip>
 
               <Card>
-                <Card.Header title="Dont touch me" />
+                <Card.Header title="Add divider" />
+                <Card.Divider />
               </Card>
 
               <Card>
-                <Card.Header title="Insert divider here" />
+                <Card.Header title="No divider" />
+              </Card>
+
+              <Card>
+                <Card.Header title="Add divider" />
                 <Card.Divider />
+                <div>something</div>
+                <Card.Header title="Add divider" />
+                <Card.Divider />
+                <Card.Header title="no divider" />
+                <Card.Header title="no divider" />
               </Card>
             </Card.Content>
           </Card>

--- a/packages/wix-ui-codemod/src/wix-style-react/migrate-wsr8.ts
+++ b/packages/wix-ui-codemod/src/wix-style-react/migrate-wsr8.ts
@@ -93,7 +93,7 @@ const transform: Transform = (file, api) => {
     ),
   );
 
-  // add <Card.Divider/> after <Card.Header withoutDivider />
+  // add <Card.Divider/> after <Card.Header />
   root
     .find(j.JSXOpeningElement, { name: { name: 'Card' } })
     .forEach(cardPath => {
@@ -107,7 +107,7 @@ const transform: Transform = (file, api) => {
           path.openingElement.selfClosing &&
           get(path, 'openingElement.attributes').filter(
             attribute => attribute.name.name === 'withoutDivider',
-          ).length === 1
+          ).length === 0
         ) {
           acc.push(index);
         }


### PR DESCRIPTION
this PR fixes `Card.Divider` insertion in `migrate-wsr8` codemod.

code like so:
```
<Card>
  <Card.Header title="Add divider" />
</Card>

<Card>
  <Card.Header withoutDivider title="No divider" />
</Card>
```

should be changed to:

```
<Card>
  <Card.Header title="Add divider" />
  <Card.Divider />
</Card>

<Card>
  <Card.Header title="No divider" />
</Card>
```

---

before this change there was a mistake, `<Card.Divider/>` would get inserted when `<Card.Header />` has `withoutDivider` but it should be opposite