### PR TITLE
Fix(button-next): dataHook -> data-hook

### DIFF
--- a/packages/wix-ui-core/src/components/button-next/button-next.tsx
+++ b/packages/wix-ui-core/src/components/button-next/button-next.tsx
@@ -30,7 +30,7 @@ const _addAffix = (Affix, styleClass, dataHook) =>
   Affix &&
   React.cloneElement(Affix, {
     className: classNames(classes[styleClass], Affix.props.className),
-    dataHook,
+    'data-hook': Affix.props['data-hook'] || Affix.props.dataHook || dataHook,
   });
 
 /**


### PR DESCRIPTION
Pass in a default `data-hook` attribute as a valid HTML attribute.
Also, make sure to enable consumers to override with their own `data-hook` or `dataHook` attributes.