### PR TITLE
<NavStep /> - add className prop which is sent by <NavStepper />

### DIFF
--- a/packages/wix-ui-core/src/components/nav-stepper/NavStep.tsx
+++ b/packages/wix-ui-core/src/components/nav-stepper/NavStep.tsx
@@ -5,12 +5,20 @@ import { StepProps } from '../stepper';
 export type ExternalNavStepProps = Partial<StepProps> & {
   disabled?: boolean;
   children: React.ReactNode;
+  className?: string;
 };
 export type NavStepProps = StepProps & ExternalNavStepProps;
 
 export class NavStep extends React.PureComponent<NavStepProps> {
   render() {
-    const { active, disabled, visited, children, ...rest } = this.props;
+    const {
+      active,
+      disabled,
+      visited,
+      children,
+      className,
+      ...rest
+    } = this.props;
     const ariaProps: any = {};
     active && (ariaProps['aria-current'] = 'page');
 
@@ -18,7 +26,7 @@ export class NavStep extends React.PureComponent<NavStepProps> {
       <li
         {...ariaProps}
         {...rest}
-        className={st(classes.root, { active, visited, disabled })}
+        className={st(classes.root, { active, visited, disabled }, className)}
       >
         {children}
       </li>


### PR DESCRIPTION
This PR fixes a bug that started with migration to Stalable 3 in the `<NavStepper>` component.

`<NavStepper>` is sending a `className` props (https://github.com/wix/wix-ui/blob/master/packages/wix-ui-core/src/components/nav-stepper/NavStepper.tsx#L37-L38) to its child which is a `<NavStep>`. However, currently the `NavStep` component ignores this prop and does not render it in the `<li>` element.

So I added this prop which is sent to the call to `st(...)`.


I tested locally with `wix-ui-premium-purchase` which extends `NavStepper`. Current behavior is that the child elements have no styling. This change fixes the issue.