### PR TITLE
(StorybookUtils): LiveCodeExample - set overflow to visible

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/index.scss
@@ -209,7 +209,6 @@
 
 .preview {
   padding: 30px 20px;
-  overflow: auto;
   @include checkerboard(20px, #eff2f6, #fff);
 
   &.darkPreview {

--- a/packages/wix-storybook-utils/src/Playground/index.tsx
+++ b/packages/wix-storybook-utils/src/Playground/index.tsx
@@ -102,6 +102,7 @@ const Playground: React.FunctionComponent<Props> = ({
             editorCode: formatted,
           });
         }}
+        previewProps={{className: styles.overflowPreview}}
         {...rest}
       />
     ),

--- a/packages/wix-storybook-utils/src/Playground/styles.scss
+++ b/packages/wix-storybook-utils/src/Playground/styles.scss
@@ -93,3 +93,7 @@
     border-color: #32536a;
   }
 }
+
+.overflowPreview {
+  overflow: auto;
+}


### PR DESCRIPTION
@argshook @shlomitc 

before:
![Screen Shot 2020-10-26 at 9 19 57](https://user-images.githubusercontent.com/7388217/97144123-9219c000-176c-11eb-88b1-dddaa6fced8e.png)


after:
![Screen Shot 2020-10-26 at 9 19 41](https://user-images.githubusercontent.com/7388217/97144128-947c1a00-176c-11eb-83f3-071fda42b69b.png)
