### PR TITLE
fix(Tag): use `classes` instead of `style`

### DIFF
--- a/packages/wix-ui-core/src/components/tags-list/Tag.tsx
+++ b/packages/wix-ui-core/src/components/tags-list/Tag.tsx
@@ -111,7 +111,7 @@ export class FocusableTag extends React.Component<TagProps> {
         <input
           ref={this.inputRef}
           data-hook={DataHooks.TagInput}
-          className={style.tagInput}
+          className={classes.tagInput}
           type="checkbox"
           checked={checked}
           onChange={onChange}
@@ -155,7 +155,7 @@ export class FocusableTag extends React.Component<TagProps> {
 
     const rootElementProps = {
       onKeyDown: this.handleKeyDown,
-      className: classNames(style.tag, className),
+      className: classNames(classes.tag, className),
       ...wrapperStyles,
     };
 


### PR DESCRIPTION
this PR updates `Tag` component to use `classes` from new stylable API instead of `style`

it is because stylable has been upgraded to version 3 here https://github.com/wix/wix-ui/pull/1833