### PR TITLE
feat(Image&MediaImage): expose `nativeRef` prop

### DIFF
--- a/packages/wix-ui-core/src/components/image/image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/image/image.browser.spec.tsx
@@ -72,12 +72,11 @@ describe('Image', () => {
 
     it('should pass the given reference to the native image element', async () => {
       const ref = React.createRef<HTMLImageElement>();
-      const expectedSrc = 'something';
+      const expectedTagName = 'IMG';
 
       const imageDriver = await createDriver(<Image nativeRef={ref} />);
-      ref.current.src = expectedSrc;
 
-      expect(await imageDriver.getSrc()).toEqual(expectedSrc);
+      expect(await imageDriver.getTagName()).toEqual(expectedTagName);
     });
   });
 

--- a/packages/wix-ui-core/src/components/image/image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/image/image.browser.spec.tsx
@@ -66,8 +66,18 @@ describe('Image', () => {
       const imageDriver = await createDriver(
         <Image className={expectedClassName} />,
       );
-      
+
       expect(await imageDriver.hasClass(expectedClassName)).toBe(true);
+    });
+
+    it('should pass the given reference to the native image element', async () => {
+      const ref = React.createRef<HTMLImageElement>();
+      const expectedSrc = 'something';
+
+      const imageDriver = await createDriver(<Image nativeRef={ref} />);
+      ref.current.src = expectedSrc;
+
+      expect(await imageDriver.getSrc()).toEqual(expectedSrc);
     });
   });
 

--- a/packages/wix-ui-core/src/components/image/image.driver.private.ts
+++ b/packages/wix-ui-core/src/components/image/image.driver.private.ts
@@ -10,6 +10,7 @@ export interface ImageDriver extends ImagePublicDriver {
   getResizeMode(): Promise<string | boolean>;
   getSrcSet(): Promise<string>;
   hasClass(className: string): Promise<boolean>;
+  getTagName(): Promise<string>;
 }
 
 export const imageDriverFactory = (base: UniDriver): ImageDriver => {
@@ -25,6 +26,7 @@ export const imageDriverFactory = (base: UniDriver): ImageDriver => {
     ...publicDriver,
     getResizeMode: async () => getStyleState('resizeMode'),
     getSrcSet: () => base.attr('srcSet'),
-    hasClass: className => base.hasClass(className)
+    hasClass: className => base.hasClass(className),
+    getTagName: async () => (await base.getNative()).tagName,
   };
 };

--- a/packages/wix-ui-core/src/components/image/image.tsx
+++ b/packages/wix-ui-core/src/components/image/image.tsx
@@ -20,7 +20,7 @@ export interface ImageState {
   src?: string;
   status: ImageStatus;
 }
-class ImageComponent extends React.PureComponent<ImageProps, ImageState> {
+export class Image extends React.PureComponent<ImageProps, ImageState> {
   private readonly getSrc = (): string =>
     this.props.src ? this.props.src : this.getSrcSet();
 
@@ -122,7 +122,3 @@ class ImageComponent extends React.PureComponent<ImageProps, ImageState> {
     }
   };
 }
-
-export const Image = React.forwardRef<HTMLImageElement, ImageProps>(
-  (props, ref) => <ImageComponent {...props} nativeRef={ref} />,
-);

--- a/packages/wix-ui-core/src/components/image/image.tsx
+++ b/packages/wix-ui-core/src/components/image/image.tsx
@@ -4,6 +4,8 @@ import { ImageStatus, FALLBACK_IMAGE } from './consts';
 
 export interface ImageProps {
   nativeProps?: React.ImgHTMLAttributes<HTMLImageElement>;
+  /** A reference to be passed to the native image element */
+  nativeRef?: React.Ref<HTMLImageElement>;
   src?: string;
   srcSet?: string;
   alt?: string;
@@ -18,7 +20,7 @@ export interface ImageState {
   src?: string;
   status: ImageStatus;
 }
-export class Image extends React.PureComponent<ImageProps, ImageState> {
+class ImageComponent extends React.PureComponent<ImageProps, ImageState> {
   private readonly getSrc = (): string =>
     this.props.src ? this.props.src : this.getSrcSet();
 
@@ -45,11 +47,13 @@ export class Image extends React.PureComponent<ImageProps, ImageState> {
       resizeMode,
       srcSet,
       nativeProps,
+      nativeRef,
       ...additionalProps
     } = this.props;
     const ret = {
       ...additionalProps,
       ...nativeProps,
+      ref: nativeRef,
       src: this.state.src,
       srcSet: this.isErrorState() ? null : srcSet,
       onLoad: this.handleOnLoad,
@@ -118,3 +122,7 @@ export class Image extends React.PureComponent<ImageProps, ImageState> {
     }
   };
 }
+
+export const Image = React.forwardRef<HTMLImageElement, ImageProps>(
+  (props, ref) => <ImageComponent {...props} nativeRef={ref} />,
+);

--- a/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
@@ -153,6 +153,18 @@ describe('MediaImage', () => {
     );
   });
 
+  it('should pass the given reference to the native image element', async () => {
+    const ref = React.createRef<HTMLImageElement>();
+    const expectedSrc = 'something';
+
+    const mediaImageDriver = await createDriver(
+      <MediaImage nativeRef={ref} />,
+    );
+    ref.current.src = expectedSrc;
+
+    expect(await mediaImageDriver.getSrc()).toEqual(expectedSrc);
+  });
+
   describe('props are not provided', () => {
     it('displays empty pixel when mediaPlatformItem are not provided', async () => {
       const onLoadSpy = jest.fn();

--- a/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.browser.spec.tsx
@@ -155,14 +155,11 @@ describe('MediaImage', () => {
 
   it('should pass the given reference to the native image element', async () => {
     const ref = React.createRef<HTMLImageElement>();
-    const expectedSrc = 'something';
+    const expectedTagName = 'IMG';
 
-    const mediaImageDriver = await createDriver(
-      <MediaImage nativeRef={ref} />,
-    );
-    ref.current.src = expectedSrc;
+    const mediaImageDriver = await createDriver(<MediaImage nativeRef={ref} />);
 
-    expect(await mediaImageDriver.getSrc()).toEqual(expectedSrc);
+    expect(await mediaImageDriver.getTagName()).toEqual(expectedTagName);
   });
 
   describe('props are not provided', () => {

--- a/packages/wix-ui-core/src/components/media-image/media-image.private.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/media-image/media-image.private.uni.driver.ts
@@ -8,6 +8,7 @@ export interface MediaImageDriver extends ImagePublicDriver {
   hasClass(className: string): Promise<boolean>;
   getWidthAttribute(): Promise<number>;
   getHeightAttribute(): Promise<number>;
+  getTagName(): Promise<string>;
 }
 
 const attributeToNumber = async (base, name) => Number(await base.attr(name));
@@ -20,5 +21,6 @@ export const mediaImageDriverFactory = (base: UniDriver): MediaImageDriver => {
     hasClass: className => base.hasClass(className),
     getWidthAttribute: () => attributeToNumber(base, 'width'),
     getHeightAttribute: () => attributeToNumber(base, 'height'),
+    getTagName: async () => (await base.getNative()).tagName,
   };
 };

--- a/packages/wix-ui-core/src/components/media-image/media-image.tsx
+++ b/packages/wix-ui-core/src/components/media-image/media-image.tsx
@@ -61,6 +61,8 @@ export interface MediaProps {
   scale?: MediaImageScaling;
   /** A class name to be applied on the root element */
   className?: string;
+  /** A reference to be passed to the native image element */
+  nativeRef?: React.Ref<HTMLImageElement>;
 }
 
 export class MediaImage extends React.Component<MediaProps> {
@@ -104,6 +106,7 @@ export class MediaImage extends React.Component<MediaProps> {
       className,
       width,
       height,
+      nativeRef,
     } = this.props;
 
     return (
@@ -113,6 +116,7 @@ export class MediaImage extends React.Component<MediaProps> {
         alt={alt}
         nativeProps={{ width, height }}
         errorImage={this.getImageSource(errorMediaPlatformItem)}
+        nativeRef={nativeRef}
         onLoad={onLoad}
         onError={onError}
       />


### PR DESCRIPTION
This PR exposes a `nativeRef` prop for Image & MediaImage instead of https://github.com/wix/wix-ui/pull/2037 which is problematic to verify and might affect current applications.

We also thought about exposing `onComplete` that "opt-in"s the logic but it's still hard to verify and actually might be confusing with the loading status... Because we need to expose the case that the image is completed but the loading status is still "loading".

Besides, I think it makes sense to expose a ref for such an atom component - similar to the ButtonNext case.