### PR TITLE
feat(DropdownContent) - Check the selected option exists before attem…

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.spec.tsx
@@ -92,6 +92,18 @@ describe('DropdownContent', () => {
       expect(driver.optionAt(15).isHovered()).toBe(true);
     });
 
+    it('should not throw exception if first selected id does not exist in options', () => {
+      const driver = createDriver(
+        createDropdownContent({
+          options,
+          selectedIds: [1000, 15],
+          optionsContainerId: 'container',
+        }),
+      );
+      
+      expect(driver.getContainerScrollPosition('container')).toBe(0);
+    });
+
     it('should trigger an onMouseDown event', () => {
       const onMouseDown = jest.fn();
       const driver = createDriver(

--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
@@ -61,22 +61,25 @@ export class DropdownContent extends React.PureComponent<
       const selectedIndex = this.props.options.findIndex(
         option => option.id === this.props.selectedIds[0],
       );
-      const selectedOption = this.optionsContainerRef.childNodes[
-        selectedIndex
-      ] as HTMLElement;
-      const parentRect = this.optionsContainerRef.getBoundingClientRect();
-      const selectedRect = selectedOption.getBoundingClientRect();
 
-      if (selectedRect.bottom > parentRect.bottom) {
-        this.optionsContainerRef.scrollTop = Math.min(
-          selectedOption.offsetTop +
-            selectedOption.clientHeight / 2 -
-            this.optionsContainerRef.offsetHeight / 2,
-          this.optionsContainerRef.scrollHeight,
-        );
+      if (selectedIndex > -1) {
+        const selectedOption = this.optionsContainerRef.childNodes[
+          selectedIndex
+        ] as HTMLElement;
+        const parentRect = this.optionsContainerRef.getBoundingClientRect();
+        const selectedRect = selectedOption.getBoundingClientRect();
+  
+        if (selectedRect.bottom > parentRect.bottom) {
+          this.optionsContainerRef.scrollTop = Math.min(
+            selectedOption.offsetTop +
+              selectedOption.clientHeight / 2 -
+              this.optionsContainerRef.offsetHeight / 2,
+            this.optionsContainerRef.scrollHeight,
+          );
+        }
+  
+        this.setHoveredIndex(selectedIndex);
       }
-
-      this.setHoveredIndex(selectedIndex);
     }
   }
 


### PR DESCRIPTION
…pting to scroll to it

I needed to add this check because of the AddressInput, it doesn't reset its selected id when its options change - that's probably not the expected behavior but I didn't want to mess with it.