### PR TITLE
fix(address-input): #IE-141|disable browser autocomplete for autocomp…

### DIFF
--- a/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
@@ -850,7 +850,7 @@ describe('AddressInput', () => {
       init({});
       const browserAutoComplete = driver.getAutoComplete();
 
-      expect(browserAutoComplete).toBe('no-autocomplete');
+      expect(browserAutoComplete).toBe('off');
     });
 
     it('Should handle onChange event', () => {

--- a/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.spec.tsx
@@ -846,6 +846,13 @@ describe('AddressInput', () => {
       expect(driver.isDisabled()).toBeFalsy();
     });
 
+    it('Should pass autocomplete prop (no-autocomplete)', () => {
+      init({});
+      const browserAutoComplete = driver.getAutoComplete();
+
+      expect(browserAutoComplete).toBe('no-autocomplete');
+    });
+
     it('Should handle onChange event', () => {
       const onChange = jest.fn();
       init({ onChange });

--- a/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
@@ -541,7 +541,8 @@ export class AddressInput extends React.PureComponent<
       style: inputStyle,
       inputClassName,
       required: this.props.required,
-      autoComplete: 'no-autocomplete',
+      autoComplete: 'off',
+      type: 'search',
     };
 
     const states = {};

--- a/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
+++ b/packages/wix-ui-core/src/components/address-input/AddressInput.tsx
@@ -541,6 +541,7 @@ export class AddressInput extends React.PureComponent<
       style: inputStyle,
       inputClassName,
       required: this.props.required,
+      autoComplete: 'no-autocomplete',
     };
 
     const states = {};

--- a/packages/wix-ui-core/src/components/input/Input.driver.ts
+++ b/packages/wix-ui-core/src/components/input/Input.driver.ts
@@ -26,6 +26,9 @@ export const inputDriverFactory = ({ element, eventTrigger }) => {
     /** get suffix */
     getSuffix: () => input.nextSibling,
 
+    /** get autoComplete */
+    getAutoComplete: () => input.autocomplete,
+
     /** is disabled */
     isDisabled: () => input.disabled,
 

--- a/packages/wix-ui-core/src/components/input/Input.driver.ts
+++ b/packages/wix-ui-core/src/components/input/Input.driver.ts
@@ -27,8 +27,7 @@ export const inputDriverFactory = ({ element, eventTrigger }) => {
     getSuffix: () => input.nextSibling,
 
     /** get autoComplete */
-    getAutoComplete: () => input.autocomplete,
-
+    getAutoComplete: () => input.getAttribute('autocomplete'),
     /** is disabled */
     isDisabled: () => input.disabled,
 


### PR DESCRIPTION
In address component (which uses InputWithOptions), browser autocomplete should be disabled.
If not disabled, it causes weird behaviour: 
when user start typing, both browser autocomplete and input options open (browser autocomplete gets the focus)
this causes situation where pressing down/up key doesn't navigate through the input options as expected, but navigates through browser autocomplete options.