### PR TITLE
feat(MediaImage) - pass dimensions to the native image

### DIFF
--- a/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
@@ -105,6 +105,15 @@ describe('MediaImage', () => {
     expect(await mediaImageDriver.getSrc()).toEqual(SRC);
   });
 
+  it('should set the container dimensions as attributes when provided', async () => {
+    const mediaImageDriver = await createDriver(
+      <MediaImage mediaPlatformItem={mediaPlatformItem} width={WIDTH} height={HEIGHT} />,
+    );
+
+    expect(await mediaImageDriver.getWidthAttribute()).toEqual(WIDTH);
+    expect(await mediaImageDriver.getWidthAttribute()).toEqual(HEIGHT);
+  });
+
   it('displays an alt prop', async () => {
     imageClientSDK.getScaleToFillImageURL.mockReturnValue(BROKEN_SRC);
 

--- a/packages/wix-ui-core/src/components/media-image/media-image.private.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/media-image/media-image.private.uni.driver.ts
@@ -6,7 +6,11 @@ import {
 
 export interface MediaImageDriver extends ImagePublicDriver {
   hasClass(className: string): Promise<boolean>;
+  getWidthAttribute(): Promise<number>;
+  getHeightAttribute(): Promise<number>;
 }
+
+const attributeToNumber = async (base, name) => Number(await base.attr(name));
 
 export const mediaImageDriverFactory = (base: UniDriver): MediaImageDriver => {
   const publicDriver = publicMediaImageDriverFactory(base);
@@ -14,5 +18,7 @@ export const mediaImageDriverFactory = (base: UniDriver): MediaImageDriver => {
   return {
     ...publicDriver,
     hasClass: className => base.hasClass(className),
+    getWidthAttribute: () => attributeToNumber(base, 'width'),
+    getHeightAttribute: () => attributeToNumber(base, 'height'),
   };
 };

--- a/packages/wix-ui-core/src/components/media-image/media-image.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.tsx
@@ -102,6 +102,8 @@ export class MediaImage extends React.Component<MediaProps> {
       errorMediaPlatformItem,
       alt,
       className,
+      width,
+      height,
     } = this.props;
 
     return (
@@ -109,6 +111,7 @@ export class MediaImage extends React.Component<MediaProps> {
         src={this.getImageSource(mediaPlatformItem)}
         className={className}
         alt={alt}
+        nativeProps={{ width, height }}
         errorImage={this.getImageSource(errorMediaPlatformItem)}
         onLoad={onLoad}
         onError={onError}


### PR DESCRIPTION
This PR passes the container dimensions to the native image as attributes, if they are provided.

The thing is today we can pass the container (or target) dimensions:
```jsx
const containerWidth = 300;
const containerHeight = 250;
const sourceWidth = 480;
const sourceHeight = 360;

// ...

<MediaImage
  width={containerWidth}
  height={containerHeight}
  mediaPlatformItem={{
    uri: 'c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg',
    width: sourceWidth,
    height: sourceHeight,
  }}
/>
```

And then we'll get:
![image](https://user-images.githubusercontent.com/7141972/103655252-a568b900-4f6f-11eb-853c-9f6c58970d48.png)

Basically the image itself might be larger according to the media platform service's calculation, but the container (IMO) should be resized as requested (300x250). In other words, I think that `width` & `height` on the direct component (not those of mediaPlatformItem) should behave like `width` & `height` of a regular native `img` element. In this way, we render the dimensions that we actually requested and not different sizes (even though the resource itself might arrive larger depends on the media service)...

So after the change, the same code above will produce:
![image](https://user-images.githubusercontent.com/7141972/103656055-cc73ba80-4f70-11eb-9296-698aac5a598a.png)

Besides that it's more correct (you get the container/target you request), it also has a matter of [performance](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/).

The only concern is this usage:
https://github.com/wix-private/scheduler/blob/master/statics/viewer/bookings-service-details-widget/src/components/BookingServicePage/Widget/Header/Header.tsx#L59-L60

It might affect since in the past they render the dimensions which return and calculated by media service as are, and now the image would be restricted by `headerDimensions` (according to code).  @liorMar - WDYT? If it's problematic, we can pass `nativeProps` prop or something like that, but I think this change is correct in general...