### PR TITLE
wix-ui-core(Dropdown): do not invoke `onSelect` after Tab

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
@@ -143,6 +143,29 @@ describe('Dropdown', () => {
       expect(onSelect).toHaveBeenCalledTimes(1);
     });
 
+    it('should not be called after Tab key press', () => {
+      const onSelect = jest.fn();
+      const dropdown = (
+        <Dropdown
+          placement="top"
+          initialSelectedIds={[]}
+          onDeselect={() => null}
+          onSelect={onSelect}
+          onInitialSelectedOptionsSet={() => null}
+          openTrigger={CLICK}
+          options={options}
+        >
+          <input data-hook="open-dropdown-input" />
+        </Dropdown>
+      );
+
+      const driver = createDriver(dropdown);
+
+      driver.click();
+      Simulate.keyDown(driver.getTargetElement(), { key: 'Tab' });
+      expect(onSelect).toHaveBeenCalledTimes(0);
+    });
+
     it('should be called when re-selecting a selected item when opted-in', () => {
       const onSelect = jest.fn();
       const driver = createDriver(

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -213,11 +213,7 @@ export class DropdownComponent extends React.PureComponent<
           }
           break;
         }
-        case 'Tab': {
-          this.onKeyboardSelect();
-          this.close();
-          break;
-        }
+        case 'Tab':
         case 'Escape': {
           this.close();
           break;


### PR DESCRIPTION
described in https://jira.wixpress.com/browse/SER-1158