### PR TITLE
add isRtl to scope in LiveCodeExample

### DIFF
--- a/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.tsx
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.tsx
@@ -268,7 +268,7 @@ export default class LiveCodeExample extends React.PureComponent<Props, State> {
 
         <LiveProvider
           code={code.trim()}
-          scope={this.props.scope}
+          scope={{ ...this.props.scope, isRtl }}
           noInline={!autoRender}
           transformCode={this.transformCode}
         >

--- a/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.tsx
+++ b/packages/wix-storybook-utils/src/LiveCodeExample/LiveCodeExample.tsx
@@ -268,7 +268,7 @@ export default class LiveCodeExample extends React.PureComponent<Props, State> {
 
         <LiveProvider
           code={code.trim()}
-          scope={{ ...this.props.scope, isRtl }}
+          scope={{ isRtl, ...this.props.scope }}
           noInline={!autoRender}
           transformCode={this.transformCode}
         >


### PR DESCRIPTION
So that the content in the live example can use this if needed