### PR TITLE
wix-ui-core(Autocomplete): add inputId to support screen reader

### DIFF
--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.spec.tsx
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.spec.tsx
@@ -25,6 +25,17 @@ describe('Autocomplete', () => {
     expect(driver.isContentElementExists()).toBeFalsy();
   });
 
+  it('should set id for options nodes when inputId is given', () => {
+    const id = 'test-input-id';
+    const index = 2;
+    const driver = createDriver(
+        <Autocomplete options={options} inputId={id} />
+    );
+    driver.click();
+    const optionElement: HTMLElement = driver.optionAt(index).getElement();
+    expect(optionElement.id).toEqual(`${id}-content_option-${index}`);
+  });
+
   it('should initialize autocomplete with value', () => {
     const driver = createDriver(
       <Autocomplete initialSelectedId={1} options={options} />,

--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
@@ -41,6 +41,8 @@ export interface AutocompleteProps {
   prefix?: React.ReactNode;
   /** Suffix */
   suffix?: React.ReactNode;
+  /** DOM id for underlying input */
+  inputId?: string;
   inputProps?: InputProps;
 }
 
@@ -126,6 +128,7 @@ export class Autocomplete extends React.PureComponent<
       onManualInput,
       disabled,
       className,
+      inputId,
     } = this.props;
     const inputProps = this._createInputProps();
     return (
@@ -144,6 +147,7 @@ export class Autocomplete extends React.PureComponent<
         onManualInput={onManualInput}
         options={options}
         inputProps={inputProps}
+        id={inputId ? inputId : null}
       />
     );
   }


### PR DESCRIPTION
In order to make aria-activedescendant not null in <InputWithOptions>, we must pass a dom id for the input, and then ids can be given to the options.
This will make the Autocomplete component accessible for NVDA screen reader on windows. 