### PR TITLE
wix-storybook-utils: feat(LiveCodeExample): add button to prettify code

### DIFF
--- a/packages/wix-storybook-utils/src/CopyButton/index.tsx
+++ b/packages/wix-storybook-utils/src/CopyButton/index.tsx
@@ -5,6 +5,7 @@ import TextButton from '../TextButton';
 
 interface Props {
   source: string;
+  prefixIcon?: React.ReactNode;
 }
 
 interface State {
@@ -41,7 +42,7 @@ export class CopyButton extends React.Component<Props, State> {
 
   render() {
     return (
-      <TextButton onClick={this.onCopy}>
+      <TextButton onClick={this.onCopy} prefixIcon={this.props.prefixIcon}>
         {this.state.notification ? 'Copied to clipboard!' : 'Copy'}
       </TextButton>
     );

--- a/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.tsx
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.tsx
@@ -131,13 +131,13 @@ export default class LiveCodeExample extends React.Component<Props, State> {
     // key codes for vs code
     const shouldPrettify = [
       /* windows: shift + alt + f */
-      e.shiftKey && e.altKey && e.keyCode === 70,
+      e.shiftKey && e.altKey && e.key === 'F',
 
       /* osx: shift + option + f */
-      e.shiftKey && e.altKey && e.keyCode === 70,
+      e.shiftKey && e.altKey && e.key === 'F',
 
       /* unix: shift + ctrl + i */
-      e.shiftKey && e.ctrlKey && e.keyCode === 73,
+      e.shiftKey && e.ctrlKey && e.key === 'I',
     ].some(Boolean);
 
     if (shouldPrettify) {

--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -32,7 +32,7 @@
 .headerControl {
   display: flex;
   align-items: center;
-  margin-left: 20px;
+  margin-left: 15px;
 
   // Hide toggles on compact mode
   .compact & {


### PR DESCRIPTION
This PR adds a button to `LiveCodeExample` component which, once clicked, would format (prettify) code

non compact mode:
![2020-04-27-180002_screenshot](https://user-images.githubusercontent.com/4284659/80387286-23d56d00-88b1-11ea-8cc1-eb9ea9f53410.png)

compact mode:
![2020-04-27-180022_screenshot](https://user-images.githubusercontent.com/4284659/80455521-94719d80-8934-11ea-9785-6575f826f831.png)

button appears only after code has been edited

---

this will become automatically available for `code` and `example` section users