### PR TITLE
wix-ui-core: disable browser field optimization + index.st.css fix

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -5,10 +5,6 @@
   "version": "3.0.0",
   "main": "./dist/src/index.js",
   "module": "./dist/es/src/index.js",
-  "browser": {
-    "./index.st.css": "./index.es.st.css",
-    "./index.js": "./dist/es/src/index.js"
-  },
   "stylable": {
     "manifest": "./dist/standalone/src/stylable.manifest.json"
   },

--- a/packages/wix-ui-core/scripts/patch-stylable/tasks/transpile-patch-export.js
+++ b/packages/wix-ui-core/scripts/patch-stylable/tasks/transpile-patch-export.js
@@ -10,7 +10,7 @@ const appendFile = util.promisify(fs.appendFileSync);
  */
 const addPopoverInternalParts = ({entryFile}) => {
   const popoverInternalParts = (isEs) => `
-  :import {-st-from: "./dist/${isEs ? 'es/' : ''}src/components/popover/Popover.st.css";-st-named: arrow as Popover_arrow, withArrow as  as Popover_withArrow, popoverContent as Popover_popoverContent;}
+  :import {-st-from: "./dist/${isEs ? 'es/' : ''}src/components/popover/Popover.st.css";-st-named: arrow as Popover_arrow, withArrow as Popover_withArrow, popoverContent as Popover_popoverContent;}
   .root .Popover_arrow {}
   .root .Popover_withArrow {}
   .root .Popover_popoverContent {}


### PR DESCRIPTION
1. minor fix for the index file creation
2. preventing the browser field from taking action. it seems like there are many mixed imports from other libraries. For example, importing `wix-ui-core/button` from the `js` file but `wix-ui-core/index.st.css` from the `.st.css` file. This causes a mixture of CommonJS and ESM.

Since this is a breaking change, I'm reverting.
Probably the right way to go is to create an entry per-component which can be easily opted-in