### PR TITLE
Dropdown - Mark onDeselect prop as optional

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -26,7 +26,7 @@ export type DropdownProps = Pick<PopoverProps, 'fixed' | 'flip' | 'moveBy'> & {
   /** Handler for when a mouse down event occurs on an option */
   onContentMouseDown?(e: React.MouseEvent): void;
   /** Handler for when an option is deselected */
-  onDeselect(option: Option | null): void;
+  onDeselect?(option: Option | null): void;
   /** Handler for when dropdown becomes opened/closed */
   onExpandedChange?(isExpanded: boolean): void;
   /** initial selected option ids */


### PR DESCRIPTION
Mark `onDeselect` prop as optional because it is only relevant for multiselection flow and not for all flows.