### PR TITLE
`wix-ui-framework`: use esModuleInterop

### DIFF
--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/cli.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/cli.ts
@@ -1,4 +1,4 @@
-export const cli = program =>
+export const cli = (program) =>
   program
     .command('export-testkits')
     .description('Generate testkit export file')

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.spec.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as cista from 'cista';
+import fs from 'fs';
+import path from 'path';
+import cista from 'cista';
 
 import { exportTestkits, warningBanner } from '.';
 

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
@@ -1,6 +1,6 @@
-import * as path from 'path';
-import * as fs from 'fs';
-import * as ejs from 'ejs';
+import path from 'path';
+import fs from 'fs';
+import ejs from 'ejs';
 import camelCase from 'lodash/camelCase';
 import kebabCase from 'lodash/kebabCase';
 import snakeCase from 'lodash/snakeCase';

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
@@ -1,9 +1,9 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as ejs from 'ejs';
-import * as camelCase from 'lodash/camelCase';
-import * as kebabCase from 'lodash/kebabCase';
-import * as snakeCase from 'lodash/snakeCase';
+import camelCase from 'lodash/camelCase';
+import kebabCase from 'lodash/kebabCase';
+import snakeCase from 'lodash/snakeCase';
 
 import { fileExists } from '../../file-exists';
 import { objectEntries } from '../../object-entries';

--- a/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/export-testkits/index.ts
@@ -9,7 +9,7 @@ import { fileExists } from '../../file-exists';
 import { objectEntries } from '../../object-entries';
 import { Options } from './typings';
 
-const pathResolver = cwd => (...a) => path.resolve(cwd, ...a);
+const pathResolver = (cwd) => (...a) => path.resolve(cwd, ...a);
 
 export const warningBanner = (templatePath: string) =>
   `/* eslint-disable */
@@ -40,7 +40,7 @@ const tryRequire = ({ requirePath, cwd }) => {
   }
 };
 
-const guards: (a: Options) => Promise<void> = async unsafeOptions => {
+const guards: (a: Options) => Promise<void> = async (unsafeOptions) => {
   const pathResolve = pathResolver(unsafeOptions._process.cwd);
 
   if (!unsafeOptions.output) {
@@ -110,7 +110,7 @@ const ejsSource = ({ source, definitions, components }) => {
   }
 };
 
-const makeOutput: (a: Options) => Promise<void> = async options => {
+const makeOutput: (a: Options) => Promise<void> = async (options) => {
   const components = require(path.resolve(
     options._process.cwd,
     options.components,

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/copy-templates.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/copy-templates.spec.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as cista from 'cista';
+import path from 'path';
+import cista from 'cista';
 import { fsToJson } from '../../../fs-to-json';
 
 import { copyTemplates } from '../tasks/copy-templates';

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/copy-templates.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/copy-templates.spec.ts
@@ -4,7 +4,7 @@ import { fsToJson } from '../../../fs-to-json';
 
 import { copyTemplates } from '../tasks/copy-templates';
 
-const templatesFixturesPath = folder =>
+const templatesFixturesPath = (folder: string) =>
   path.join(__dirname, '..', '__testfixtures__', 'templates', folder);
 
 describe('copyTemplates', () => {

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/verify-working-directory.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/verify-working-directory.spec.ts
@@ -9,7 +9,7 @@ import {
 
 let isGitRepoCleanSpy;
 
-const mockGitStatus = isClean => {
+const mockGitStatus = (isClean) => {
   isGitRepoCleanSpy = jest
     .spyOn(utils, 'isGitRepoClean')
     .mockImplementation(() => Promise.resolve(isClean));

--- a/packages/wix-ui-framework/src/cli-commands/generate/__test__/verify-working-directory.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/__test__/verify-working-directory.spec.ts
@@ -1,4 +1,4 @@
-import * as cista from 'cista';
+import cista from 'cista';
 
 import * as logger from '../../../logger';
 import * as utils from '../utils';

--- a/packages/wix-ui-framework/src/cli-commands/generate/cli.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/cli.ts
@@ -1,4 +1,4 @@
-export const cli = program =>
+export const cli = (program) =>
   program
     .command('generate')
     .description('Scaffold file structure from templates')

--- a/packages/wix-ui-framework/src/cli-commands/generate/index.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/index.spec.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as cista from 'cista';
+import fs from 'fs';
+import cista from 'cista';
 
 import { generate } from '.';
 

--- a/packages/wix-ui-framework/src/cli-commands/generate/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/index.ts
@@ -8,7 +8,7 @@ const defaultTemplatesPath = '.wuf/generator/templates';
 
 export const generate: (
   a: Options & { componentName: string },
-) => Promise<void> = opts => {
+) => Promise<void> = (opts) => {
   try {
     require(path.join(opts._process.cwd, 'package.json'));
   } catch (e) {
@@ -33,7 +33,7 @@ export const generate: (
     return runTasks(options);
   }
 
-  return runPrompts().then(answers =>
+  return runPrompts().then((answers) =>
     runTasks({
       ...options,
       ...answers,

--- a/packages/wix-ui-framework/src/cli-commands/generate/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/index.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'path';
 
 import { Options } from './typings';
 import { runTasks } from './run-tasks';

--- a/packages/wix-ui-framework/src/cli-commands/generate/run-tasks.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/run-tasks.ts
@@ -9,7 +9,7 @@ interface Task {
   message: string;
 }
 
-export const runTasks: (a: Options) => Promise<void> = options => {
+export const runTasks: (a: Options) => Promise<void> = (options) => {
   const tasks: Task[] = [
     {
       // requires are put here for a reason, it is to delay code execution until needed. That's because one task
@@ -48,7 +48,7 @@ export const runTasks: (a: Options) => Promise<void> = options => {
               spinner.stop();
               logger.success(`Done: ${message}`);
             })
-            .catch(e => {
+            .catch((e) => {
               spinner.stop();
               logger.error(`Failed: ${message} ${e}`);
               return Promise.resolve();
@@ -63,7 +63,7 @@ export const runTasks: (a: Options) => Promise<void> = options => {
       ),
     )
 
-    .catch(e => {
+    .catch((e) => {
       logger.error(e);
       process.exit(1);
     });

--- a/packages/wix-ui-framework/src/cli-commands/generate/run-tasks.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/run-tasks.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as logger from '../../logger';
 
 import { Options } from './typings';

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/copy-templates.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/copy-templates.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as mkdirp from 'mkdirp';
-import * as kebabCase from 'lodash/kebabCase';
-import * as camelCase from 'lodash/camelCase';
-import * as snakeCase from 'lodash/snakeCase';
+import kebabCase from 'lodash/kebabCase';
+import camelCase from 'lodash/camelCase';
+import snakeCase from 'lodash/snakeCase';
 
 import { Options } from '../typings';
 import { replaceTemplates } from './replace-templates';

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/copy-templates.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/copy-templates.ts
@@ -10,9 +10,9 @@ import { replaceTemplates } from './replace-templates';
 import { createValuesMap } from '../create-values-map';
 import { interpolateFileName } from '../interpolate-file-name';
 
-const pathExists = p =>
-  new Promise(resolve => {
-    fs.access(p, fs.constants.F_OK, err => {
+const pathExists = (p: string) =>
+  new Promise((resolve) => {
+    fs.access(p, fs.constants.F_OK, (err) => {
       resolve(!err);
     });
   });
@@ -29,7 +29,7 @@ export const copyTemplates = async ({
   }
 
   const readdir = (entry: string) =>
-    fs.readdirSync(entry).map(dir => path.join(entry, dir));
+    fs.readdirSync(entry).map((dir) => path.join(entry, dir));
 
   const componentNames = {
     ComponentName,

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/copy-templates.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/copy-templates.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as mkdirp from 'mkdirp';
+import fs from 'fs';
+import path from 'path';
+import mkdirp from 'mkdirp';
 import kebabCase from 'lodash/kebabCase';
 import camelCase from 'lodash/camelCase';
 import snakeCase from 'lodash/snakeCase';

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/replace-templates.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/replace-templates.ts
@@ -1,4 +1,4 @@
-import * as ejs from 'ejs';
+import ejs from 'ejs';
 
 import camelCase from 'lodash/camelCase';
 import kebabCase from 'lodash/kebabCase';

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/replace-templates.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/replace-templates.ts
@@ -1,8 +1,8 @@
 import * as ejs from 'ejs';
 
-import * as camelCase from 'lodash/camelCase';
-import * as kebabCase from 'lodash/kebabCase';
-import * as snakeCase from 'lodash/snakeCase';
+import camelCase from 'lodash/camelCase';
+import kebabCase from 'lodash/kebabCase';
+import snakeCase from 'lodash/snakeCase';
 
 const utils = {
   toCamel: camelCase,

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/replace-templates.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/replace-templates.ts
@@ -24,7 +24,7 @@ export const replaceTemplates = (source: string, scope: Object) => {
    * 1. with major version release
    * 2. when ensured no consumers use it
    */
-  const replaceDeprecatedSyntax = source.replace(/{%[\w-]+%}/g, match => {
+  const replaceDeprecatedSyntax = source.replace(/{%[\w-]+%}/g, (match) => {
     const key = match.slice(2, -2);
 
     if (!scope.hasOwnProperty(key)) {

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-codemods.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-codemods.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { exec } from 'child_process';
 
 import * as logger from '../../../logger';

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-codemods.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-codemods.ts
@@ -38,7 +38,7 @@ const runCodemod: ({
 
     const execProc = exec(command);
 
-    execProc.stderr.on('data', data => {
+    execProc.stderr.on('data', (data) => {
       logger.error(`Error in ${codemodConfig.codemod}: ${data.toString()}`);
       reject(data.toString());
     });
@@ -49,7 +49,7 @@ const runCodemod: ({
     });
   });
 
-export const runCodemods: (options: Options) => Promise<void> = options => {
+export const runCodemods: (options: Options) => Promise<void> = (options) => {
   const { ComponentName, description, codemods } = options;
 
   const codemodsIndex: CodemodConfig[] = require(path.resolve(

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-prompts.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-prompts.ts
@@ -1,4 +1,4 @@
-import * as prompts from 'prompts';
+import prompts from 'prompts';
 
 import { Answers } from '../typings';
 

--- a/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-prompts.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/tasks/run-prompts.ts
@@ -13,7 +13,7 @@ export const runPrompts: () => Promise<Answers> = async () => {
       type: 'text',
       name: 'ComponentName',
       message: 'Component name (PascalCase)',
-      validate: value => {
+      validate: (value) => {
         if (!value.length) {
           return 'Please supply a component name';
         }

--- a/packages/wix-ui-framework/src/cli-commands/generate/utils.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/utils.ts
@@ -1,4 +1,4 @@
-import * as simpleGit from 'simple-git';
+import simpleGit from 'simple-git';
 
 export const isGitRepoClean = (cwd) =>
   new Promise((resolve) => {

--- a/packages/wix-ui-framework/src/cli-commands/generate/utils.ts
+++ b/packages/wix-ui-framework/src/cli-commands/generate/utils.ts
@@ -1,18 +1,18 @@
 import * as simpleGit from 'simple-git';
 
-export const isGitRepoClean = cwd =>
-  new Promise(resolve => {
+export const isGitRepoClean = (cwd) =>
+  new Promise((resolve) => {
     simpleGit(cwd).status((err, status) => {
       resolve(status.isClean());
     });
   });
 
-export const isPascalCase = value => /^([A-Z][a-z]*)+$/.test(value);
+export const isPascalCase = (value) => /^([A-Z][a-z]*)+$/.test(value);
 
 // HelloWorld -> helloWorld
-export const pascalToCamel = str =>
-  str.replace(/^./, match => match.toLowerCase());
+export const pascalToCamel = (str) =>
+  str.replace(/^./, (match) => match.toLowerCase());
 
 // HelloWorld -> hello-world
-export const pascalToKebab = str =>
-  pascalToCamel(str).replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+export const pascalToKebab = (str) =>
+  pascalToCamel(str).replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);

--- a/packages/wix-ui-framework/src/cli-commands/update-components-list/cli.ts
+++ b/packages/wix-ui-framework/src/cli-commands/update-components-list/cli.ts
@@ -1,4 +1,4 @@
-export const cli = program =>
+export const cli = (program) =>
   program
     .command('update')
     .description('Update components list file')

--- a/packages/wix-ui-framework/src/cli-commands/update-components-list/index.spec.ts
+++ b/packages/wix-ui-framework/src/cli-commands/update-components-list/index.spec.ts
@@ -1,6 +1,6 @@
-import * as cista from 'cista';
-import * as path from 'path';
-import * as fs from 'fs';
+import cista from 'cista';
+import path from 'path';
+import fs from 'fs';
 
 import { updateComponentsList } from '.';
 

--- a/packages/wix-ui-framework/src/cli-commands/update-components-list/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/update-components-list/index.ts
@@ -1,7 +1,7 @@
-import * as path from 'path';
-import * as fs from 'fs';
+import path from 'path';
+import fs from 'fs';
 import { promisify } from 'util';
-import * as minimatch from 'minimatch';
+import minimatch from 'minimatch';
 
 import { Path, Process } from '../../typings.d';
 import { fileExists } from '../../file-exists';

--- a/packages/wix-ui-framework/src/cli-commands/update-components-list/index.ts
+++ b/packages/wix-ui-framework/src/cli-commands/update-components-list/index.ts
@@ -12,7 +12,7 @@ import { mapTree } from '../../map-tree';
 const fsReadFile = promisify(fs.readFile);
 const fsWriteFile = promisify(fs.writeFile);
 
-const pathResolver = cwd => (...a) => path.resolve(cwd, ...a);
+const pathResolver = (cwd) => (...a) => path.resolve(cwd, ...a);
 
 interface Options {
   shape?: Path;
@@ -32,7 +32,7 @@ const readOutputFile = async (path = '') => {
   }
 };
 
-const guards: (a: Options) => Promise<void> = async unsafeOptions => {
+const guards: (a: Options) => Promise<void> = async (unsafeOptions) => {
   const pathResolve = pathResolver(unsafeOptions._process.cwd);
 
   const options = {
@@ -48,8 +48,9 @@ const guards: (a: Options) => Promise<void> = async unsafeOptions => {
 
   if (!(await fileExists(options.shape))) {
     throw new Error(
-      `Component structure file does not exist at "${unsafeOptions.shape ||
-        options.shape}"`,
+      `Component structure file does not exist at "${
+        unsafeOptions.shape || options.shape
+      }"`,
     );
   }
 
@@ -62,7 +63,7 @@ const guards: (a: Options) => Promise<void> = async unsafeOptions => {
   return makeOutput(options);
 };
 
-const makeOutput: (a: Options) => Promise<void> = async options => {
+const makeOutput: (a: Options) => Promise<void> = async (options) => {
   const shapeRaw = await fsReadFile(options.shape, 'utf8');
   const shape = JSON.parse(shapeRaw);
   const output = await readOutputFile(options.output);

--- a/packages/wix-ui-framework/src/file-exists.ts
+++ b/packages/wix-ui-framework/src/file-exists.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs';
 import { promisify } from 'util';
 
 import { Path } from './typings.d';

--- a/packages/wix-ui-framework/src/file-exists.ts
+++ b/packages/wix-ui-framework/src/file-exists.ts
@@ -5,7 +5,7 @@ import { Path } from './typings.d';
 
 const fsAccess = promisify(fs.access);
 
-export const fileExists: (a: Path) => Promise<boolean> = path =>
+export const fileExists: (a: Path) => Promise<boolean> = (path) =>
   fsAccess(path, fs.constants.F_OK)
     .then(() => true)
     .catch(() => false);

--- a/packages/wix-ui-framework/src/fs-to-json/index.spec.ts
+++ b/packages/wix-ui-framework/src/fs-to-json/index.spec.ts
@@ -1,4 +1,4 @@
-import * as cista from 'cista';
+import cista from 'cista';
 import { fsToJson } from './index';
 
 describe('fsToJson', () => {

--- a/packages/wix-ui-framework/src/fs-to-json/index.ts
+++ b/packages/wix-ui-framework/src/fs-to-json/index.ts
@@ -30,10 +30,10 @@ export const fsToJson: (a: Params) => Promise<Object> = async ({
   const recursion = ({ entries, entryCwd }) =>
     entries.reduce(
       (accPromise: Promise<Object>, entry: string) =>
-        accPromise.then(async acc => {
+        accPromise.then(async (acc) => {
           const entryPath = pathResolve(entryCwd, entry);
 
-          if (exclude.some(glob => minimatch(entryPath, glob))) {
+          if (exclude.some((glob) => minimatch(entryPath, glob))) {
             return acc;
           }
 

--- a/packages/wix-ui-framework/src/fs-to-json/index.ts
+++ b/packages/wix-ui-framework/src/fs-to-json/index.ts
@@ -1,7 +1,7 @@
-import * as fs from 'fs';
+import fs from 'fs';
 import { promisify } from 'util';
 import { resolve as pathResolve } from 'path';
-import * as minimatch from 'minimatch';
+import minimatch from 'minimatch';
 
 import { fileExists } from '../file-exists';
 

--- a/packages/wix-ui-framework/src/index.ts
+++ b/packages/wix-ui-framework/src/index.ts
@@ -13,14 +13,14 @@ import { cli as updateComponentsListCli } from './cli-commands/update-components
 // otherwise `dist` would contain extraneous `src` folder
 const { version } = require('../package.json');
 
-const extendOptions = options => ({
+const extendOptions = (options) => ({
   ...options,
   _process: {
     cwd: process.cwd(),
   },
 });
 
-const run = action => options =>
+const run = (action) => (options) =>
   action(extendOptions(options)).catch(console.error);
 
 program.name('wuf').version(version, '-v, --version');

--- a/packages/wix-ui-framework/src/index.ts
+++ b/packages/wix-ui-framework/src/index.ts
@@ -1,4 +1,4 @@
-import * as program from 'commander';
+import program from 'commander';
 
 import { generate } from './cli-commands/generate';
 import { cli as generateCli } from './cli-commands/generate/cli';

--- a/packages/wix-ui-framework/src/logger.ts
+++ b/packages/wix-ui-framework/src/logger.ts
@@ -1,8 +1,9 @@
 import * as chalk from 'chalk';
 import * as ora from 'ora';
 
-export const error = msg => console.log(`${chalk.red('✖')} ${msg}`);
-export const success = msg => console.log(`${chalk.green('✔')} ${msg}`);
-export const info = msg => console.log(`${chalk.blue('ℹ')} ${msg}`);
+export const error = (msg: string) => console.log(`${chalk.red('✖')} ${msg}`);
+export const success = (msg: string) =>
+  console.log(`${chalk.green('✔')} ${msg}`);
+export const info = (msg: string) => console.log(`${chalk.blue('ℹ')} ${msg}`);
 export const divider = () => console.log();
-export const spinner = text => ora(text).start();
+export const spinner = (msg: string) => ora(msg).start();

--- a/packages/wix-ui-framework/src/logger.ts
+++ b/packages/wix-ui-framework/src/logger.ts
@@ -1,5 +1,5 @@
-import * as chalk from 'chalk';
-import * as ora from 'ora';
+import chalk from 'chalk';
+import ora from 'ora';
 
 export const error = (msg: string) => console.log(`${chalk.red('✖')} ${msg}`);
 export const success = (msg: string) =>

--- a/packages/wix-ui-framework/src/map-tree/index.ts
+++ b/packages/wix-ui-framework/src/map-tree/index.ts
@@ -1,4 +1,4 @@
-const isObject = o => o && o.toString() === '[object Object]';
+const isObject = (o) => o && o.toString() === '[object Object]';
 
 /**
  * mapTree is like Array.prototype.map but for objects

--- a/packages/wix-ui-framework/src/object-entries.ts
+++ b/packages/wix-ui-framework/src/object-entries.ts
@@ -1,2 +1,2 @@
 export const objectEntries = (object: object) =>
-  Object.keys(object).map(key => [key, object[key]]);
+  Object.keys(object).map((key) => [key, object[key]]);

--- a/packages/wix-ui-framework/test/cli.spec.ts
+++ b/packages/wix-ui-framework/test/cli.spec.ts
@@ -11,7 +11,7 @@ const cli = (...args) => {
 
 describe('wuf', () => {
   describe('help', () => {
-    it('should be displayed when no params', done => {
+    it('should be displayed when no params', (done) => {
       nixt()
         .expect(({ stdout }) => {
           expect(stdout).toMatchSnapshot();
@@ -20,7 +20,7 @@ describe('wuf', () => {
         .end(done);
     });
 
-    it('should be displayed when --help', done => {
+    it('should be displayed when --help', (done) => {
       nixt()
         .expect(({ stdout }) => {
           expect(stdout).toMatchSnapshot();
@@ -31,7 +31,7 @@ describe('wuf', () => {
   });
 
   describe('-v, --version', () => {
-    it('should echo version from package.json', done => {
+    it('should echo version from package.json', (done) => {
       nixt()
         .expect(({ stdout }) => {
           expect(stdout).toEqual(packageJson.version);
@@ -43,7 +43,7 @@ describe('wuf', () => {
 
   describe('generate', () => {
     describe('--help', () => {
-      it('should render help text', done => {
+      it('should render help text', (done) => {
         nixt()
           .expect(({ stdout }) => {
             expect(stdout).toMatchSnapshot();
@@ -54,7 +54,7 @@ describe('wuf', () => {
     });
 
     describe('--component-name', () => {
-      it('should prompt for component name by default', done => {
+      it('should prompt for component name by default', (done) => {
         nixt()
           .expect(({ stdout }) => {
             expect(stdout).toMatch(/Component name \(PascalCase\).*Test/);
@@ -65,7 +65,7 @@ describe('wuf', () => {
           .end(done);
       });
 
-      it('should not prompt for component name given --component-name flag', done => {
+      it('should not prompt for component name given --component-name flag', (done) => {
         nixt()
           .expect(({ stdout }) => {
             expect(stdout).toMatch(/Generating.*<Testable\/>.*component/);
@@ -78,7 +78,7 @@ describe('wuf', () => {
 
   describe('export-testkits', () => {
     describe('--help', () => {
-      it('should render help text', done => {
+      it('should render help text', (done) => {
         nixt()
           .expect(({ stdout }) => {
             expect(stdout).toMatchSnapshot();
@@ -89,7 +89,7 @@ describe('wuf', () => {
     });
 
     describe('--output', () => {
-      it('should fail with error, when --output is missing', done => {
+      it('should fail with error, when --output is missing', (done) => {
         nixt()
           .expect(({ stderr }) => {
             expect(stderr).toMatch(
@@ -102,7 +102,7 @@ describe('wuf', () => {
     });
 
     describe('--definitions', () => {
-      it('should fail with error, given non existing path', done => {
+      it('should fail with error, given non existing path', (done) => {
         nixt()
           .expect(({ stderr }) => {
             expect(stderr).toMatch(
@@ -117,7 +117,7 @@ describe('wuf', () => {
 
   describe('update', () => {
     describe('--help', () => {
-      it('should render help text', done => {
+      it('should render help text', (done) => {
         nixt()
           .expect(({ stdout }) => {
             expect(stdout).toMatchSnapshot();

--- a/packages/wix-ui-framework/test/cli.spec.ts
+++ b/packages/wix-ui-framework/test/cli.spec.ts
@@ -1,6 +1,6 @@
-import * as path from 'path';
-import * as nixt from 'nixt';
-import * as cista from 'cista';
+import path from 'path';
+import nixt from 'nixt';
+import cista from 'cista';
 
 import * as packageJson from '../package.json';
 

--- a/packages/wix-ui-framework/tsconfig.json
+++ b/packages/wix-ui-framework/tsconfig.json
@@ -15,7 +15,8 @@
     ],
     "outDir": "dist",
     "rootDir": "./src",
-    "declaration": true
+    "declaration": true,
+    "esModuleInterop": true
   },
   "typeRoots": [
     "node_modules/@types"

--- a/packages/wix-ui-framework/tslint.json
+++ b/packages/wix-ui-framework/tslint.json
@@ -25,10 +25,6 @@
       "error",
       "always"
     ],
-    "arrow-parens": [
-      true,
-      "ban-single-arg-parens"
-    ],
     "array-bracket-spacing": [
       true,
       "never"


### PR DESCRIPTION
This PR updates wix-ui-framework with `esModuleInterop` in `tsconfig.json`. This allows to easily avoid errors like `This module can only be referenced with ECMAScript imports/exports`
