### PR TITLE
#IE-88|pass required prop to input

### DIFF
--- a/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
@@ -961,6 +961,18 @@ describe('AddressInput', () => {
       init({ id });
       expect(driver.getElementId()).toBe(id);
     });
+
+    it('Should pass required prop', () => {
+      init({ required: true });
+
+      expect(driver.getInput().required).toBe(true);
+    });
+
+    it('Should pass required false as default', () => {
+      init();
+
+      expect(driver.getInput().required).toBe(false);
+    });
   });
 
   describe('Preview states', () => {

--- a/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
@@ -125,6 +125,7 @@ export type AddressInputProps = Pick<
   /** Options box z-index */
   optionsContainerZIndex?: number;
   className?: string;
+  /** Sets the input to required */
   required?: boolean;
 };
 

--- a/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
@@ -125,6 +125,7 @@ export type AddressInputProps = Pick<
   /** Options box z-index */
   optionsContainerZIndex?: number;
   className?: string;
+  required?: boolean;
 };
 
 export interface AddressInputState {
@@ -203,6 +204,7 @@ export class AddressInput extends React.PureComponent<
     throttleInterval: 150,
     lang: 'en',
     converterType: Converter.full,
+    required: false,
   };
 
   client: MapsClient;
@@ -537,6 +539,7 @@ export class AddressInput extends React.PureComponent<
       onMouseLeave: this.props.onMouseLeave,
       style: inputStyle,
       inputClassName,
+      required: this.props.required,
     };
 
     const states = {};


### PR DESCRIPTION
This pr fixes issue in AddressInput, in which required prop is not passed to the input element.