### PR TITLE
`<Tooltip/>` - Don't handle focus and blur on disabled tooltip

### DIFF
--- a/packages/wix-ui-core/src/components/tooltip-next/tooltip-next.tsx
+++ b/packages/wix-ui-core/src/components/tooltip-next/tooltip-next.tsx
@@ -97,13 +97,13 @@ export class TooltipNext extends React.PureComponent<
   };
 
   _renderElement = () => {
-    const { children, 'aria-describedby': ariaDescribedBy } = this.props;
+    const { children, disabled, 'aria-describedby': ariaDescribedBy } = this.props;
     if (typeof children === 'string' || !children) {
       return children || '';
     }
     return React.cloneElement(children as any, {
-      onFocus: this._onFocus,
-      onBlur: this._onBlur,
+      onFocus: disabled ? undefined : this._onFocus,
+      onBlur: disabled ? undefined : this._onBlur,
       'aria-describedby': ariaDescribedBy,
     });
   };

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.spec.tsx
@@ -187,18 +187,26 @@ function runTests(render, tooltip) {
 
   describe('`disabled` prop', () => {
     it('[when] given false should not show tooltip on mouse enter', async () => {
-      const children = 'kido';
+      const children = <div>kido</div>;
       const { driver } = render(tooltip({ children, disabled: true }));
       expect(await driver.tooltipExists()).toBe(false);
       await driver.mouseEnter();
       expect(await driver.tooltipExists()).toBe(false);
     });
     it('[when] given true should not show tooltip on focus', async () => {
-      const children = 'kido';
+      const children = <div>kido</div>;
       const { driver } = render(tooltip({ children, disabled: true }));
       expect(await driver.tooltipExists()).toBe(false);
       await driver.tabIn();
       expect(await driver.tooltipExists()).toBe(false);
+    });
+    it('[when] given true should not call onShow() prop on focus', async () => {
+      const children = <div>kido</div>;
+      const onShow = jest.fn();
+      const { driver } = render(tooltip({ children, onShow, disabled: true }));
+      expect(await driver.tooltipExists()).toBe(false);
+      await driver.tabIn();
+      expect(onShow).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
+++ b/packages/wix-ui-core/src/components/tooltip/Tooltip.tsx
@@ -95,13 +95,13 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
   };
 
   _renderElement = () => {
-    const { children, 'aria-describedby': ariaDescribedBy } = this.props;
+    const { children, disabled, 'aria-describedby': ariaDescribedBy } = this.props;
     if (typeof children === 'string' || !children) {
       return children || '';
     }
     return React.cloneElement(children as any, {
-      onFocus: this._onFocus,
-      onBlur: this._onBlur,
+      onFocus: disabled ? undefined : this._onFocus,
+      onBlur: disabled ? undefined : this._onBlur,
       'aria-describedby': ariaDescribedBy,
     });
   };


### PR DESCRIPTION
## Motivation
Fixes [DSM-1564](https://jira.wixpress.com/browse/DSM-1564) - **Tooltip onShow handler is called on children focus on Chrome even when the tooltip is disabled**.

## Notes
1. The existing `disabled` focus test wasn't really working. It was passing even without `disabled: true` because the children was a string that cannot be focused into. So I changed it to be an element.
2. The current code didn't show tooltip when `disabled: true` because `isShown()` returned `false`, but it did call `onShow`, which caused our code to send BI event ([WOSSM-403](https://jira.wixpress.com/browse/WOSSM-403)).
