### PR TITLE
refactor radio button in order to support a11y

### DIFF
--- a/packages/wix-ui-core/src/components/radio-button/RadioButton.tsx
+++ b/packages/wix-ui-core/src/components/radio-button/RadioButton.tsx
@@ -117,27 +117,27 @@ export class RadioButton extends React.Component<
         aria-checked={checked ? checked : false}
         {...filterDataProps(this.props)}
       >
-        <input
-          type="radio"
-          className={classes.hiddenRadio}
-          disabled={disabled}
-          required={required}
-          onFocus={this.onFocus}
-          onBlur={this.onInputBlur}
-          checked={checked}
-          value={value}
-          name={name}
-          tabIndex={tabIndex}
-          onChange={() => null}
-          onKeyDown={this.handleInputKeyDown}
-          ref={radio => (this.radioRef = radio)}
-          aria-label={this.props['aria-label']}
-        />
         <span
           className={classes.icon}
           onMouseEnter={this.onHover}
           onMouseLeave={onIconBlur}
         >
+          <input
+            type="radio"
+            className={classes.hiddenRadio}
+            disabled={disabled}
+            required={required}
+            onFocus={this.onFocus}
+            onBlur={this.onInputBlur}
+            checked={checked}
+            value={value}
+            name={name}
+            tabIndex={tabIndex}
+            onChange={() => null}
+            onKeyDown={this.handleInputKeyDown}
+            ref={radio => (this.radioRef = radio)}
+            aria-label={this.props['aria-label']}
+          />
           {checked ? checkedIcon : uncheckedIcon}
         </span>
         <span className={classes.label}>{label}</span>


### PR DESCRIPTION
In order to enable a11y focus ring in radion button - https://jira.wixpress.com/browse/EE-24790
I'm passing `checkedIcon` to `RadioButton` with 'wixSdkShowFocusOnSibling' class, in order to enable the focus ring of the radio button. 
please review it :) @argshook 