### PR TITLE
wix-ui-test-utils: feat(puppeteer): support `wrapper` argument

### DIFF
--- a/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
+++ b/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
@@ -23,11 +23,19 @@ export function puppeteerUniTestkitFactoryCreator<T extends BaseUniDriver>(
     options: { dataHook: string }
   ) => T
 ) {
-  return async (obj: { dataHook: string; page: Page }) => {
-    const base = pupUniDriver({
-      page: obj.page,
-      selector: `[data-hook='${obj.dataHook}']`,
-    });
+  return async (obj: {
+    dataHook: string;
+    page: Page;
+    wrapper?: ElementHandle;
+  }) => {
+    const {wrapper: element} = obj; // destructuring `wrapper` so that type inference works well
+    const selector = `[data-hook='${obj.dataHook}']`;
+    const page = obj.page;
+
+    const base = element
+      ? pupUniDriver(async () => ({element, page, selector}))
+      : pupUniDriver({page, selector});
+
     const body = pupUniDriver({page: obj.page, selector: 'body'});
     return driverFactory(base, body, {dataHook: obj.dataHook});
   };

--- a/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
+++ b/packages/wix-ui-test-utils/src/puppeteer/puppeteer.ts
@@ -3,16 +3,21 @@ import {BaseUniDriver} from '../base-driver';
 import {UniDriver} from '@unidriver/core';
 import {pupUniDriver} from '@unidriver/puppeteer';
 
+interface DriverFactoryOptions {
+  dataHook: string;
+}
+
+/** @DEPRECATED please use `puppeteerUniTestkitFactoryCreator` */
 export function puppeteerTestkitFactoryCreator<T>(
   driverFactory: (
     e: ElementHandle | null,
     page: Page,
-    options: { dataHook: string }
+    options: DriverFactoryOptions
   ) => T
 ) {
   return async (obj: { dataHook: string; page: Page }) =>
     driverFactory(await obj.page.$(`[data-hook='${obj.dataHook}']`), obj.page, {
-      dataHook: obj.dataHook,
+      dataHook: obj.dataHook
     });
 }
 
@@ -20,13 +25,13 @@ export function puppeteerUniTestkitFactoryCreator<T extends BaseUniDriver>(
   driverFactory: (
     base: UniDriver,
     body: UniDriver,
-    options: { dataHook: string }
+    options: DriverFactoryOptions
   ) => T
 ) {
   return async (obj: {
     dataHook: string;
     page: Page;
-    wrapper?: ElementHandle;
+    wrapper?: ElementHandle | null;
   }) => {
     const {wrapper: element} = obj; // destructuring `wrapper` so that type inference works well
     const selector = `[data-hook='${obj.dataHook}']`;

--- a/packages/wix-ui-test-utils/test/puppeteer.spec.ts
+++ b/packages/wix-ui-test-utils/test/puppeteer.spec.ts
@@ -1,0 +1,72 @@
+import * as puppeteer from 'puppeteer';
+import {UniDriver} from '@unidriver/core';
+
+import {puppeteerUniTestkitFactoryCreator as makeTestkit} from '../src/puppeteer';
+import {baseUniDriverFactory} from '../src/base-driver';
+
+const mockTestkit = (base: UniDriver) => {
+  return {
+    ...baseUniDriverFactory(base),
+    text: () => base.text()
+  };
+};
+
+describe('puppeteerUniTestkitFactoryCreator', () => {
+  let browser: puppeteer.Browser, page: puppeteer.Page;
+  beforeAll(async () => {
+    browser = await puppeteer.launch();
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    browser.close();
+  });
+
+  it('should return testkit factory which returns testkit instance', async () => {
+    page.setContent(`
+<html>
+<body>
+<div data-hook="dataHook">content</div>
+</body>
+</html>
+                    `);
+    const testkitFactory = makeTestkit(mockTestkit);
+    const testkit = await testkitFactory({
+      page,
+      dataHook: 'dataHook'
+    });
+
+    expect(testkit).toEqual(
+      expect.objectContaining({
+        exists: expect.any(Function),
+        element: expect.any(Function),
+        click: expect.any(Function)
+      })
+    );
+
+    expect(await testkit.text()).toEqual('content');
+  });
+
+  describe('`wrappper`', () => {
+    it('should return testkit factory which returns testkit instance', async () => {
+      page.setContent(`
+<html>
+<body>
+  <div data-hook="dataHook">fake content</div>
+  <div data-hook="wrapper">
+    <div data-hook="dataHook">real content</div>
+  </div>
+</body>
+</html>
+                    `);
+      const testkitFactory = makeTestkit(mockTestkit);
+      const testkit = await testkitFactory({
+        page,
+        dataHook: 'dataHook',
+        wrapper: await page.$('[data-hook="wrapper"]')
+      });
+
+      expect((await testkit.text()).trim()).toEqual('real content');
+    });
+  });
+});

--- a/packages/wix-ui-test-utils/test/puppeteer.spec.ts
+++ b/packages/wix-ui-test-utils/test/puppeteer.spec.ts
@@ -11,6 +11,23 @@ const mockTestkit = (base: UniDriver) => {
   };
 };
 
+const mockHtml = `
+<html>
+  <body>
+    <div data-hook="dataHook">content</div>
+  </body>
+</html>
+`.trim();
+
+const mockNestedHtml = `
+  <html>
+    <body>
+      <div data-hook="dataHook">fake content</div>
+      <div data-hook="wrapper"><div data-hook="dataHook">real content</div></div>
+    </body>
+  </html>
+`.trim();
+
 describe('puppeteerUniTestkitFactoryCreator', () => {
   let browser: puppeteer.Browser, page: puppeteer.Page;
   beforeAll(async () => {
@@ -23,13 +40,7 @@ describe('puppeteerUniTestkitFactoryCreator', () => {
   });
 
   it('should return testkit factory which returns testkit instance', async () => {
-    page.setContent(`
-<html>
-<body>
-<div data-hook="dataHook">content</div>
-</body>
-</html>
-                    `);
+    page.setContent(mockHtml);
     const testkitFactory = makeTestkit(mockTestkit);
     const testkit = await testkitFactory({
       page,
@@ -49,16 +60,7 @@ describe('puppeteerUniTestkitFactoryCreator', () => {
 
   describe('`wrappper`', () => {
     it('should return testkit factory which returns testkit instance', async () => {
-      page.setContent(`
-<html>
-<body>
-  <div data-hook="dataHook">fake content</div>
-  <div data-hook="wrapper">
-    <div data-hook="dataHook">real content</div>
-  </div>
-</body>
-</html>
-                    `);
+      page.setContent(mockNestedHtml);
       const testkitFactory = makeTestkit(mockTestkit);
       const testkit = await testkitFactory({
         page,


### PR DESCRIPTION
This PR adds support for `wrapper` argument in `puppeteerUniTestkitFactoryCreator`.
Similar to how `wrapper` is supported in `enzymeUniTestkitFactoryCreator`

puppeteer unidriver usage before this PR:

```js
import { puppeteer } from 'puppeteer'
import { ButtonTestkit } from 'wix-style-react/dist/testkit/puppeteer'

const browser = await puppeteer.launch();
const page = await browser.newPage();

it('should work', async () => {
  const buttonTestkit = ButtonTestkit({
    page,
    dataHook: 'my-button'
  })
  expect(await buttonTestkit.exists()).toBe(true)
  // what if `page` has more than one button with `my-button` datahook? We can't test them easily :(
})
```

this would look for `[data-hook="my-button"]` and would use first occurence of element for the testkit.

if `page` has multiple elements with `my-button` data-hook, there's no way to test the rest of elements, user is always getting testkit for
first one (because unidriver internally does `page.$(selector)`)

---

this PR adds `wrapper` argument. continuing on example from above

```js
import { puppeteer } from 'puppeteer'
import { ButtonTestkit } from 'wix-style-react/dist/testkit/puppeteer'

const browser = await puppeteer.launch();
const page = await browser.newPage();

it('should work', async () => {
  const buttonTestkit = ButtonTestkit({
    page,
    dataHook: 'my-button',
    wrapper: await page.$('.some-wrapper-selector')
  })
  // testkit of a first `my-button` occurence within `.some-wrapper-selector`
  expect(await buttonTestkit.exists()).toBe(true)
})
```

