### PR TITLE
wix-storybook-utils: import codemirror style globally

### DIFF
--- a/packages/wix-storybook-utils/src/NewPlayground/index.js
+++ b/packages/wix-storybook-utils/src/NewPlayground/index.js
@@ -14,6 +14,7 @@ import 'codemirror/addon/hint/xml-hint';
 import debounce from 'lodash/debounce';
 
 import styles from '../LiveCodeExample/index.scss';
+import "./styles.global.scss";
 import { transformCode } from '../LiveCodeExample/doctor-code';
 
 import 'codemirror/lib/codemirror.css';

--- a/packages/wix-storybook-utils/src/NewPlayground/styles.global.scss
+++ b/packages/wix-storybook-utils/src/NewPlayground/styles.global.scss
@@ -1,0 +1,2 @@
+@import "~codemirror/lib/codemirror.css";
+@import "~codemirror/theme/neo.css";


### PR DESCRIPTION
using `.global.scss` extension disables css modules