### PR TITLE
`react-autodocs-utils` pin babel parser version

### DIFF
--- a/packages/react-autodocs-utils/CHANGELOG.md
+++ b/packages/react-autodocs-utils/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Fixed** for any bug fixes.
 * **Security** in case of vulnerabilities.
 
+## [3.6.3] - 2021-02-23
+### Fixed
+- pin `@babel/core` & `@babel/parser` versions to fix parser failure for class components with static properties
+
 ## [3.6.2] - 2020-07-20
 ### Fixed
 - pin `react-docgen-typescript` to `1.18.0` - newer versions introduce issues [1e115a59](https://github.com/wix/react-autodocs-utils/commit/1e115a59)

--- a/packages/react-autodocs-utils/package.json
+++ b/packages/react-autodocs-utils/package.json
@@ -38,7 +38,8 @@
     "jest": "^24.8.0"
   },
   "dependencies": {
-    "@babel/parser": "^7.5.5",
+    "@babel/core": "7.11.4",
+    "@babel/parser": "7.11.4",
     "@babel/traverse": "^7.5.5",
     "@babel/types": "^7.5.5",
     "doctrine": "^3.0.0",

--- a/packages/react-autodocs-utils/package.json
+++ b/packages/react-autodocs-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autodocs-utils",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "Set of utilities for extracting meta information about react components mostly to generate automated documentation",
   "main": "index.js",
   "private": false,


### PR DESCRIPTION
the latest versions are causing us problems

in particular code like `static property = ...` within a `class` is
interpreted as `propertyDefinition`, which `ast-types` of `recast`
throws an error for.

pinning version is a workaround
