### PR TITLE
wix-ui-core: fix(Popover): pass `clickOutsideRef`

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -515,6 +515,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
           excludeClass={excludeClass ? excludeClass : classes.popover}
         >
           <div
+            ref={this.clickOutsideRef}
             style={style}
             data-content-hook={this.contentHook}
             className={st(classes.root, { fluid }, this.props.className)}


### PR DESCRIPTION
otherwise it will always be `{ current: null }` and `clickOutside`
component will not work properly.

This is already done in `popover-next`, exactly the same way: https://github.com/wix/wix-ui/blob/master/packages/wix-ui-core/src/components/popover-next/popover-next.tsx#L435

required for https://github.com/wix/wix-style-react/pull/5445