### PR TITLE
[wix-ui-core] <Autocomplete /> fix option select

### DIFF
--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.e2e.ts
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.e2e.ts
@@ -50,4 +50,18 @@ describe('Autocomplete', () => {
 
     expect(driver.getText()).toBe('value1');
   });
+
+  eyes.it('should choose one of filtered autocomplete items', async () => {
+    const driver = autocompleteTestkitFactory({ dataHook });
+    await waitForVisibilityOf(driver.element(), 'Cannot find Autocomplete');
+
+    driver.focus();
+    driver.enterText('value');
+    driver
+      .dropdownContent()
+      .optionAt(1)
+      .click();
+
+    expect(driver.getText()).toBe('value1');
+  });
 });

--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.e2e.ts
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.e2e.ts
@@ -55,13 +55,13 @@ describe('Autocomplete', () => {
     const driver = autocompleteTestkitFactory({ dataHook });
     await waitForVisibilityOf(driver.element(), 'Cannot find Autocomplete');
 
-    driver.focus();
-    driver.enterText('value');
-    driver
+    await driver.focus();
+    await driver.enterText('value');
+    await driver
       .dropdownContent()
-      .optionAt(1)
+      .optionAt(0)
       .click();
 
-    expect(driver.getText()).toBe('value1');
+    expect(await driver.getText()).toBe('value0');
   });
 });

--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
@@ -120,6 +120,10 @@ export class Autocomplete extends React.PureComponent<
     }
   };
 
+  _handleContentMouseDown(e) {
+    e.preventDefault(); // Prevent input blur
+  }
+
   render() {
     const {
       options,
@@ -148,6 +152,7 @@ export class Autocomplete extends React.PureComponent<
         options={options}
         inputProps={inputProps}
         id={inputId ? inputId : null}
+        onContentMouseDown={this._handleContentMouseDown}
         {...filterDataProps(this.props)}
       />
     );

--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
@@ -121,7 +121,7 @@ export class Autocomplete extends React.PureComponent<
   };
 
   _handleContentMouseDown(e) {
-    // e.preventDefault(); // Prevent input blur
+    e.preventDefault(); // Prevent input blur from stopping click event
   }
 
   render() {

--- a/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/wix-ui-core/src/components/autocomplete/Autocomplete.tsx
@@ -121,7 +121,7 @@ export class Autocomplete extends React.PureComponent<
   };
 
   _handleContentMouseDown(e) {
-    e.preventDefault(); // Prevent input blur
+    // e.preventDefault(); // Prevent input blur
   }
 
   render() {

--- a/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
@@ -210,7 +210,6 @@ export class InputWithOptions extends React.PureComponent<
     const { onContentMouseDown } = this.props;
     this.isEditing = false;
     onContentMouseDown && onContentMouseDown(e);
-    e.preventDefault(); // Prevent input blur
   };
 
   render() {

--- a/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
+++ b/packages/wix-ui-core/src/components/input-with-options/InputWithOptions.tsx
@@ -210,6 +210,7 @@ export class InputWithOptions extends React.PureComponent<
     const { onContentMouseDown } = this.props;
     this.isEditing = false;
     onContentMouseDown && onContentMouseDown(e);
+    e.preventDefault(); // Prevent input blur
   };
 
   render() {


### PR DESCRIPTION
Can be reproduced in storybook.
Try type value and select some of the dropdown items(for example "value1"). It will not be selected
AR:
![Screen Recording 2020-11-03 at 16 16 03 (1)](https://user-images.githubusercontent.com/19636412/98005105-6005ff00-1df9-11eb-81ee-a955db13af7a.gif)

ER:
![Screen Recording 2020-11-03 at 17 11 07](https://user-images.githubusercontent.com/19636412/98004249-5cbe4380-1df8-11eb-90ab-6212637572f9.gif)



the same fix was done for addressInput component https://github.com/wix/wix-ui/commit/624c5ee6271837e8074eb0991db6c8dbe91e306d