### PR TITLE
<RadioButton/> - remove disabled styles

### DIFF
--- a/packages/wix-ui-core/src/components/radio-button/RadioButton.st.css
+++ b/packages/wix-ui-core/src/components/radio-button/RadioButton.st.css
@@ -12,11 +12,6 @@
 
 .root:checked::icon, .root:hover::icon {}
 
-.root:disabled {
-  filter: grayscale(75%);
-  opacity: 0.7;
-}
-
 .hiddenRadio {
   position: absolute;
   overflow: hidden;


### PR DESCRIPTION
Any wix-ui-core component should not apply specific styling. It should be free of styles except for common ones.