### PR TITLE
[wix-ui-icons-common] Set @types/node to a fixed version

### DIFF
--- a/packages/wix-ui-icons-common/package.json
+++ b/packages/wix-ui-icons-common/package.json
@@ -43,7 +43,7 @@
     "@storybook/addon-options": "^5.3.19",
     "@storybook/react": "^5.3.19",
     "@types/jest": "^22.2.3",
-    "@types/node": "^12.0.0",
+    "@types/node": "12.12.47",
     "@types/react": "~16.4.2",
     "babel-loader": "^8.1.0",
     "babel-preset-yoshi": "^4.78.0",


### PR DESCRIPTION
Master currently fails with errors relating to @types/node mismatch with typescript version.
http://pullrequest-tc.dev.wixpress.com/viewLog.html?buildId=11439970&buildTypeId=FedInfra_Package_WixUiIconsCommon&tab=buildLog&branch_FedInfra_Package=1910%2Fhead&_focus=3683

This PR fixes that issue.