### PR TITLE
<Dropdown/> reset hover state when on mouse leave

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.spec.tsx
@@ -45,7 +45,7 @@ describe('DropdownContent', () => {
     it('should be hovered on mouse enter and not on mouse leave', () => {
       const driver = createDriver(createDropdownContent({ options }));
       driver.optionAt(0).mouseEnter();
-      expect(driver.optionAt(0).isHovered()).toBeTruthy();
+      expect(driver.optionAt(0).isHovered()).toBe(true);;
       driver.optionAt(0).mouseLeave();
       expect(driver.optionAt(0).isHovered()).toBeFalsy();
     });

--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.spec.tsx
@@ -42,6 +42,14 @@ describe('DropdownContent', () => {
       expect(onOptionClick).toHaveBeenCalledWith(options[4]);
     });
 
+    it('should be hovered on mouse enter and not on mouse leave', () => {
+      const driver = createDriver(createDropdownContent({ options }));
+      driver.optionAt(0).mouseEnter();
+      expect(driver.optionAt(0).isHovered()).toBeTruthy();
+      driver.optionAt(0).mouseLeave();
+      expect(driver.optionAt(0).isHovered()).toBeFalsy();
+    });
+
     it('should not select non selectable options', () => {
       const onOptionClick = jest.fn();
       const driver = createDriver(
@@ -100,7 +108,7 @@ describe('DropdownContent', () => {
           optionsContainerId: 'container',
         }),
       );
-      
+
       expect(driver.getContainerScrollPosition('container')).toBe(0);
     });
 

--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.spec.tsx
@@ -47,7 +47,7 @@ describe('DropdownContent', () => {
       driver.optionAt(0).mouseEnter();
       expect(driver.optionAt(0).isHovered()).toBe(true);;
       driver.optionAt(0).mouseLeave();
-      expect(driver.optionAt(0).isHovered()).toBeFalsy();
+      expect(driver.optionAt(0).isHovered()).toBe(false);
     });
 
     it('should not select non selectable options', () => {

--- a/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-content/DropdownContent.tsx
@@ -264,6 +264,7 @@ export class DropdownContent extends React.PureComponent<
                   ? evt => this.onMouseEnter(evt, index)
                   : undefined
               }
+              onMouseLeaveHandler={()=>{this.setHoveredIndex(NOT_HOVERED_INDEX)}}
             />
           ))}
         </div>

--- a/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.driver.ts
+++ b/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.driver.ts
@@ -7,6 +7,7 @@ export const dropdownOptionDriverFactory = ({ element, eventTrigger }) => {
     exists: () => !!element,
     click: () => element && eventTrigger.click(element),
     mouseEnter: () => element && eventTrigger.mouseEnter(element),
+    mouseLeave: () => element && eventTrigger.mouseLeave(element),
     className: () => element && element.className,
     isHovered: () => element && domUtils.hasStyleState(element, 'hovered'),
     isSelected: () => element && domUtils.hasStyleState(element, 'selected'),

--- a/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.spec.tsx
@@ -11,6 +11,7 @@ describe('DropdownOption', () => {
 
   const onClickHandler = jest.fn();
   const onMouseEnterHandler = jest.fn();
+  const onMouseLeaveHandler = jest.fn();
 
   const createOption = (isDisabled = false) =>
     OptionFactory.create({
@@ -28,6 +29,7 @@ describe('DropdownOption', () => {
       onClickHandler={onClickHandler}
       className="className"
       onMouseEnterHandler={onMouseEnterHandler}
+      onMouseLeaveHandler={onMouseLeaveHandler}
     />
   );
 
@@ -50,6 +52,13 @@ describe('DropdownOption', () => {
     const driver = createDriver(createDropdownOption(option));
     driver.mouseEnter();
     expect(onMouseEnterHandler).toHaveBeenCalled();
+  });
+
+  it('should call mouse leave handler', () => {
+    const option = createOption();
+    const driver = createDriver(createDropdownOption(option));
+    driver.mouseLeave();
+    expect(onMouseLeaveHandler).toHaveBeenCalled();
   });
 
   it('should be hovered and selected but not disabled', () => {

--- a/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.tsx
+++ b/packages/wix-ui-core/src/components/dropdown-option/DropdownOption.tsx
@@ -10,6 +10,7 @@ export interface DropdownOptionProps {
   isHovered: boolean;
   onClickHandler: React.MouseEventHandler<HTMLDivElement> | undefined;
   onMouseEnterHandler: React.MouseEventHandler<HTMLDivElement> | undefined;
+  onMouseLeaveHandler: React.MouseEventHandler<HTMLDivElement> | undefined;
   dataHook?: string;
 }
 
@@ -25,6 +26,7 @@ export const DropdownOption: DropdownOptionType = (
     isHovered,
     onClickHandler,
     onMouseEnterHandler,
+    onMouseLeaveHandler,
     dataHook,
   } = props;
   const disabled = option.isDisabled;
@@ -50,6 +52,7 @@ export const DropdownOption: DropdownOptionType = (
       onClick={onClickHandler}
       title={option.value}
       onMouseEnter={onMouseEnterHandler}
+      onMouseLeave={onMouseLeaveHandler}
     >
       {option.render(option.value)}
     </div>


### PR DESCRIPTION
Currently dropdown options remains hovered even if the mouse is no longer hovered on option.
The hovered state should disappear if the mouse is out of dropdown component bounds.
This PR add the mouse leave handler which resets the hovered state.