### PR TITLE
Use correct string format for Stylable for ButtonStyle

### DIFF
--- a/packages/wix-ui-core/src/components/deprecated/button/ButtonStyle.st.css
+++ b/packages/wix-ui-core/src/components/deprecated/button/ButtonStyle.st.css
@@ -13,7 +13,7 @@
     padding: 0px 23px;
     borderRadius: 0;
 
-    fontFamily: "HelveticaNeueW01-45Ligh", "HelveticaNeueW02-45Ligh", "HelveticaNeueW10-45Ligh", "Helvetica Neue", "Helvetica", "Arial", "メイリオ; meiryo", "ヒラギノ角ゴ pro w3", "hiragino kaku gothic pro", "sans-serif";
+    fontFamily: '"HelveticaNeueW01-45Ligh", "HelveticaNeueW02-45Ligh", "HelveticaNeueW10-45Ligh", "Helvetica Neue", "Helvetica", "Arial", "メイリオ; meiryo", "ヒラギノ角ゴ pro w3", "hiragino kaku gothic pro", "sans-serif"';
     fontSize: 16px;
     lineHeight: 24px;
     fontStyle: normal;


### PR DESCRIPTION
### Summary

As part of the work on Yoshi v5, we're bumping Stylable to v4. Stylable v4, checks that the CSS it outputs is valid CSS and fails otherwise. The CSS output of the changed file includes invalid CSS syntax which causes it to fail in the browser (I don't have a real site use-case). With Stylable v4, it fails in build time and prevents us from testing Yoshi v5 on more projects.

This PR fixes it by having a single string for the entire font-family variable. This fixes the build time issues with Yoshi v5 and should also fix a production bug we currently have.

cc @barak007 
