### PR TITLE
lock "react-docgen-typescript" dependency

### DIFF
--- a/packages/react-autodocs-utils/package.json
+++ b/packages/react-autodocs-utils/package.json
@@ -43,7 +43,7 @@
     "@babel/types": "^7.5.5",
     "doctrine": "^3.0.0",
     "react-docgen": "^4.1.1",
-    "react-docgen-typescript": "^1.12.5",
+    "react-docgen-typescript": "1.18.0",
     "recast": "0.13.0",
     "typescript": "^2.7.1"
   }


### PR DESCRIPTION
We're getting this error message:
```
Module build failed (from ../node_modules/wix-storybook-utils/loader.js):
Error: Unable to parse component in path "...wix-style-react/src/Popover", reason: TypeError: Cannot read property 'props' of undefined
    at error (/Users/talza/WebstormProjects/wix-style-react/node_modules/react-autodocs-utils/src/gather-all/index.js:23:41)
    at /Users/talza/WebstormProjects/wix-style-react/node_modules/react-autodocs-utils/src/gather-all/index.js:31:51
 @ ./stories/index.js 201:0-42
 @ ./.storybook/config.js
 @ multi ./node_modules/@storybook/core/dist/server/common/polyfills.js ./node_modules/@storybook/core/dist/server/preview/globals.js ./.storybook/config.js (webpack)-hot-middleware/client.js?
```

After investigation, it seems like this dependency was updated [15 hours ago](https://www.npmjs.com/package/react-docgen-typescript). I haven't found a changelog in the repository. I wasn't sure which PR was breaking us. I've installed this dependency with version `1.18.0` in `wix-style-react` and storybook works as expected. 
