### PR TITLE
wix-ui-core: support `data-` attributes on all components

### DIFF
--- a/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
@@ -20,6 +20,7 @@ import {
   convertToPartialAddress,
   trySetStreetNumberIfNotReceived,
 } from '../../clients/GoogleMaps/google2address/google2address';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 const first = require('lodash/first');
 const throttle = require('lodash/throttle');
@@ -514,7 +515,6 @@ export class AddressInput extends React.PureComponent<
     return (
       <InputWithOptions
         className={st(classes.root, states, className)}
-        data-hook={this.props['data-hook']}
         onContentMouseDown={this._handleContentMouseDown}
         onSelect={this._onSelect}
         options={options}
@@ -535,6 +535,7 @@ export class AddressInput extends React.PureComponent<
         emptyStateMessage={emptyStateMessage}
         emptyStateStyle={optionStyle}
         optionsContainerZIndex={optionsContainerZIndex}
+        {...filterDataProps(this.props)}
       />
     );
   }

--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
@@ -3,6 +3,7 @@ import { st, classes } from './Autocomplete.st.css';
 import { InputWithOptions } from '../input-with-options';
 import { Option, OptionFactory } from '../dropdown-option/OptionFactory';
 import { InputProps, AriaAutoCompleteType } from '../input';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 const createDivider = (value = null) =>
   OptionFactory.createDivider({ className: classes.divider, value });
@@ -134,7 +135,6 @@ export class Autocomplete extends React.PureComponent<
     return (
       <InputWithOptions
         className={st(classes.root, { disabled }, className)}
-        data-hook={this.props['data-hook']}
         onSelect={this._onSelect}
         initialSelectedIds={
           initialSelectedId || initialSelectedId === 0
@@ -148,6 +148,7 @@ export class Autocomplete extends React.PureComponent<
         options={options}
         inputProps={inputProps}
         id={inputId ? inputId : null}
+        {...filterDataProps(this.props)}
       />
     );
   }

--- a/packages/wix-ui-core/src/components/avatar/avatar.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.tsx
@@ -5,6 +5,7 @@ import { withFocusable } from '../../hocs/Focusable/FocusableHOC';
 import { st, classes } from './avatar.st.css';
 import { ContentType } from './types';
 import { nameToInitials } from './util';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 interface FocusableHOCProps {
   focusableOnFocus?(): void;
@@ -153,7 +154,6 @@ export class AvatarComponent extends React.Component<
       onClick,
       focusableOnFocus,
       focusableOnBlur,
-      'data-hook': dataHook,
     } = this.props;
     const contentType = this.getCurrentContentType();
     const focusProps = !!onClick && {
@@ -166,7 +166,6 @@ export class AvatarComponent extends React.Component<
 
     return (
       <div
-        data-hook={dataHook}
         data-content-type={contentType} // for testing
         data-img-loaded={this.state.imgLoaded} // for testing
         title={title || name}
@@ -181,6 +180,7 @@ export class AvatarComponent extends React.Component<
           },
           this.props.className,
         )}
+        {...filterDataProps(this.props)}
       >
         {this.getContent(contentType)}
       </div>

--- a/packages/wix-ui-core/src/components/captcha/Captcha.tsx
+++ b/packages/wix-ui-core/src/components/captcha/Captcha.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as Reaptcha from 'reaptcha';
 import { Size, CaptchaType, Theme, CaptchaLang } from './types';
 import { st, classes } from './Captcha.st.css';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface CaptchaProps {
   required?: boolean;
@@ -120,11 +121,11 @@ export class Captcha extends React.PureComponent<CaptchaProps, CaptchaState> {
           { loaded: this.state.rendered },
           this.props.className,
         )}
-        data-hook={this.props['data-hook']}
         data-captcha-type={captchaType}
         data-theme={theme}
         data-lang={lang}
         data-size={size}
+        {...filterDataProps(this.props)}
       >
         {!this.state.rendered && (
           <div className={classes.loaderWrapper}>{loader}</div>

--- a/packages/wix-ui-core/src/components/checkbox/Checkbox.tsx
+++ b/packages/wix-ui-core/src/components/checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { st, classes } from './Checkbox.st.css';
 import { noop } from '../../utils';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface OnChangeEvent extends React.ChangeEvent<HTMLInputElement> {
   checked: boolean;
@@ -68,8 +69,8 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
           },
           this.props.className,
         )}
-        data-hook={this.props['data-hook']}
         onMouseDown={this.handleMouseDown}
+        {...filterDataProps(this.props)}
       >
         <input
           type="checkbox"

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.private.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.private.uni.driver.ts
@@ -1,0 +1,8 @@
+import { UniDriver } from 'wix-ui-test-utils/unidriver';
+
+import { circularProgressBarUniDriverFactory as publicDriverFactory } from './CircularProgressBar.uni.driver';
+
+export const circularProgressBarUniDriverFactory = (base: UniDriver) => ({
+  ...publicDriverFactory(base),
+  getAttribute: base.attr,
+});

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.spec.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.spec.tsx
@@ -5,7 +5,7 @@ import { CircularProgressBar } from './';
 import { runTestkitExistsSuite } from '../../common/testkitTests';
 import { circularProgressBarTestkitFactory } from '../../testkit';
 import { circularProgressBarTestkitFactory as enzymeCircularProgressBarTestkitFactory } from '../../testkit/enzyme';
-import { circularProgressBarUniDriverFactory } from './CircularProgressBar.uni.driver';
+import { circularProgressBarUniDriverFactory } from './CircularProgressBar.private.uni.driver';
 
 const createCircularProgressBar = (props = {}) => {
   return <CircularProgressBar {...props} />;
@@ -25,16 +25,27 @@ describe('CircularProgressBar', () => {
   });
 
   describe('[async]', () => {
-    runTests(
-      testContainer.createUniRendererAsync(circularProgressBarUniDriverFactory),
+    const render = testContainer.createUniRendererAsync(
+      circularProgressBarUniDriverFactory,
     );
+
+    runTests(render);
+
+    it('should support data- attributes', async () => {
+      const driver = await render(
+        createCircularProgressBar({
+          'data-hello': 'world',
+          'hello-data': 'i should not exist!',
+        }),
+      );
+      expect(await driver.getAttribute('data-hello')).toBe('world');
+      expect(await driver.getAttribute('hello-data')).toBe(null);
+    });
   });
 
   function runTests(render) {
     it('should render', async () => {
-      const driver = await render(
-        createCircularProgressBar({ ...defaultProps }),
-      );
+      const driver = await render(createCircularProgressBar(defaultProps));
       expect(await driver.exists()).toBe(true);
     });
 
@@ -223,9 +234,7 @@ describe('CircularProgressBar', () => {
       });
 
       it('should not display percentages value by default', async () => {
-        const driver = await render(
-          createCircularProgressBar({ ...defaultProps }),
-        );
+        const driver = await render(createCircularProgressBar(defaultProps));
         expect(await driver.isPercentagesProgressDisplayed()).toBe(false);
       });
     });

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { st, classes } from './CircularProgressBar.st.css';
 import { Arc } from './Arc';
 import { dataHooks } from './constants';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface CircularProgressBarProps {
   /** represent the progress state in percentages (0 - no progress, 100 - progress completed) */
@@ -112,7 +113,7 @@ export const CircularProgressBar: React.FunctionComponent<CircularProgressBarPro
     <div
       className={st(classes.root, { error, success }, _props.className)}
       data-error={error}
-      data-hook={_props['data-hook']}
+      {...filterDataProps(props)}
     >
       {renderArcs(_props)}
       {showProgressIndication && (

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -4,6 +4,7 @@ import { Popover, Placement, PopoverProps } from '../popover';
 import { DropdownContent, IDOMid } from '../dropdown-content';
 import { Option } from '../dropdown-option';
 import { CLICK, HOVER, OPEN_TRIGGER_TYPE } from './constants';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export type DropdownProps = Pick<PopoverProps, 'fixed' | 'flip' | 'moveBy'> & {
   /** hook for testing purposes */
@@ -307,7 +308,6 @@ export class DropdownComponent extends React.PureComponent<
     return (
       <Popover
         className={st(classes.root, { 'content-visible': shown }, className)}
-        data-hook={this.props['data-hook']}
         placement={placement}
         shown={shown}
         showArrow={showArrow}
@@ -331,6 +331,7 @@ export class DropdownComponent extends React.PureComponent<
         moveBy={moveBy}
         role={role}
         zIndex={optionsContainerZIndex}
+        {...filterDataProps(this.props)}
       >
         <Popover.Element>{children}</Popover.Element>
         <Popover.Content>

--- a/packages/wix-ui-core/src/components/ellipsis-tooltip/EllipsisTooltip.tsx
+++ b/packages/wix-ui-core/src/components/ellipsis-tooltip/EllipsisTooltip.tsx
@@ -5,6 +5,7 @@ import * as classNames from 'classnames';
 import { classes as ellipsisClasses } from './Ellipsis.st.css';
 import { StateFullComponentWrap } from './StateFullComponentWrap';
 import { RuntimeStylesheet } from '@stylable/runtime';
+import { filterDataProps } from '../../utils/filter-data-props';
 const debounce = require('lodash/debounce');
 
 interface EllipsisTooltipProps {
@@ -132,10 +133,10 @@ export class EllipsisTooltip extends React.Component<
               )
             : ''
         }
-        data-hook={this.props['data-hook']}
         appendTo="window"
         content={<div>{this.textNode.textContent}</div>}
         showArrow
+        {...filterDataProps(this.props)}
       >
         {this._renderChildren()}
       </Tooltip>

--- a/packages/wix-ui-core/src/components/file-picker-button/FilePickerButton.tsx
+++ b/packages/wix-ui-core/src/components/file-picker-button/FilePickerButton.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { st, classes } from './FilePickerButton.st.css';
 import { DataHook } from './test/FilePickerButton.helpers';
 import { noop } from '../../utils';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface FilePickerButtonProps {
   id?: string;
@@ -59,7 +60,7 @@ export class FilePickerButton extends React.Component<
     return (
       <div
         className={st(classes.root, { required, disabled }, className)}
-        data-hook={this.props['data-hook']}
+        {...filterDataProps(this.props)}
       >
         <input
           id={id}

--- a/packages/wix-ui-core/src/components/icon-with-options/IconWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/icon-with-options/IconWithOptions.tsx
@@ -4,6 +4,7 @@ import { Dropdown } from '../dropdown';
 import { Placement } from '../popover';
 import { Option } from '../dropdown-option';
 import { HOVER, OPEN_TRIGGER_TYPE } from '../dropdown/constants';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface IconWithOptionsProps {
   /** The location to display the content */
@@ -45,14 +46,12 @@ export const IconWithOptions: React.FunctionComponent<IconWithOptionsProps> = pr
     iconUrl,
     fixedHeader,
     fixedFooter,
-    dataHook,
     className,
   } = props;
 
   return (
     <Dropdown
       className={st(classes.root, className)}
-      data-hook={dataHook}
       options={options}
       placement={placement}
       openTrigger={openTrigger}
@@ -64,6 +63,7 @@ export const IconWithOptions: React.FunctionComponent<IconWithOptionsProps> = pr
       fixedHeader={fixedHeader}
       onDeselect={onDeselect}
       initialSelectedIds={initialSelectedIds}
+      {...filterDataProps(props)}
     >
       <img src={iconUrl} tabIndex={5} />
     </Dropdown>

--- a/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
@@ -6,6 +6,7 @@ import { Option, OptionFactory } from '../dropdown-option';
 import { IDOMid } from '../dropdown-content';
 import { OPEN_TRIGGER_TYPE } from '../dropdown/constants';
 import { Input, InputProps } from '../input';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export const DataHooks = {
   input: 'input',
@@ -239,7 +240,6 @@ export class InputWithOptions extends React.PureComponent<
     return (
       <Dropdown
         className={st(classes.root, className)}
-        data-hook={this.props['data-hook']}
         placement={placement}
         openTrigger={openTrigger}
         disabled={inputProps.disabled}
@@ -265,6 +265,7 @@ export class InputWithOptions extends React.PureComponent<
         contentId={contentId}
         onExpandedChange={this.changeExpanded}
         optionsContainerZIndex={optionsContainerZIndex}
+        {...filterDataProps(this.props)}
       >
         <Input
           data-hook={DataHooks.input}

--- a/packages/wix-ui-core/src/components/input/Input.tsx
+++ b/packages/wix-ui-core/src/components/input/Input.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { st, classes } from './Input.st.css';
 import { Omit } from 'type-zoo';
 import * as classnames from 'classnames';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 type OmittedInputProps = 'value' | 'prefix';
 export type AriaAutoCompleteType = 'list' | 'none' | 'both';
@@ -70,8 +71,8 @@ export class Input extends React.Component<InputProps, InputState> {
           { disabled, error: !!error && !disabled, focus },
           className,
         )}
-        data-hook={this.props['data-hook']}
         style={inlineStyle}
+        {...filterDataProps(this.props)}
       >
         {prefix}
         <input

--- a/packages/wix-ui-core/src/components/label-with-options/LabelWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/label-with-options/LabelWithOptions.tsx
@@ -6,6 +6,7 @@ import { Option, OptionFactory } from '../dropdown-option';
 import { Label } from '../deprecated/label';
 import { CLICK } from '../dropdown/constants';
 import { noop } from '../../utils';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 const createDivider = (value = null) =>
   OptionFactory.createDivider({ className: classes.divider, value });
@@ -97,7 +98,6 @@ export class LabelWithOptions extends React.PureComponent<
           },
           className,
         )}
-        data-hook={this.props['data-hook']}
         multi={multi}
         placement="bottom-start"
         initialSelectedIds={initialSelectedIds}
@@ -109,6 +109,7 @@ export class LabelWithOptions extends React.PureComponent<
         onSelect={this.onSelect}
         onDeselect={this.onDeselect}
         disabled={disabled}
+        {...filterDataProps(this.props)}
       >
         <div className={classes.selection}>
           <Label

--- a/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/linear-progress-bar/LinearProgressBar.tsx
@@ -5,6 +5,7 @@ import {
   ProgressBarDataKeys,
   ProgressBarAriaKeys,
 } from './DataHooks';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface LinearProgressBarProps {
   /** represent the progress state in percentages (min || 0 - no progress, max || 100 - progress completed) */
@@ -132,7 +133,7 @@ export const LinearProgressBar: React.FunctionComponent<LinearProgressBarProps> 
       data-error={error}
       role="progressbar"
       className={st(classes.root, { error, success }, className)}
-      data-hook={props['data-hook']}
+      {...filterDataProps(props)}
     >
       {renderBarSection(_props.value)}
 

--- a/packages/wix-ui-core/src/components/menu-item/menu-item.tsx
+++ b/packages/wix-ui-core/src/components/menu-item/menu-item.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { st, classes } from './menu-item.st.css';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface MenuItemProps {
   /** hook for testing purposes */
@@ -39,11 +40,11 @@ export const MenuItem: React.FunctionComponent<MenuItemProps> = props => {
         className,
       )}
       {...rest}
-      data-hook={props['data-hook']}
       data-selected={selected}
       data-highlighted={highlighted}
       data-disabled={disabled}
       onClick={disabled ? () => null : onSelect}
+      {...filterDataProps(props)}
     />
   );
 };

--- a/packages/wix-ui-core/src/components/nav-stepper/NavStepper.tsx
+++ b/packages/wix-ui-core/src/components/nav-stepper/NavStepper.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { st, classes } from './NavStepper.st.css';
 import { Stepper } from '../stepper';
 import { NavStep, ExternalNavStepProps } from './NavStep';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export { ExternalNavStepProps } from './NavStep';
 
@@ -24,7 +25,7 @@ export class NavStepper extends React.PureComponent<NavStepperProps> {
     return (
       <nav
         className={st(classes.root, className)}
-        data-hook={this.props['data-hook']}
+        {...filterDataProps(this.props)}
       >
         <Stepper activeStep={activeStep}>
           {({ getStepProps }) => (

--- a/packages/wix-ui-core/src/components/pagination/Pagination.tsx
+++ b/packages/wix-ui-core/src/components/pagination/Pagination.tsx
@@ -3,6 +3,7 @@ import { PageStrip } from './PageStrip';
 import { st, classes } from './Pagination.st.css';
 import { measureAndSetRootMinWidth } from './root-min-width';
 import { PaginationDataHooks } from './DataHooks';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 const upperCaseFirst = (str: string): string =>
   str[0].toUpperCase() + str.slice(1);
@@ -381,7 +382,7 @@ export class Pagination extends React.Component<
         onMouseLeave={this.props.onMouseLeave}
         style={inlineStyle || { width }}
         className={st(classes.root, styleStates, this.props.className)}
-        data-hook={this.props['data-hook']}
+        {...filterDataProps(this.props)}
       >
         {showFirstLastNavButtons && this.renderNavButton(ButtonType.First)}
         {showPreviousLabel

--- a/packages/wix-ui-core/src/components/popover-next/popover-next.tsx
+++ b/packages/wix-ui-core/src/components/popover-next/popover-next.tsx
@@ -12,6 +12,7 @@ import CSSTransition from './components/CSSTransition';
 import Loader from './components/Loader';
 import Portal from './components/Portal';
 import { PopperProps } from './components/Popper';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 import { style, classes } from '../popover/Popover.st.css';
 
@@ -433,12 +434,12 @@ export class PopoverNext extends React.Component<
             <div
               ref={this.clickOutsideRef}
               style={inlineStyles}
-              data-hook={this.props['data-hook']}
               data-content-hook={this.contentHook}
               className={style(classes.root, { fluid }, className)}
               onMouseEnter={onMouseEnter}
               onMouseLeave={onMouseLeave}
               id={id}
+              {...filterDataProps(this.props)}
             >
               <Reference innerRef={r => (this.targetRef = r)}>
                 {({ ref }) => (

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -6,6 +6,7 @@ import { CSSTransition } from 'react-transition-group';
 import { Portal } from 'react-portal';
 import { st, classes } from './Popover.st.css';
 import { createModifiers } from './modifiers';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 import {
   buildChildrenObject,
@@ -515,12 +516,12 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
         >
           <div
             style={style}
-            data-hook={this.props['data-hook']}
             data-content-hook={this.contentHook}
             className={st(classes.root, { fluid }, this.props.className)}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             id={id}
+            {...filterDataProps(this.props)}
           >
             <Reference innerRef={r => (this.targetRef = r)}>
               {({ ref }) => (

--- a/packages/wix-ui-core/src/components/radio-button/RadioButton.tsx
+++ b/packages/wix-ui-core/src/components/radio-button/RadioButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { st, classes } from './RadioButton.st.css';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 const noop = () => null;
 
@@ -110,11 +111,11 @@ export class RadioButton extends React.Component<
           },
           className,
         )}
-        data-hook={this.props['data-hook']}
         onChange={this.handleInputChange}
         onClick={this.handleClick}
         role="radio"
         aria-checked={checked ? checked : false}
+        {...filterDataProps(this.props)}
       >
         <input
           type="radio"

--- a/packages/wix-ui-core/src/components/slider/Slider.tsx
+++ b/packages/wix-ui-core/src/components/slider/Slider.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Ticks } from './Ticks';
 import { Thumb, getThumbSize } from './Thumb';
 import { st, classes } from './Slider.st.css';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 const noop = () => {};
 
@@ -513,7 +514,6 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
           },
           className,
         )}
-        data-hook={this.props['data-hook']}
         onMouseDown={this.handleMouseDown}
         onTouchStart={this.handleMouseDown}
         onKeyDown={this.handleKeyDown}
@@ -532,6 +532,7 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
         aria-valuemax={max}
         aria-valuenow={value}
         aria-label={this.props['aria-label']}
+        {...filterDataProps(this.props)}
       >
         <div className={classes.inner} style={this.getInnerDims()}>
           <div

--- a/packages/wix-ui-core/src/components/tags-list/TagsList.tsx
+++ b/packages/wix-ui-core/src/components/tags-list/TagsList.tsx
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 
 import { DataHooks, DisplayNames } from './TagsList.helpers';
 import { st, classes } from './TagsList.st.css';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 import { noop } from '../../utils';
 export interface TagsListProps {
@@ -21,6 +22,7 @@ export const TagsList: React.FunctionComponent<TagsListProps> = ({
 } = {}) => (
   <div
     className={st(classes.root, className)}
+    {...filterDataProps(rest)}
     data-hook={DataHooks.TagsList}
     onChange={onChange}
     role="group"

--- a/packages/wix-ui-core/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/wix-ui-core/src/components/thumbnail/Thumbnail.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { st, classes } from './Thumbnail.st.css';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface ThumbnailProps {
   /** hook for testing purposes */
@@ -24,8 +25,8 @@ export const Thumbnail: React.FunctionComponent<ThumbnailProps> = props => {
   return (
     <div
       className={st(classes.root, { selected, disabled }, className)}
-      data-hook={props['data-hook']}
       onClick={onClick}
+      {...filterDataProps(props)}
     >
       {children}
 

--- a/packages/wix-ui-core/src/components/time-picker/TimePicker.tsx
+++ b/packages/wix-ui-core/src/components/time-picker/TimePicker.tsx
@@ -12,6 +12,7 @@ import {
   parseTime,
   isValidTime,
 } from './utils';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export type TimePickerProps = Pick<
   InputProps,
@@ -487,7 +488,6 @@ export class TimePicker extends React.PureComponent<
       <Input
         {...passThroughProps}
         className={st(classes.root, { focus }, className)}
-        data-hook={this.props['data-hook']}
         ref={ref => (this._inputRef = ref)}
         type="text"
         value={value}
@@ -501,6 +501,7 @@ export class TimePicker extends React.PureComponent<
         onClick={this._onClick}
         onDragStart={e => e.stopPropagation()}
         style={inlineStyle}
+        {...filterDataProps(this.props)}
       />
     );
   }

--- a/packages/wix-ui-core/src/components/toggle-switch/ToggleSwitch.tsx
+++ b/packages/wix-ui-core/src/components/toggle-switch/ToggleSwitch.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { st, classes } from './ToggleSwitch.st.css';
 import { dataHooks } from './constants';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 // The only reason this exists is that Santa currently doesn't support boolean and number types
 // in the style panel, and some of the styling options have to live in the layout panel,
@@ -71,8 +72,8 @@ export class ToggleSwitch extends React.PureComponent<
           },
           className,
         )}
-        data-hook={this.props['data-hook']}
         style={inlineStyles.root}
+        {...filterDataProps(this.props)}
       >
         <div
           data-hook={dataHooks.track}

--- a/packages/wix-ui-core/src/components/tooltip-next/tooltip-next.tsx
+++ b/packages/wix-ui-core/src/components/tooltip-next/tooltip-next.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { st, classes } from '../tooltip/Tooltip.st.css';
 import { PopoverNext } from '../popover-next';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 import { Placement, AppendTo } from '../popover';
 
@@ -154,9 +155,6 @@ export class TooltipNext extends React.PureComponent<
     return (
       <PopoverNext
         className={st(classes.root, this.props.className)}
-        {...(this.props['data-hook']
-          ? { 'data-hook': this.props['data-hook'] }
-          : {})}
         placement={placement}
         shown={disabled ? false : this.state.isOpen}
         showArrow={showArrow}
@@ -177,6 +175,7 @@ export class TooltipNext extends React.PureComponent<
         zIndex={zIndex}
         minWidth={minWidth}
         maxWidth={maxWidth}
+        {...filterDataProps(this.props)}
       >
         <PopoverNext.Element>{this._renderElement()}</PopoverNext.Element>
         <PopoverNext.Content>{content}</PopoverNext.Content>

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { st, classes } from './Tooltip.st.css';
 import { Popover, Placement, AppendTo } from '../popover';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 export interface Point {
   x: number;
@@ -152,7 +153,6 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     return (
       <Popover
         className={st(classes.root, className)}
-        data-hook={this.props['data-hook']}
         placement={placement}
         shown={disabled ? false : this.state.isOpen}
         showArrow={showArrow}
@@ -173,6 +173,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
         zIndex={zIndex}
         minWidth={minWidth}
         maxWidth={maxWidth}
+        {...filterDataProps(this.props)}
       >
         <Popover.Element>{this._renderElement()}</Popover.Element>
         <Popover.Content>{content}</Popover.Content>

--- a/packages/wix-ui-core/src/components/video/Video.tsx
+++ b/packages/wix-ui-core/src/components/video/Video.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { playerComponents, playerVerifiers } from './players';
 import { PlayerNameType, ICommonProps, IConfig } from './types';
 import { st, classes } from './Video.st.css';
+import { filterDataProps } from '../../utils/filter-data-props';
 
 const noop = () => null;
 const DEFAULT_PLAYER = 'playable';
@@ -92,7 +93,7 @@ export class Video extends React.Component<IVideoProps, IVideoState> {
         id={id}
         style={{ width, height }}
         className={st(classes.root, className)}
-        data-hook={this.props['data-hook']}
+        {...filterDataProps(this.props)}
       >
         <Player {...playerProps} ref={playerRef} />
       </div>

--- a/packages/wix-ui-core/src/utils/filter-data-props.spec.ts
+++ b/packages/wix-ui-core/src/utils/filter-data-props.spec.ts
@@ -1,7 +1,7 @@
 import { filterDataProps } from './filter-data-props';
 
 describe('filterDataProps', () => {
-  it('should be defined', () => {
+  it('should return only data-* props', () => {
     const assert = {
       'data-hook': 'hook!',
       hello: null,

--- a/packages/wix-ui-core/src/utils/filter-data-props.spec.ts
+++ b/packages/wix-ui-core/src/utils/filter-data-props.spec.ts
@@ -1,0 +1,25 @@
+import { filterDataProps } from './filter-data-props';
+
+describe('filterDataProps', () => {
+  it('should be defined', () => {
+    const assert = {
+      'data-hook': 'hook!',
+      hello: null,
+      0: 0,
+      'dat-a': '',
+      ' data-': '',
+      'data-': '',
+      data: { hook: '' },
+      'data-data': 'hello!',
+      'data-string-that-sets-some-size-for-example': 'yo',
+    };
+
+    const expectation = {
+      'data-hook': 'hook!',
+      'data-data': 'hello!',
+      'data-string-that-sets-some-size-for-example': 'yo',
+    };
+
+    expect(filterDataProps(assert)).toEqual(expectation);
+  });
+});

--- a/packages/wix-ui-core/src/utils/filter-data-props.ts
+++ b/packages/wix-ui-core/src/utils/filter-data-props.ts
@@ -1,0 +1,10 @@
+const acceptedPropsStart = 'data-';
+
+export const filterDataProps = (props: object) =>
+  Object.fromEntries(
+    Object.entries(props).filter(
+      ([key]) =>
+        key.length > acceptedPropsStart.length &&
+        key.startsWith(acceptedPropsStart),
+    ),
+  );

--- a/packages/wix-ui-core/src/utils/filter-data-props.ts
+++ b/packages/wix-ui-core/src/utils/filter-data-props.ts
@@ -4,6 +4,7 @@ export const filterDataProps = (props: object) => {
   const output = {};
   for (const key in props) {
     if (
+      props.hasOwnProperty(key) &&
       key.length > acceptedPropsStart.length &&
       key.startsWith(acceptedPropsStart)
     ) {

--- a/packages/wix-ui-core/src/utils/filter-data-props.ts
+++ b/packages/wix-ui-core/src/utils/filter-data-props.ts
@@ -1,10 +1,14 @@
 const acceptedPropsStart = 'data-';
 
-export const filterDataProps = (props: object) =>
-  Object.fromEntries(
-    Object.entries(props).filter(
-      ([key]) =>
-        key.length > acceptedPropsStart.length &&
-        key.startsWith(acceptedPropsStart),
-    ),
-  );
+export const filterDataProps = (props: object) => {
+  const output = {};
+  for (const key in props) {
+    if (
+      key.length > acceptedPropsStart.length &&
+      key.startsWith(acceptedPropsStart)
+    ) {
+      output[key] = props[key];
+    }
+  }
+  return output;
+};


### PR DESCRIPTION
This PR relates to stylable v3 upgrade in https://github.com/wix/wix-style-react/pull/5445

in previously used Stylable v1 a side effect of its usage was that all
`data-` props were applied to components. With Stylable v3 it's no
longer the case, thus if we want to use `data-` attributes, we need to
set them explicitly.

in wix-style-react some of components, for example `CircularProgressBar`
internally uses `CircularProgressBar` from wix-ui-core. It also tries to
set attributes like `data-size` and use them while testing.

with Stylable v3 change `data-size` is no longer available, thus
creating an issue of missing attribute.

This PR adds `filterDataProps` function and applies it to all
components. This function takes all props, filters only those that start
with `data-` and spreads them on component.

In essence, we get the behaviour of `data-` same as we had in Stylable
v1 but witout the need to explicitly set each `data-` attribute by hand

@shlomitc fyi