### PR TITLE
chore(button-next): add affix icon data hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "lerna": "^3.22.1"
+    "lerna": "^2.8.0"
   },
   "name": "wix-ui",
   "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "lerna": "^2.8.0"
+    "lerna": "^3.22.1"
   },
   "name": "wix-ui",
   "version": "1.0.0",

--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 
 import { st, classes } from './button-next.st.css';
+import { dataHooks } from './constants';
 import { isStatelessComponent } from '../../utils';
 
 export interface ButtonProps
@@ -25,10 +26,11 @@ export interface ButtonProps
   focusableOnBlur?(): void;
 }
 
-const _addAffix = (Affix, styleClass) =>
+const _addAffix = (Affix, styleClass, dataHook) =>
   Affix &&
   React.cloneElement(Affix, {
     className: classNames(classes[styleClass], Affix.props.className),
+    dataHook,
   });
 
 /**
@@ -78,14 +80,14 @@ class ButtonNextComponent extends React.Component<ButtonProps> {
         aria-disabled={disabled}
         className={st(classes.root, { disabled }, this.props.className)}
       >
-        {_addAffix(prefixIcon, 'prefix')}
+        {_addAffix(prefixIcon, 'prefix', dataHooks.prefixIcon)}
         <span
           className={st(classes.content, contentClassName)}
           ref={contentRef}
         >
           {children}
         </span>
-        {_addAffix(suffixIcon, 'suffix')}
+        {_addAffix(suffixIcon, 'suffix', dataHooks.suffixIcon)}
       </Component>
     );
   }

--- a/packages/wix-ui-core/src/components/button-next/button-next.uni.driver.ts
+++ b/packages/wix-ui-core/src/components/button-next/button-next.uni.driver.ts
@@ -3,6 +3,9 @@ import {
   baseUniDriverFactory,
 } from 'wix-ui-test-utils/base-driver';
 import { UniDriver } from 'wix-ui-test-utils/unidriver';
+import { dataHooks } from './constants';
+
+const byDataHook = dataHook => `[data-hook="${dataHook}"]`;
 
 export interface ButtonNextDriver extends BaseUniDriver {
   /** returns button text */
@@ -11,6 +14,10 @@ export interface ButtonNextDriver extends BaseUniDriver {
   isButtonDisabled(): Promise<boolean>;
   /** returns true if button focused */
   isFocused(): Promise<boolean>;
+  /** returns true if a prefix icon exists */
+  isPrefixIconExists(): Promise<boolean>;
+  /** returns true if a suffix icon exists */
+  isSuffixIconExists(): Promise<boolean>;
 }
 
 export const buttonNextDriverFactory = (base: UniDriver): ButtonNextDriver => ({
@@ -21,4 +28,7 @@ export const buttonNextDriverFactory = (base: UniDriver): ButtonNextDriver => ({
     //Using aria-disabled to know if button is disabled.
     return (await base.attr('aria-disabled')) === 'true';
   },
+  
+  isPrefixIconExists: async () => base.$(byDataHook(dataHooks.prefixIcon)).exists(),
+  isSuffixIconExists: async () => base.$(byDataHook(dataHooks.suffixIcon)).exists(),
 });

--- a/packages/wix-ui-core/src/components/button-next/constants.ts
+++ b/packages/wix-ui-core/src/components/button-next/constants.ts
@@ -1,0 +1,4 @@
+export enum dataHooks {
+  prefixIcon = 'prefix-icon',
+  suffixIcon = 'suffix-icon'
+}


### PR DESCRIPTION
Following this PR - https://github.com/wix/wix-style-react/pull/6831

This PR contains the following:
- add data hooks for button icon affixes
- expose methods that verifies affix icon existence in `unidriver`