### PR TITLE
Image - fix SSR support

### DIFF
--- a/packages/wix-ui-core/perfer.config.js
+++ b/packages/wix-ui-core/perfer.config.js
@@ -36,7 +36,7 @@ const files = [
   ['tooltip-next.js', 16],
   ['toggle-switch.js', 6],
   ['tooltip.js', 29],
-  ['video.js', 90],
+  ['video.js', 90.2],
 ];
 
 module.exports = {

--- a/packages/wix-ui-core/src/components/image/image.tsx
+++ b/packages/wix-ui-core/src/components/image/image.tsx
@@ -19,7 +19,8 @@ export interface ImageState {
   status: ImageStatus;
 }
 export class Image extends React.PureComponent<ImageProps, ImageState> {
-  private readonly getSrc = (): string => (this.props.src ? this.props.src : this.getSrcSet());
+  private readonly getSrc = (): string =>
+    this.props.src ? this.props.src : this.getSrcSet();
 
   private readonly getSrcSet = (): string =>
     this.props.srcSet ? this.getErrorImage() : FALLBACK_IMAGE;
@@ -28,15 +29,24 @@ export class Image extends React.PureComponent<ImageProps, ImageState> {
     this.props.errorImage ? this.props.errorImage : FALLBACK_IMAGE;
 
   private readonly getErrorSrc = (): string =>
-    this.state.src === this.props.errorImage ? FALLBACK_IMAGE : this.getErrorImage();
+    this.state.src === this.props.errorImage
+      ? FALLBACK_IMAGE
+      : this.getErrorImage();
 
-  private readonly isErrorState = (): boolean => this.state.status === ImageStatus.error;
+  private readonly isErrorState = (): boolean =>
+    this.state.status === ImageStatus.error;
 
   private readonly isResized = (): boolean =>
     this.props.resizeMode === 'contain' || this.props.resizeMode === 'cover';
 
   private getImageProps() {
-    const { errorImage, resizeMode, srcSet, nativeProps, ...additionalProps } = this.props;
+    const {
+      errorImage,
+      resizeMode,
+      srcSet,
+      nativeProps,
+      ...additionalProps
+    } = this.props;
     const ret = {
       ...additionalProps,
       ...nativeProps,
@@ -95,23 +105,28 @@ export class Image extends React.PureComponent<ImageProps, ImageState> {
       );
     }
 
-    return <img ref={this.imageRef} {...commonProps} {...this.getImageProps()} />;
+    return (
+      <img ref={this.imageRef} {...commonProps} {...this.getImageProps()} />
+    );
   }
 
-  private readonly handleOnLoad: React.EventHandler<React.SyntheticEvent<HTMLImageElement>> = (
-    e,
-  ) => {
+  private readonly handleOnLoad: React.EventHandler<
+    React.SyntheticEvent<HTMLImageElement>
+  > = (e) => {
     if (!this.isErrorState()) {
       this.setState({
-        status: this.state.status === 'error' ? ImageStatus.error : ImageStatus.loaded,
+        status:
+          this.state.status === 'error'
+            ? ImageStatus.error
+            : ImageStatus.loaded,
       });
       this.props.onLoad && this.props.onLoad(e);
     }
   };
 
-  private readonly handleOnError: React.EventHandler<React.SyntheticEvent<HTMLImageElement>> = (
-    e,
-  ) => {
+  private readonly handleOnError: React.EventHandler<
+    React.SyntheticEvent<HTMLImageElement>
+  > = (e) => {
     if (!this.isErrorState()) {
       this.setState({
         status: ImageStatus.error,

--- a/packages/wix-ui-core/src/components/image/image.tsx
+++ b/packages/wix-ui-core/src/components/image/image.tsx
@@ -112,7 +112,7 @@ export class Image extends React.PureComponent<ImageProps, ImageState> {
 
   private readonly handleOnLoad: React.EventHandler<
     React.SyntheticEvent<HTMLImageElement>
-  > = (e) => {
+  > = e => {
     if (!this.isErrorState()) {
       this.setState({
         status:
@@ -126,7 +126,7 @@ export class Image extends React.PureComponent<ImageProps, ImageState> {
 
   private readonly handleOnError: React.EventHandler<
     React.SyntheticEvent<HTMLImageElement>
-  > = (e) => {
+  > = e => {
     if (!this.isErrorState()) {
       this.setState({
         status: ImageStatus.error,


### PR DESCRIPTION
This PR adds support to rerender the component when using SSR to allow the event handlers be invoked after the component is hydrated.

Apparently, the problem is that the event handlers aren't invoked after the image is hydrated since the image is already loaded before they are even registered and so the status of the image remains as "loading" (check [this](https://stackoverflow.com/questions/39777833/image-onload-event-in-isomorphic-universal-react-register-event-after-image-is) out).

Indirect example showing the issue:
![image](https://user-images.githubusercontent.com/7141972/108096986-3dd37c80-708a-11eb-9b2d-da650d038ff7.png)


Notice it's still WIP.