### PR TITLE
wix-ui-core: move yoshi-stylable-dependencies to dependencies

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -104,7 +104,8 @@
     "type-zoo": "3.1.1",
     "wix-eventually": "^2.2.0",
     "wix-ui-icons-common": "^2.0.0",
-    "wix-ui-test-utils": "^1.0.151"
+    "wix-ui-test-utils": "^1.0.151",
+    "yoshi-stylable-dependencies": "^4.49.0"
   },
   "devDependencies": {
     "@applitools/eyes-storybook": "^3.3.1",
@@ -150,7 +151,6 @@
     "wix-ui-framework": "^3.3.1",
     "wix-ui-mocha-runner": "^1.0.0",
     "yoshi": "^4.55.1",
-    "yoshi-stylable-dependencies": "^4.49.0",
     "yoshi-style-dependencies": "^4.37.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
for any user of wix-ui-core `yoshi-stylable-dependencies` is a
dependency. thus, moving from depDep to dep installs it also for user
automatically