### PR TITLE
Revert "Dropdown keyboard Accessibility - open with space key"

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -188,7 +188,6 @@ export class DropdownComponent extends React.PureComponent<
   }
 
   isClosingKey(key) {
-    // a comment to sign my commits
     return key === 'Tab' || key === 'Enter' || key === 'Escape';
   }
 

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -188,7 +188,7 @@ export class DropdownComponent extends React.PureComponent<
   }
 
   isClosingKey(key) {
-    return key === 'Tab' || key === 'Enter' || key === 'Escape' || key === ' ';
+    return key === 'Tab' || key === 'Enter' || key === 'Escape';
   }
 
   onKeyDown(evt: React.KeyboardEvent<HTMLElement>) {
@@ -203,8 +203,7 @@ export class DropdownComponent extends React.PureComponent<
         this.dropdownContentRef.onKeyDown(eventKey, evt);
 
       switch (eventKey) {
-        case 'Enter':
-        case ' ': {
+        case 'Enter': {
           this.onKeyboardSelect();
           const { multi } = this.props;
           !multi && this.close();

--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.tsx
@@ -188,6 +188,7 @@ export class DropdownComponent extends React.PureComponent<
   }
 
   isClosingKey(key) {
+    // a comment to sign my commits
     return key === 'Tab' || key === 'Enter' || key === 'Escape';
   }
 


### PR DESCRIPTION
Reverts wix/wix-ui#2077

Unfortunately, I have to revert this PR.
This component is used by the InputWithOption and the AdressInput components and these changes broke the behavior of these two-component.
On components that have input as a trigger element space shouldn't close the list.
We tried to find a quick fix but it seems like the current behavior of the component is very strange and there are no unit tests for the keyboard behavior so it is very hard to understand if we broke something.
I agree that we have to fix this behavior and that refactoring should be done here.
But these changes are required to do a lot of tests and we don't have the capacity for it at the moment.

@aarnoldaas - if it is a critical change for you then you could contribute it. If you are planning to do it please let us know before opening a PR. 