### PR TITLE
wix-storybook-utils: new component with code snippet support

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.tsx
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.tsx
@@ -307,12 +307,7 @@ export default class LiveCodeExample extends React.PureComponent<Props, State> {
               {this.renderError()}
             </div>
 
-            <Collapse
-              isOpened={isEditorOpened}
-              className={classnames(styles.editor, {
-                [styles.opened]: isEditorOpened,
-              })}
-            >
+            <Collapse isOpened={isEditorOpened} className={styles.editor}>
               <LiveEditor
                 onChange={this.debouncedOnCodeChange}
                 className={styles.editorView}

--- a/packages/wix-storybook-utils/src/LiveCodeExample/format-code.tsx
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/format-code.tsx
@@ -1,0 +1,26 @@
+import prettier from 'prettier/standalone';
+import babylonParser from 'prettier/parser-babylon';
+
+export const formatCode = (code: string) => {
+  try {
+    const filteredCode = code
+      .split('\n')
+      .filter(
+        line =>
+          !/\/(\*|\/)+.*((t|e)slint[-|:](dis|en)able|prettier-ignore)/.test(
+            line,
+          ),
+      )
+      .join('\n');
+
+    return prettier.format(filteredCode, {
+      parser: 'babel',
+      plugins: [babylonParser],
+      singleQuote: true,
+      trailingComma: 'all',
+    });
+  } catch (e) {
+    console.error('Unable to format code', e);
+    return code;
+  }
+};

--- a/packages/wix-storybook-utils/src/Playground/create-reducer.ts
+++ b/packages/wix-storybook-utils/src/Playground/create-reducer.ts
@@ -1,0 +1,4 @@
+export const createReducer = (initialState, actions = {}) => (
+  state = initialState,
+  action,
+) => (actions[action.type] || (() => state))(state, action);

--- a/packages/wix-storybook-utils/src/Playground/index.tsx
+++ b/packages/wix-storybook-utils/src/Playground/index.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import * as queryString from 'query-string';
+import UploadExportSmall from 'wix-ui-icons-common/UploadExportSmall';
+import DownloadImportSmall from 'wix-ui-icons-common/DownloadImportSmall';
+import Close from 'wix-ui-icons-common/system/Close';
+import Check from 'wix-ui-icons-common/Check';
+
+import { formatCode } from '../LiveCodeExample/format-code';
+import LiveCodeExample from '../LiveCodeExample';
+import TextButton from '../TextButton';
+import styles from './styles.scss';
+
+const snippetDatastoreUrl = `https://www.wix.com/_serverless/wix-style-react-playground/snippet/`;
+
+const loadSnippet = async snippetId => {
+  const response = await fetch(`${snippetDatastoreUrl}/${snippetId}`);
+  const code = await response.text();
+  return code && code.trim().length ? formatCode(code) : '';
+};
+
+const saveSnippet = async (code: string): Promise<string> => {
+  const response = await fetch(snippetDatastoreUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ data: code }),
+  });
+  const snippetId = await response.text();
+  return snippetId;
+};
+
+const LoadPrompt = ({ onClose, onConfirm }) => {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <div className={styles.loadPrompt}>
+      <div>
+        {'Snippet ID: '}
+        <input
+          className={styles.loadPromptInput}
+          placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          type="text"
+          value={value}
+          onChange={event => setValue(event.target.value)}
+        />
+      </div>
+      <button
+        className={styles.loadPromptButton}
+        onClick={() => onConfirm(value)}
+      >
+        <Check />
+      </button>
+      <button className={styles.closeButton} onClick={onClose}>
+        <Close />
+      </button>
+    </div>
+  );
+};
+
+const SaveSuccess = ({ snippetId, urlFormatter, onClose }) => (
+  <div className={styles.saveSuccess}>
+    Snippet saved! ID: {snippetId}
+    {urlFormatter && (
+      <a href={urlFormatter(snippetId)} target="_blank">
+        Use this link to open playground
+      </a>
+    )}
+    <button className={styles.closeButton} onClick={onClose}>
+      <Close />
+    </button>
+  </div>
+);
+
+const Playground = ({ initialCode = '', urlFormatter, ...rest }) => {
+  const [code, setCode] = React.useState({ raw: initialCode });
+  const [status, setStatus] = React.useState('idle');
+  const [snippetId, setSnippedId] = React.useState('');
+  let editorCode = '';
+
+  React.useEffect(() => {
+    const id =
+      (queryString.parse(window.location.search).snippet as string) || null;
+
+    if (id) {
+      setStatus('loading');
+      loadSnippet(snippetId);
+    }
+  }, []);
+
+  const save =
+    status === 'saveSuccess' ? (
+      <SaveSuccess
+        snippetId={snippetId}
+        urlFormatter={urlFormatter}
+        onClose={() => setStatus('idle')}
+      />
+    ) : (
+      <TextButton
+        onClick={() => {
+          saveSnippet(editorCode).then(id => {
+            setSnippedId(id);
+            setStatus('saveSuccess');
+          });
+        }}
+        disabled={status === 'loading'}
+        prefixIcon={<UploadExportSmall />}
+      >
+        Save
+      </TextButton>
+    );
+
+  const load =
+    status === 'loadPrompt' ? (
+      <LoadPrompt
+        onClose={() => setStatus('idle')}
+        onConfirm={snippetId => {
+          loadSnippet(snippetId).then(code => {
+            setStatus('idle');
+            setCode({ raw: code });
+            editorCode = code;
+          });
+        }}
+      />
+    ) : (
+      <TextButton
+        onClick={() => setStatus('loadPrompt')}
+        prefixIcon={<DownloadImportSmall />}
+      >
+        Load
+      </TextButton>
+    );
+
+  const memoizedLiveCodeExample = React.useMemo(
+    () => (
+      <LiveCodeExample
+        initialCode={code.raw}
+        onChange={code => (editorCode = code)}
+        {...rest}
+      />
+    ),
+    [code],
+  );
+
+  return (
+    <>
+      <div className={styles.header}>
+        {status !== 'loadPrompt' && save}
+        {status !== 'saveSuccess' && load}
+      </div>
+      {memoizedLiveCodeExample}
+    </>
+  );
+};
+
+export default Playground;

--- a/packages/wix-storybook-utils/src/Playground/styles.scss
+++ b/packages/wix-storybook-utils/src/Playground/styles.scss
@@ -61,8 +61,8 @@
 
 .previewWarning {
   @extend .error;
+  position: relative;
   white-space: normal;
-  min-height: 120px;
 
   > button {
     display: block;

--- a/packages/wix-storybook-utils/src/Playground/styles.scss
+++ b/packages/wix-storybook-utils/src/Playground/styles.scss
@@ -50,12 +50,17 @@
 
 .saveSuccess {
   display: grid;
-  grid-template-columns: auto 24px;
+  grid-auto-flow: column;
   gap: 12px;
   align-items: center;
 
-  & > div {
+  > div {
     align-self: center;
+  }
+
+  > a {
+    color: #3899ec;
+    text-decoration: none;
   }
 }
 

--- a/packages/wix-storybook-utils/src/Playground/styles.scss
+++ b/packages/wix-storybook-utils/src/Playground/styles.scss
@@ -1,0 +1,58 @@
+@import "../ui/typography.scss";
+
+.header {
+  margin-bottom: 12px;
+  text-align: right;
+  @include font(light);
+  font-size: 12px;
+}
+
+.loadPrompt {
+  display: inline-grid;
+  grid-template-columns: 400px auto auto;
+  gap: 10px;
+}
+
+.loadPromptButton {
+  width: 24px;
+  height: 24px;
+  background: #3899ec;
+  color: #fff;
+  border: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  justify-self: center;
+}
+
+.closeButton {
+  width: 24px;
+  height: 24px;
+  color: #000;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loadPromptInput {
+  width: 200px;
+  border-radius: 3px;
+  border: 1px solid #dfe5eb;
+  padding: 4px 5px;
+  font-size: 0.7rem;
+}
+
+.saveSuccess {
+  display: grid;
+  grid-template-columns: auto 24px;
+  gap: 12px;
+
+  & > div {
+    align-self: center;
+  }
+}

--- a/packages/wix-storybook-utils/src/Playground/styles.scss
+++ b/packages/wix-storybook-utils/src/Playground/styles.scss
@@ -1,4 +1,5 @@
 @import "../ui/typography.scss";
+@import "../LiveCodeExample/index.scss";
 
 .header {
   margin-bottom: 12px;
@@ -51,8 +52,20 @@
   display: grid;
   grid-template-columns: auto 24px;
   gap: 12px;
+  align-items: center;
 
   & > div {
     align-self: center;
+  }
+}
+
+.previewWarning {
+  @extend .error;
+  white-space: normal;
+  min-height: 120px;
+
+  > button {
+    display: block;
+    margin: 12px auto 0;
   }
 }

--- a/packages/wix-storybook-utils/src/TextButton/index.js
+++ b/packages/wix-storybook-utils/src/TextButton/index.js
@@ -1,18 +1,19 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import styles from './styles.scss';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import styles from "./styles.scss";
 
 export default class TextButton extends Component {
   static propTypes = {
     onClick: PropTypes.func,
     prefixIcon: PropTypes.node,
     children: PropTypes.node,
+    disabled: PropTypes.boolean
   };
 
   constructor(props) {
     super(props);
     this.state = {
-      isHover: false,
+      isHover: false
     };
 
     this.toggleHover = this.toggleHover.bind(this);
@@ -20,19 +21,19 @@ export default class TextButton extends Component {
 
   toggleHover() {
     this.setState({
-      isHover: !this.state.isHover,
+      isHover: !this.state.isHover
     });
   }
 
   render() {
-    const buttonColor = this.state.isHover ? '#4EB7F5' : '#3899EC';
+    const buttonColor = this.state.isHover ? "#4EB7F5" : "#3899EC";
 
     const style = {
       color: buttonColor,
-      outline: 'none',
-      border: 'none',
-      background: 'none',
-      cursor: 'pointer',
+      outline: "none",
+      border: "none",
+      background: "none",
+      cursor: "pointer"
     };
 
     return (
@@ -41,7 +42,8 @@ export default class TextButton extends Component {
         style={style}
         onMouseEnter={this.toggleHover}
         onMouseLeave={this.toggleHover}
-        onClick={this.props.onClick}
+        onClick={!this.props.disabled && this.props.onClick}
+        disabled={this.props.disabled}
       >
         {this.props.prefixIcon ? (
           <div className={styles.prefix}>{this.props.prefixIcon}</div>

--- a/packages/wix-storybook-utils/src/TextButton/index.js
+++ b/packages/wix-storybook-utils/src/TextButton/index.js
@@ -7,7 +7,7 @@ export default class TextButton extends Component {
     onClick: PropTypes.func,
     prefixIcon: PropTypes.node,
     children: PropTypes.node,
-    disabled: PropTypes.boolean
+    disabled: PropTypes.bool
   };
 
   constructor(props) {

--- a/packages/wix-storybook-utils/stories/index.js
+++ b/packages/wix-storybook-utils/stories/index.js
@@ -8,3 +8,4 @@ import "./sections/story-testkit-section.story";
 import "./sections/story-with-example-section.story";
 import "./empty-story";
 import "./components";
+import "./playground.story";

--- a/packages/wix-storybook-utils/stories/playground.story.js
+++ b/packages/wix-storybook-utils/stories/playground.story.js
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { header, importExample, description } from "../src/Sections";
+
+import Playground from "../src/Playground";
+
+export default {
+  category: "Components",
+  storyName: "Playground",
+  sections: [
+    header({ title: "Playground component" }),
+    importExample("import Playground from 'wix-storybook-utils/Playground'"),
+    description(<Playground initialCode="<div/>" />)
+  ]
+};

--- a/packages/wix-storybook-utils/stories/playground.story.js
+++ b/packages/wix-storybook-utils/stories/playground.story.js
@@ -3,12 +3,24 @@ import { header, importExample, description } from "../src/Sections";
 
 import Playground from "../src/Playground";
 
+const code = `
+class Component extends React.Component {
+  componentDidMount() {
+    console.log("hello");
+  }
+
+  render() {
+    return <div>hey</div>;
+  }
+}
+`;
+
 export default {
   category: "Components",
   storyName: "Playground",
   sections: [
     header({ title: "Playground component" }),
     importExample("import Playground from 'wix-storybook-utils/Playground'"),
-    description(<Playground initialCode="<div/>" />)
+    description(<Playground initialCode={code} />)
   ]
 };

--- a/packages/wix-storybook-utils/stories/playground.story.js
+++ b/packages/wix-storybook-utils/stories/playground.story.js
@@ -21,6 +21,6 @@ export default {
   sections: [
     header({ title: "Playground component" }),
     importExample("import Playground from 'wix-storybook-utils/Playground'"),
-    description(<Playground initialCode={code} />)
+    description(<Playground compact initiallyOpen initialCode={code} />)
   ]
 };

--- a/packages/wix-storybook-utils/stories/sections/code-examples.story.js
+++ b/packages/wix-storybook-utils/stories/sections/code-examples.story.js
@@ -1,17 +1,17 @@
-import { header, code } from '../../src/Sections';
+import { header, code } from "../../src/Sections";
 
-import importsExample from '!raw-loader!../components/examples/code-with-imports';
-import classWithArrowsExample from '!raw-loader!../components/examples/class-with-arrows';
+import importsExample from "!raw-loader!../components/examples/code-with-imports";
+import classWithArrowsExample from "!raw-loader!../components/examples/class-with-arrows";
 
 export default {
-  category: 'Sections',
-  storyName: 'Code Examples',
+  category: "Sections",
+  storyName: "Code Examples",
   sections: [
-    header({ title: 'Code examples story' }),
+    header({ title: "Code examples story" }),
     code(importsExample),
     code({
       source: classWithArrowsExample,
-      autoRender: false,
-    }),
-  ],
+      autoRender: false
+    })
+  ]
 };


### PR DESCRIPTION

This PR adds a new `<Playground/>` component.

it wraps existing `<LiveCodeExample/>` component with a feature which
allows to load and save code snippets

idle view, two new buttons at top right: save & load

![2020-04-29-184746_screenshot](https://user-images.githubusercontent.com/4284659/80616804-025bb900-8a4a-11ea-8ec9-53ae8847e6c2.png)

after clicking `load`, user is prompted to enter snippet ID

![2020-04-29-184805_screenshot](https://user-images.githubusercontent.com/4284659/80616823-05ef4000-8a4a-11ea-93d1-1d6a768571f2.png)

after clicking `save`. user is given snippet ID.

![2020-04-29-184816_screenshot](https://user-images.githubusercontent.com/4284659/80616849-0b4c8a80-8a4a-11ea-85c6-13a0a934ae7c.png)

---

in addition, this will also support snippet id through URL, so that link
sharing would be possible. this is WIP