### PR TITLE
wix-storybook-utils/import example

### DIFF
--- a/packages/wix-storybook-utils/src/Sections/index.ts
+++ b/packages/wix-storybook-utils/src/Sections/index.ts
@@ -53,7 +53,7 @@ export const header = (config: Partial<HeaderSection>): HeaderSection =>
   });
 
 export const importExample = (
-  config: string | Partial<ImportExampleSection>,
+  config?: string | Partial<ImportExampleSection>,
 ): ImportExampleSection =>
   base({
     type: SectionType.ImportExample,

--- a/packages/wix-storybook-utils/src/Sections/views/import-example/index.test.tsx
+++ b/packages/wix-storybook-utils/src/Sections/views/import-example/index.test.tsx
@@ -3,6 +3,11 @@ import { mount } from 'enzyme';
 import { importExample as view } from './';
 import { importExample as builder } from '../../index';
 
+const storyConfigFixture = {
+  metadata: { displayName: 'Component', props: {} },
+  config: {},
+};
+
 describe('importExample view', () => {
   it('should pass trimmed and ticked source to markdown', () => {
     const source = `
@@ -13,7 +18,27 @@ describe('importExample view', () => {
 \"hello\"
 \`\`\``;
 
-    const rendered = mount(view(builder({ source })));
+    const rendered = mount(view(builder({ source }), storyConfigFixture));
     expect(rendered.find('Markdown').prop('source')).toEqual(assertion);
+  });
+
+  describe('given no arguments', () => {
+    it('should construct importExample from StoryConfig', () => {
+      const assertion = `\`\`\`js
+import Component from 'library/Component';
+\`\`\``;
+
+      const rendered = mount(
+        view(builder(), {
+          ...storyConfigFixture,
+          config: {
+            importFormat:
+              "import %componentName from '%moduleName/%componentName';",
+            moduleName: 'library',
+          },
+        }),
+      );
+      expect(rendered.find('Markdown').prop('source')).toEqual(assertion);
+    });
   });
 });

--- a/packages/wix-storybook-utils/src/Sections/views/import-example/index.tsx
+++ b/packages/wix-storybook-utils/src/Sections/views/import-example/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { StoryConfig } from '../../typings/story-config';
+import { StoryConfig } from '../../../typings/story-config';
 import { ImportExampleSection } from '../../../typings/story-section';
 import { importString } from '../../../StoryPage/import-string';
 

--- a/packages/wix-storybook-utils/src/Sections/views/import-example/index.tsx
+++ b/packages/wix-storybook-utils/src/Sections/views/import-example/index.tsx
@@ -1,15 +1,25 @@
 import * as React from 'react';
 
+import { StoryConfig } from '../../typings/story-config';
 import { ImportExampleSection } from '../../../typings/story-section';
+import { importString } from '../../../StoryPage/import-string';
 
 import { Code } from './Code';
 
-export const importExample: (a: ImportExampleSection) => React.ReactNode = ({
-  dataHook = '',
-  source,
-}) =>
+export const importExample: (
+  a: ImportExampleSection,
+  b: StoryConfig,
+) => React.ReactNode = ({ dataHook = '', source }, storyConfig) =>
   typeof source === 'string' ? (
     <Code data-hook={dataHook}>{source.trim()}</Code>
   ) : (
-    source
+    source || (
+      <Code data-hook={dataHook}>
+        {importString({
+          metadata: storyConfig.metadata,
+          config: storyConfig.config,
+          exampleImport: storyConfig.exampleImport,
+        })}
+      </Code>
+    )
   );


### PR DESCRIPTION
fix cases when `importExample()` is used without any arguments and does not show any output

using `importExample()` without arguments is a valid case, it should
generate code example with data from `.storybook/webpack.config.js`