### PR TITLE
[wix-ui-core] `<Arc/>` - fix visual state when value is 0

### DIFF
--- a/packages/wix-ui-core/src/components/circular-progress-bar/Arc.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/Arc.tsx
@@ -23,7 +23,7 @@ export const Arc: React.FunctionComponent<ArcProps> = (props: ArcProps) => {
 
   return (
     <svg className={className} width={size} height={size} viewBox={viewBox}>
-      <path d={d} strokeWidth={strokeWidth} />
+      <path d={d} strokeWidth={value !== 0 ? strokeWidth : 0} />
     </svg>
   );
 };

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
@@ -74,13 +74,15 @@ const renderArcs = (props: CircularProgressBarProps) => {
         strokeWidth={4}
         size={normalizedSize}
       />
-      <Arc
-        data-hook={dataHooks.progressArcForeground}
-        value={normalizedValue}
-        className={classes.foreArc}
-        strokeWidth={4}
-        size={normalizedSize}
-      />
+      {normalizedValue && (
+        <Arc
+          data-hook={dataHooks.progressArcForeground}
+          value={normalizedValue}
+          className={classes.foreArc}
+          strokeWidth={4}
+          size={normalizedSize}
+        />
+      )}
     </div>
   );
 };

--- a/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
+++ b/packages/wix-ui-core/src/components/circular-progress-bar/CircularProgressBar.tsx
@@ -74,15 +74,13 @@ const renderArcs = (props: CircularProgressBarProps) => {
         strokeWidth={4}
         size={normalizedSize}
       />
-      {normalizedValue && (
-        <Arc
-          data-hook={dataHooks.progressArcForeground}
-          value={normalizedValue}
-          className={classes.foreArc}
-          strokeWidth={4}
-          size={normalizedSize}
-        />
-      )}
+      <Arc
+        data-hook={dataHooks.progressArcForeground}
+        value={normalizedValue}
+        className={classes.foreArc}
+        strokeWidth={4}
+        size={normalizedSize}
+      />
     </div>
   );
 };


### PR DESCRIPTION
When Arc is passed the value 0,
it shows a dot 4px wide because of the 4px stroke of the arc.
I expect the arc to be blank with value 0.

For example, if you use CircularProgressBar with value 0
Before:
![image](https://user-images.githubusercontent.com/4023882/97600904-3a9c7e00-1a12-11eb-8171-7c5042db47a3.png)

After:
![image](https://user-images.githubusercontent.com/4023882/97600956-4a1bc700-1a12-11eb-93fb-82a95461cc17.png)
