### PR TITLE
fix(avatar): dont load image when imgProps.src is undefined

### DIFF
--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -31,6 +31,11 @@ describe('Avatar', () => {
       expect((await driver.getContentType()) === 'image').toBeTruthy(),
     );
 
+  let imageSetUrlSpy;
+  beforeEach(() => {
+    imageSetUrlSpy = jest.fn();
+  });
+
   // TODO: remove this hack
   // this is to ensure `onload` is called,
   // because during yoshi3 migration it stopped working
@@ -38,6 +43,7 @@ describe('Avatar', () => {
   beforeAll(() => {
     Object.defineProperty((global as any).Image.prototype, 'src', {
       set(src) {
+        imageSetUrlSpy?.(src);
         if (src === TEST_IMG_URL) {
           setTimeout(() => this.onload());
         }
@@ -201,6 +207,20 @@ describe('Avatar', () => {
         );
         expect(imgElem.getAttribute('src')).toBe(TEST_IMG_URL);
       });
+    });
+
+    it('should load image with url', async () => {
+      const driver = await createDriver(
+        <Avatar imgProps={{ src: TEST_IMG_URL }} />,
+      );
+      expect(imageSetUrlSpy).toHaveBeenCalledWith(TEST_IMG_URL);
+    });
+
+    it('should not load image with undefined url', async () => {
+      const driver = await createDriver(
+        <Avatar imgProps={{ src: undefined }} />,
+      );
+      expect(imageSetUrlSpy).not.toHaveBeenCalled();
     });
 
     // This test is skipped because it either passes with jsdom and fails with browser (mocha-runner), or in it's current form

--- a/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.spec.tsx
@@ -43,7 +43,7 @@ describe('Avatar', () => {
   beforeAll(() => {
     Object.defineProperty((global as any).Image.prototype, 'src', {
       set(src) {
-        imageSetUrlSpy?.(src);
+        imageSetUrlSpy && imageSetUrlSpy(src);
         if (src === TEST_IMG_URL) {
           setTimeout(() => this.onload());
         }

--- a/packages/wix-ui-core/src/components/avatar/avatar.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.tsx
@@ -66,7 +66,7 @@ export class AvatarComponent extends React.Component<
   getRequestedContentType(props): ContentType {
     const { name, text, placeholder, imgProps } = props;
 
-    return imgProps?.src
+    return imgProps && imgProps.src
       ? 'image'
       : text || name
       ? 'text'

--- a/packages/wix-ui-core/src/components/avatar/avatar.tsx
+++ b/packages/wix-ui-core/src/components/avatar/avatar.tsx
@@ -66,7 +66,7 @@ export class AvatarComponent extends React.Component<
   getRequestedContentType(props): ContentType {
     const { name, text, placeholder, imgProps } = props;
 
-    return imgProps
+    return imgProps?.src
       ? 'image'
       : text || name
       ? 'text'
@@ -121,7 +121,8 @@ export class AvatarComponent extends React.Component<
   loadImg = () => {
     this.img = new Image();
     this.img.onload = () => {
-      this.setState({ imgLoaded: true });
+      // don't set state after unmount
+      this.img && this.setState({ imgLoaded: true });
     };
     this.img.src = this.props.imgProps.src;
   };


### PR DESCRIPTION
when rendering an Avatar like so `<Avatar imgProps={{ src: undefined }} />` a request for `/udefined` is issued. This is what you see in this ticket for examples: https://jira.wixpress.com/browse/WOS2-3211.

fix: not setting undefined as Image src