### PR TITLE
wix-storybook-utils: fix(LiveCodeExample): do not add scroll for compact layout

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -218,6 +218,7 @@
 
   &.compactPreview {
     background: #f0f4f7;
+    overflow: visible;
   }
 
   &.compactPreview.darkPreview {


### PR DESCRIPTION
This PR removes `overflow: auto` from non-compact version of code editor.

this way examples of component like `<Search/>` in wix-style-react are
not impacted by `overflow` rule and can display popover content without
a scroll