### PR TITLE
move `@types/react` to devDeps & `@storybook/addons` to peerDeps

### DIFF
--- a/packages/wix-storybook-utils/package.json
+++ b/packages/wix-storybook-utils/package.json
@@ -45,6 +45,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
+  "peerDependencies": {
+    "@storybook/addons": "^5.0.0"
+  },
   "dependencies": {
     "@babel/core": "~7.11.0",
     "@babel/generator": "~7.11.0",
@@ -53,7 +56,6 @@
     "@babel/plugin-syntax-jsx": "^7.2.0",
     "@babel/traverse": "~7.11.0",
     "@babel/types": "~7.11.0",
-    "@storybook/addons": "^5.0.0",
     "babel-runtime": "^6.25.0",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",
@@ -73,13 +75,12 @@
     "react-remarkable": "^1.1.3",
     "react-syntax-highlighter": "^9.0.0",
     "react-tooltip": "^4.2.15",
-    "wix-ui-icons-common": "^2.0.311",
-    "@types/react": "^16.8.1",
-    "@types/react-dom": "^16.8.1"
+    "wix-ui-icons-common": "^2.0.311"
   },
   "devDependencies": {
     "@mdx-js/loader": "^0.17.3",
     "@storybook/addon-options": "^5.2.4",
+    "@storybook/addons": "^5.0.0",
     "@storybook/react": "^5.2.4",
     "@testing-library/react": "^11.2.5",
     "@types/jest": "^23.3.8",
@@ -102,7 +103,9 @@
     "typedoc": "^0.15.0",
     "typescript": "^3.1.3",
     "wix-ui-test-utils": "^1.0.120",
-    "yoshi-style-dependencies": "^4.11.1"
+    "yoshi-style-dependencies": "^4.11.1",
+    "@types/react": "^16.8.1",
+    "@types/react-dom": "^16.8.1"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
this should help consumers of wix-storybook-utils properly resolve
dependencies in monorepo environment