### PR TITLE
[wix-ui-test-utils] Change type of wrapper component to match @testing-library/react

### DIFF
--- a/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
+++ b/packages/wix-ui-test-utils/src/vanilla/vanilla.tsx
@@ -10,13 +10,13 @@ import {UniDriver} from '@unidriver/core';
 import {jsdomReactUniDriver} from '@unidriver/jsdom-react';
 
 export interface TestkitArgs {
-  wrapper: HTMLElement;
+  wrapper: Element;
   dataHook: string;
 }
 
 export type TestkitOutputRegular<T extends BaseDriver> = (data: {
   element: Element | undefined;
-  wrapper: HTMLElement;
+  wrapper: Element;
   eventTrigger: typeof Simulate;
   dataHook: string;
 }) => T;
@@ -28,7 +28,7 @@ export type TestkitOutputUni<T extends BaseUniDriver> = (
 ) => T;
 
 const getElement = ({wrapper, dataHook}: TestkitArgs) => {
-  const domInstance = ReactDom.findDOMNode(wrapper) as HTMLElement;
+  const domInstance = ReactDom.findDOMNode(wrapper) as Element;
 
   if (domInstance) {
     const dataHookOnInstance = domInstance.attributes.getNamedItem(


### PR DESCRIPTION
Error reported here:
https://wix.slack.com/archives/C39FTGUBZ/p1605785920376600

in `wix-style-react`
`wix-ui-test-utils` is used in combination with `@testing-library/react` to create component Testkits

Since https://github.com/testing-library/react-testing-library/releases/tag/v11.2.1,
`@testing-library/react` returns `Element` type instead of `HTMLElement` type.

This PR updates the types to match the new changes