### PR TITLE
Unified Testkit Documentation

### DIFF
--- a/packages/wix-storybook-utils/src/AutoTestkit/index.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/index.tsx
@@ -6,6 +6,7 @@ import { Metadata } from '../typings/metadata';
 import { StoryConfig } from '../typings/story-config';
 
 import { DriverDocumentation } from './driver-documentation';
+import { UnifiedTestkitDocumentation } from './unified-testkit-documentation';
 import { isUnidriver, determineTestkit } from './determine-testkit';
 import Markdown from '../Markdown';
 
@@ -30,9 +31,45 @@ const unidriverFirst = drivers => {
   return [...unidrivers, ...others];
 };
 
+const createDriverDocumentation = (metadata, storyConfig) => {
+  return unidriverFirst(metadata.drivers)
+    .filter(({ error }) => !error)
+    .map(({ file, descriptor }) => {
+      const { type, title } = determineTestkit({
+        fileName: file,
+        displayName: metadata.displayName,
+      });
+
+      return (
+        <DriverDocumentation
+          key={file}
+          dataHook="auto-testkit-driver"
+          unidriver={isUnidriver(file)}
+          descriptor={descriptor}
+          metadata={metadata}
+          title={title}
+          testkitConfig={get(storyConfig, `config.testkits.${type}`)}
+        />
+      );
+    });
+};
+
+const createUnifiedTestkitDocumentation = metadata => {
+  return (
+    <UnifiedTestkitDocumentation
+      dataHook="auto-unified-testkit"
+      metadata={metadata}
+    />
+  );
+};
+
 export const AutoTestkit = ({ metadata, storyConfig }: Props) => (
   <div className="markdown-body">
-    <h1 data-hook="auto-testkit-heading">{metadata.displayName} Testkits</h1>
+    {storyConfig.config.unifiedTestkit ? (
+      <h1 data-hook="auto-testkit-heading">{metadata.displayName} Testkit</h1>
+    ) : (
+      <h1 data-hook="auto-testkit-heading">{metadata.displayName} Testkits</h1>
+    )}
 
     {get(storyConfig, 'config.testkitsWarning') && (
       <div data-hook="auto-testkit-warning">
@@ -40,25 +77,8 @@ export const AutoTestkit = ({ metadata, storyConfig }: Props) => (
       </div>
     )}
 
-    {unidriverFirst(metadata.drivers)
-      .filter(({ error }) => !error)
-      .map(({ file, descriptor }) => {
-        const { type, title } = determineTestkit({
-          fileName: file,
-          displayName: metadata.displayName,
-        });
-
-        return (
-          <DriverDocumentation
-            key={file}
-            dataHook="auto-testkit-driver"
-            unidriver={isUnidriver(file)}
-            descriptor={descriptor}
-            metadata={metadata}
-            title={title}
-            testkitConfig={get(storyConfig, `config.testkits.${type}`)}
-          />
-        );
-      })}
+    {storyConfig.config.unifiedTestkit
+      ? createUnifiedTestkitDocumentation(metadata)
+      : createDriverDocumentation(metadata, storyConfig)}
   </div>
 );

--- a/packages/wix-storybook-utils/src/AutoTestkit/method-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/method-documentation.tsx
@@ -22,15 +22,77 @@ const FunctionArguments = ({ args }) => {
   );
 };
 
+const paramDocumentation = ({ title, name, description }, index) => {
+  return (
+    <li key={index}>
+      <b>{title}</b> {name}
+      {description && ` - ${description}`}
+    </li>
+  );
+};
+
+const returnsDocumentation = ({ title, type, description }, index) => {
+  if (!type) {
+    return;
+  }
+
+  const returnType = type.applications
+    .map(app => {
+      if (app.name) {
+        return app.name;
+      }
+
+      if (app.type === 'UnionType') {
+        return app.elements
+          .map(element => {
+            if (element.value) {
+              return `'${element.value}'`;
+            }
+            return element.name;
+          })
+          .join(' | ');
+      }
+    })
+    .join(', ');
+
+  return (
+    <li key={index}>
+      <b>{title}</b> {`Promise<${returnType}>`}
+      {description && ` - ${description}`}
+    </li>
+  );
+};
+
 export const MethodDocumentation = ({ unit }) => {
-  const { args, name } = unit;
+  const { args, name, tags } = unit;
   return (
     <tr className="auto-testkit-field">
       <td>
         <span data-hook="auto-testkit-function-name">{name}</span>(
         <FunctionArguments args={args} />)
       </td>
-      <td data-hook="auto-testkit-function-description">{unit.description}</td>
+      <td data-hook="auto-testkit-function-description">
+        <div>{unit.description}</div>
+        {tags && tags.length > 0 && (
+          <ul>
+            {tags.map((tag, index) => {
+              if (tag.title === 'param') {
+                return paramDocumentation(tag, index);
+              }
+
+              if (tag.title === 'returns') {
+                return returnsDocumentation(tag, index);
+              }
+
+              return (
+                <li key={index}>
+                  <b>{tag.title}</b> {tag.description}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </td>
     </tr>
   );
 };

--- a/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+
+import { Code } from '../Sections/views/import-example/Code';
+import { makeImportCode } from './make-import-code';
+import { Metadata } from '../typings/metadata';
+import { FieldsDocumentation } from './fields-documentation';
+import { Descriptor } from './typings';
+
+interface Props {
+  dataHook?: string;
+  metadata: Metadata;
+}
+
+const extractNested = (descriptors: Descriptor[]) =>
+  descriptors.reduce(
+    (acc, descriptor) => {
+      descriptor.type === 'object'
+        ? acc.nested.push(descriptor)
+        : acc.flat.push(descriptor);
+      return acc;
+    },
+    { flat: [], nested: [] },
+  );
+
+export const UnifiedTestkitDocumentation: React.FunctionComponent<Props> = ({
+  dataHook,
+  metadata,
+}) => {
+  const driver = metadata.drivers.filter(d =>
+    d.file.endsWith('.uni.driver.js'),
+  );
+
+  let error;
+  if (driver.length === 0) {
+    error = 'No unified testkit found!';
+  } else {
+    error = driver[0].error;
+  }
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+  const { flat } = extractNested(driver[0].descriptor);
+  return (
+    <div data-hook={dataHook}>
+      <h2 data-hook="auto-testkit-driver-name">Import</h2>
+
+      <Code dataHook="auto-testkit-driver-import-code">
+        {makeImportCode({
+          testkit: {
+            template: `import { <%= component.displayName %>Testkit } from 'wix-style-react/dist/testkit';
+import { <%= component.displayName %>Testkit } from 'wix-style-react/dist/testkit/enzyme';
+import { <%= component.displayName %>Testkit } from 'wix-style-react/dist/testkit/protractor';
+import { <%= component.displayName %>Testkit } from 'wix-style-react/dist/testkit/puppeteer';`,
+          },
+          metadata,
+        })}
+      </Code>
+
+      <h2 data-hook="auto-testkit-descriptor-title">API</h2>
+
+      <div data-hook="auto-testkit-driver-descriptor">
+        <FieldsDocumentation units={flat} />
+      </div>
+    </div>
+  );
+};

--- a/packages/wix-storybook-utils/src/typings/config.ts
+++ b/packages/wix-storybook-utils/src/typings/config.ts
@@ -5,6 +5,7 @@ export interface Config {
   issueURL?: string;
   testkits?: Testkits;
   testkitsWarning?: string;
+  unifiedTestkit?: boolean;
 }
 
 export interface Testkits {


### PR DESCRIPTION
A testkit story section dedicated to unidriver.
- New import statements
- Deeper parsing of comments jsDoc
For example:
```
  /**
   * Gets the title by item index
   * @param {number} idx Item index
   * @returns {Promise<string>} Title at item index
   */
```

---
## The final page:
![image](https://user-images.githubusercontent.com/35173937/90870505-58aa8a00-e3a2-11ea-9908-4c56613ade76.png)
