### PR TITLE
Popover a11y features

### DIFF
--- a/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
@@ -1,0 +1,75 @@
+import * as eventually from 'wix-eventually';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
+import { popoverTestkitFactory } from '../../testkit/protractor';
+import { browser, by, element, Key } from 'protractor';
+import { Category } from '../../../stories/utils';
+
+describe('Popover', () => {
+  const storyUrl = createStoryUrl({
+    kind: Category.TESTS,
+    story: 'Popover - A11Y',
+  });
+  const popoverDataHook = 'storybook-popover-a11y';
+
+  beforeEach(() => browser.get(storyUrl));
+
+  it('should call onPopoverBlur when tabbing out of the popover', async () => {
+    const driver = popoverTestkitFactory({ dataHook: popoverDataHook });
+    await waitForVisibilityOf(driver.element(), 'Cannot find Popover');
+
+    await eventually(async () => {
+      expect(await driver.isContentElementExists()).toBe(true);
+    });
+
+    await element(by.buttonText('Focus Input')).click();
+
+    expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(false);
+
+    const popoverContentElement = element(by.css['[role="dialog"]']);
+
+    popoverContentElement.sendKeys(Key.TAB);
+
+    expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(true);
+  });
+
+  it('should call onEscPress when popover is focused and esc is pressed', async () => {
+    const driver = popoverTestkitFactory({ dataHook: popoverDataHook });
+    await waitForVisibilityOf(driver.element(), 'Cannot find Popover');
+
+    await eventually(async () => {
+      expect(await driver.isContentElementExists()).toBe(true);
+    });
+
+    await element(by.buttonText('Focus Popover')).click();
+
+    expect(await element(by.id('escape-hook')).isDisplayed()).toBe(false);
+
+    const popoverContentElement = element(by.css['[role="dialog"]']);
+
+    popoverContentElement.sendKeys(Key.ESCAPE);
+
+    expect(await element(by.id('escape-hook')).isDisplayed()).toBe(true);
+  });
+
+  it('should call onEscPress when input in popover is focused and esc is pressed', async () => {
+    const driver = popoverTestkitFactory({ dataHook: popoverDataHook });
+    await waitForVisibilityOf(driver.element(), 'Cannot find Popover');
+
+    await eventually(async () => {
+      expect(await driver.isContentElementExists()).toBe(true);
+    });
+
+    await element(by.buttonText('Focus Input')).click();
+
+    expect(await element(by.id('escape-hook')).isDisplayed()).toBe(false);
+
+    const popoverContentElement = element(by.css['[role="dialog"]']);
+
+    popoverContentElement.sendKeys(Key.ESCAPE);
+
+    expect(await element(by.id('escape-hook')).isDisplayed()).toBe(true);
+  });
+});

--- a/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
@@ -16,7 +16,7 @@ describe('Popover', () => {
 
   beforeEach(() => browser.get(storyUrl));
 
-  it('should call onPopoverBlur when tabbing out of the popover', async () => {
+  it('should call onTabOut when tabbing out of the popover', async () => {
     const driver = popoverTestkitFactory({ dataHook: popoverDataHook });
     await waitForVisibilityOf(driver.element(), 'Cannot find Popover');
 
@@ -28,28 +28,13 @@ describe('Popover', () => {
 
     expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(false);
 
-    const popoverContentElement = element(by.css('[role="dialog"]'));
+    const nestedInputElement = element(by.css('[role="dialog"] input'));
 
-    popoverContentElement.sendKeys(Key.TAB);
-
-    expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(true);
-  });
-
-  it('should call onPopoverBlur when clicking outside of popover', async () => {
-    const driver = popoverTestkitFactory({ dataHook: popoverDataHook });
-    await waitForVisibilityOf(driver.element(), 'Cannot find Popover');
+    nestedInputElement.sendKeys(Key.TAB);
 
     await eventually(async () => {
-      expect(await driver.isContentElementExists()).toBe(true);
+      expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(true);
     });
-
-    await element(by.buttonText('Focus Input')).click();
-
-    expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(false);
-
-    await element(by.id('focus-catcher')).click();
-
-    expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(true);
   });
 
   it('should call onEscPress when popover is focused and esc is pressed', async () => {

--- a/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
+++ b/packages/wix-ui-core/src/components/popover/Popover.e2e.ts
@@ -28,9 +28,26 @@ describe('Popover', () => {
 
     expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(false);
 
-    const popoverContentElement = element(by.css['[role="dialog"]']);
+    const popoverContentElement = element(by.css('[role="dialog"]'));
 
     popoverContentElement.sendKeys(Key.TAB);
+
+    expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(true);
+  });
+
+  it('should call onPopoverBlur when clicking outside of popover', async () => {
+    const driver = popoverTestkitFactory({ dataHook: popoverDataHook });
+    await waitForVisibilityOf(driver.element(), 'Cannot find Popover');
+
+    await eventually(async () => {
+      expect(await driver.isContentElementExists()).toBe(true);
+    });
+
+    await element(by.buttonText('Focus Input')).click();
+
+    expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(false);
+
+    await element(by.id('focus-catcher')).click();
 
     expect(await element(by.id('blurred-hook')).isDisplayed()).toBe(true);
   });
@@ -47,7 +64,7 @@ describe('Popover', () => {
 
     expect(await element(by.id('escape-hook')).isDisplayed()).toBe(false);
 
-    const popoverContentElement = element(by.css['[role="dialog"]']);
+    const popoverContentElement = element(by.css('[role="dialog"]'));
 
     popoverContentElement.sendKeys(Key.ESCAPE);
 
@@ -66,7 +83,7 @@ describe('Popover', () => {
 
     expect(await element(by.id('escape-hook')).isDisplayed()).toBe(false);
 
-    const popoverContentElement = element(by.css['[role="dialog"]']);
+    const popoverContentElement = element(by.css('[role="dialog"]'));
 
     popoverContentElement.sendKeys(Key.ESCAPE);
 

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -17,1093 +17,1134 @@ import { classes } from './Popover.st.css';
 import { PopoverNext } from '../popover-next/popover-next';
 
 function delay(millis: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, millis));
+  return new Promise(resolve => setTimeout(resolve, millis));
 }
 
 const renderPopover = (props: PopoverProps, content: string = 'Content') => (
-    <Popover {...props}>
-        <Popover.Element>
-            <div>Element</div>
-        </Popover.Element>
-        <Popover.Content>
-            <div>{content}</div>
-        </Popover.Content>
-    </Popover>
+  <Popover {...props}>
+    <Popover.Element>
+      <div>Element</div>
+    </Popover.Element>
+    <Popover.Content>
+      <div>{content}</div>
+    </Popover.Content>
+  </Popover>
 );
 
 const renderPopoverNext = (
-    props: PopoverProps,
-    content: string = 'Content',
+  props: PopoverProps,
+  content: string = 'Content',
 ) => (
-    <PopoverNext {...props}>
-        <PopoverNext.Element>
-            <div>Element</div>
-        </PopoverNext.Element>
-        <PopoverNext.Content>
-            <div>{content}</div>
-        </PopoverNext.Content>
-    </PopoverNext>
+  <PopoverNext {...props}>
+    <PopoverNext.Element>
+      <div>Element</div>
+    </PopoverNext.Element>
+    <PopoverNext.Content>
+      <div>{content}</div>
+    </PopoverNext.Content>
+  </PopoverNext>
 );
 
 describe('Popover && PopoverNext', () => {
-    const container = new ReactDOMTestContainer().unmountAfterEachTest();
+  const container = new ReactDOMTestContainer().unmountAfterEachTest();
 
-    const regularDriver = container.createLegacyRenderer(
-        popoverPrivateDriverFactory,
-    );
+  const regularDriver = container.createLegacyRenderer(
+    popoverPrivateDriverFactory,
+  );
 
-    const uniDriver = container.createUniRendererAsync((base, body) => {
-        const privateDriver = popoverPrivateDriverFactory({
-            element: container.componentNode,
-            eventTrigger: Simulate,
-        });
-
-        return {
-            ...privateDriver,
-            ...testkit(base, body),
-        };
+  const uniDriver = container.createUniRendererAsync((base, body) => {
+    const privateDriver = popoverPrivateDriverFactory({
+      element: container.componentNode,
+      eventTrigger: Simulate,
     });
 
-    describe('[sync] Popover', () => {
-        runTests(regularDriver, container, renderPopover, Popover);
-    });
+    return {
+      ...privateDriver,
+      ...testkit(base, body),
+    };
+  });
 
-    describe('[async] Popover', () => {
-        runTests(uniDriver, container, renderPopover, Popover);
-    });
+  describe('[sync] Popover', () => {
+    runTests(regularDriver, container, renderPopover, Popover);
+  });
 
-    describe('[sync] PopoverNext', () => {
-        runTests(regularDriver, container, renderPopoverNext, PopoverNext, true);
-    });
+  describe('[async] Popover', () => {
+    runTests(uniDriver, container, renderPopover, Popover);
+  });
 
-    describe('[async] PopoverNext', () => {
-        runTests(uniDriver, container, renderPopoverNext, PopoverNext, true);
-    });
+  describe('[sync] PopoverNext', () => {
+    runTests(regularDriver, container, renderPopoverNext, PopoverNext, true);
+  });
+
+  describe('[async] PopoverNext', () => {
+    runTests(uniDriver, container, renderPopoverNext, PopoverNext, true);
+  });
 });
 
-function runTests(createDriver, container, popoverWithProps, Component, isPopoverNext = false) {
-    it('should render', async () => {
+function runTests(
+  createDriver,
+  container,
+  popoverWithProps,
+  Component,
+  isPopoverNext = false,
+) {
+  it('should render', async () => {
+    const driver = await createDriver(
+      popoverWithProps({
+        placement: 'bottom',
+        shown: false,
+      }),
+    );
+
+    expect(await driver.exists()).toBe(true);
+  });
+
+  describe('Display', () => {
+    it(`doesn't display popup when shown={false}`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: false,
+        }),
+      );
+
+      expect(await driver.isTargetElementExists()).toBe(true);
+      expect(await driver.isContentElementExists()).toBe(false);
+    });
+
+    it(`displays popup when shown={true}`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: true,
+        }),
+      );
+
+      await eventually(async () => {
+        expect(await driver.isContentElementExists()).toBe(true);
+      });
+    });
+  });
+
+  describe('Events', () => {
+    it(`calls mouseEnter and mouseLeave callbacks`, async () => {
+      const onMouseEnter = jest.fn();
+      const onMouseLeave = jest.fn();
+
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: false,
+          onMouseEnter,
+          onMouseLeave,
+        }),
+      );
+
+      await driver.mouseEnter();
+      expect(onMouseEnter).toHaveBeenCalled();
+
+      await driver.mouseLeave();
+      expect(onMouseLeave).toBeCalled();
+    });
+
+    describe('onClick', () => {
+      it('should execute onClick callback', async () => {
+        const onClick = jest.fn();
+
         const driver = await createDriver(
-            popoverWithProps({
-                placement: 'bottom',
-                shown: false,
-            }),
+          popoverWithProps({
+            placement: 'bottom',
+            shown: false,
+            onClick,
+          }),
         );
 
-        expect(await driver.exists()).toBe(true);
+        await driver.click();
+        expect(onClick).toBeCalled();
+      });
     });
 
-    describe('Display', () => {
-        it(`doesn't display popup when shown={false}`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: false,
-                }),
-            );
-
-            expect(await driver.isTargetElementExists()).toBe(true);
-            expect(await driver.isContentElementExists()).toBe(false);
-        });
-
-        it(`displays popup when shown={true}`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: true,
-                }),
-            );
-
-            await eventually(async () => {
-                expect(await driver.isContentElementExists()).toBe(true);
-            });
-        });
-    });
-
-    describe('Events', () => {
-        it(`calls mouseEnter and mouseLeave callbacks`, async () => {
-            const onMouseEnter = jest.fn();
-            const onMouseLeave = jest.fn();
-
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: false,
-                    onMouseEnter,
-                    onMouseLeave,
-                }),
-            );
-
-            await driver.mouseEnter();
-            expect(onMouseEnter).toHaveBeenCalled();
-
-            await driver.mouseLeave();
-            expect(onMouseLeave).toBeCalled();
-        });
-
-        describe('onClick', () => {
-            it('should execute onClick callback', async () => {
-                const onClick = jest.fn();
-
-                const driver = await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: false,
-                        onClick,
-                    }),
-                );
-
-                await driver.click();
-                expect(onClick).toBeCalled();
-            });
-        });
-
-        describe('onClickOutside', () => {
-            it('should be triggered when outside of the popover is called', async () => {
-                const onClickOutside = jest.fn();
-
-                const driver = await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: true,
-                        onClickOutside,
-                    }),
-                );
-
-                await driver.clickOutside();
-                await eventually(async () => {
-                    expect(onClickOutside).toBeCalled();
-                });
-            });
-
-            it('should not trigger onClickOutside when clicking inside with an excluded class', async () => {
-                const onClickOutside = jest.fn();
-
-                const driver = await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: false,
-                        onClickOutside,
-                        excludeClass: 'excludeClass',
-                    }),
-                );
-
-                await driver.click();
-                expect(onClickOutside).not.toBeCalled();
-            });
-        });
-
-        describe('onClickOutside + disableClickOutsideWhenClosed', () => {
-            it('should be triggered when outside of the popover is called', async () => {
-                const onClickOutside = jest.fn();
-
-                const driver = await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: true,
-                        onClickOutside,
-                        disableClickOutsideWhenClosed: true,
-                    }),
-                );
-
-                await eventually(async () => {
-                    await driver.isContentElementExists();
-                });
-
-                await driver.clickOutside();
-
-                expect(onClickOutside).toBeCalled();
-            });
-
-            it('should *not* be triggered when outside of the popover is called and the popover is *not* shown', async () => {
-                const onClickOutside = jest.fn();
-
-                const driver = await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: false,
-                        onClickOutside,
-                        disableClickOutsideWhenClosed: true,
-                    }),
-                );
-
-                await driver.clickOutside();
-                expect(onClickOutside).not.toBeCalled();
-            });
-
-            const appendToValues: AppendTo[] = [
-                'parent',
-                'window',
-                'viewport',
-                'scrollParent',
-            ];
-            appendToValues.map(value => {
-                it(`should not be triggered when content is clicked and appended to ${value}`, async () => {
-                    const onClickOutside = jest.fn();
-
-                    const driver = await createDriver(
-                        popoverWithProps({
-                            placement: 'bottom',
-                            shown: true,
-                            onClickOutside,
-                            appendTo: value,
-                        }),
-                    );
-
-                    await eventually(async () => {
-                        await driver.isContentElementExists();
-                    });
-
-                    await driver.clickOnContent();
-                    expect(onClickOutside).not.toBeCalled();
-                });
-            });
-        });
-    });
-
-    describe('Position', () => {
-        let updatePositionSpy;
-
-        beforeEach(() => {
-            updatePositionSpy = jest.spyOn(Component.prototype, 'updatePosition');
-        });
-
-        afterEach(() => {
-            updatePositionSpy.mockRestore();
-        });
-
-        it(`offsets the popup arrow by specified amount`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: true,
-                    showArrow: true,
-                    moveArrowTo: 10,
-                }),
-            );
-
-            await eventually(async () => {
-                expect((await driver.getArrowOffset()).left).toBe('10px');
-            });
-        });
-
-        it(`should update popper's position when props are chaning`, async () => {
-            await createDriver(
-                popoverWithProps(
-                    {
-                        placement: 'bottom',
-                        shown: true,
-                    },
-                    'Old Content!',
-                ),
-            );
-
-            await createDriver(
-                popoverWithProps(
-                    {
-                        placement: 'bottom',
-                        shown: true,
-                    },
-                    'New content!',
-                ),
-            );
-
-            // Should have been called for each update
-            expect(updatePositionSpy).toHaveBeenCalledTimes(2);
-        });
-
-        it(`should not directly update popper's position when the visibillity hasn't changed`, async () => {
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    showDelay: 10,
-                    shown: false,
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    showDelay: 10,
-                    shown: true,
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    showDelay: 10,
-                    shown: false,
-                }),
-            );
-
-            expect(updatePositionSpy).toHaveBeenCalledTimes(1);
-        });
-    });
-
-    describe('Animation and delay', () => {
-        // Since Popover.Content can render outside the component's root, let's query
-        // the entire document with the assumption that we don't render more than one
-        // popover at a time.
-        const queryPopoverContent = () =>
-            queryHook<HTMLElement>(document, 'popover-content');
-
-        it('animates on close given a timeout', async () => {
-            await createDriver(
-                popoverWithProps({ placement: 'bottom', shown: true, timeout: 10 }),
-            );
-
-            await createDriver(
-                popoverWithProps({ placement: 'bottom', shown: false, timeout: 10 }),
-            );
-
-            expect(queryPopoverContent()).toBeTruthy();
-            await eventually(
-                () => {
-                    expect(queryPopoverContent()).toBeNull();
-                },
-                { interval: 1 },
-            );
-        });
-
-        it(`doesn't animate on close when timeout={0}`, async () => {
-            await createDriver(
-                popoverWithProps({ placement: 'bottom', shown: true, timeout: 0 }),
-            );
-
-            await createDriver(
-                popoverWithProps({ placement: 'bottom', shown: false, timeout: 0 }),
-            );
-
-            expect(queryPopoverContent()).toBeNull();
-        });
-
-        it(`doesn't animate on close when timeout is an object with 0 values`, async () => {
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: true,
-                    timeout: { enter: 0, exit: 0 },
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: false,
-                    timeout: { enter: 0, exit: 0 },
-                }),
-            );
-
-            expect(queryPopoverContent()).toBeNull();
-        });
-
-        it(`should close after hideDelay`, async () => {
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    shown: true,
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    shown: false,
-                }),
-            );
-
-            expect(queryPopoverContent()).toBeTruthy();
-            await eventually(
-                () => {
-                    expect(queryPopoverContent()).toBeNull();
-                },
-                { interval: 10 },
-            );
-        });
-
-        it(`should open after showDelay`, async () => {
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    showDelay: 10,
-                    shown: false,
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    showDelay: 10,
-                    shown: true,
-                }),
-            );
-
-            expect(queryPopoverContent()).toBeNull();
-            await eventually(
-                () => {
-                    expect(queryPopoverContent()).toBeTruthy();
-                },
-                { interval: 10 },
-            );
-        });
-
-        it(`should reset timeout when state has changed`, async () => {
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    showDelay: 10,
-                    shown: false,
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    showDelay: 10,
-                    shown: true,
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    showDelay: 10,
-                    shown: false,
-                }),
-            );
-
-            expect(queryPopoverContent()).toBeNull();
-            await delay(15);
-            expect(queryPopoverContent()).toBeNull();
-        });
-
-        it(`should not update delay until the popover visibillity has fully changed`, async () => {
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    shown: true,
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 10,
-                    shown: false,
-                }),
-            );
-
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 1000,
-                    shown: false,
-                }),
-            );
-
-            expect(queryPopoverContent()).toBeTruthy();
-
-            // Making sure the popover is closed after the first `hideDelay` (10ms), and not the second
-            // one (1000ms)
-            await delay(10);
-            expect(queryPopoverContent()).toBeNull();
-        });
-
-        it(`should show the popover immediately on first render if needed`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    showDelay: 10,
-                    shown: true,
-                }),
-            );
-
-            await eventually(async () => {
-                expect(await driver.isContentElementExists()).toBe(true);
-            });
-        });
-
-        it(`should show the popover immediately when delays are 0`, async () => {
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 0,
-                    showDelay: 0,
-                    shown: false,
-                }),
-            );
-
-            expect(queryPopoverContent()).toBeNull();
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 0,
-                    showDelay: 0,
-                    shown: true,
-                }),
-            );
-
-            await eventually(async () => {
-                expect(queryPopoverContent()).toBeTruthy();
-            });
-
-            // Close again the popover
-            await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    hideDelay: 0,
-                    showDelay: 0,
-                    shown: false,
-                }),
-            );
-
-            expect(queryPopoverContent()).toBeNull();
-        });
-    });
-
-    describe('Portal and containment', () => {
-        const portalContainer = new ReactDOMTestContainer().destroyAfterEachTest();
-
-        it(`renders the popup directly into the popover root by default`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: true,
-                }),
-            );
-            await eventually(async () => {
-                expect((await driver.getContentElement()).parentElement).toBe(
-                    container.componentNode,
-                );
-            });
-        });
-
-        it(`renders the popup into a portal when given appendTo prop`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: true,
-                    appendTo: portalContainer.node,
-                }),
-            );
-
-            await eventually(async () => {
-                expect((await driver.getContentElement()).parentElement).toBe(
-                    await driver.getPortalElement(),
-                );
-            });
-
-            expect((await driver.getPortalElement()).parentElement).toBe(
-                portalContainer.node,
-            );
-            expect((await driver.getPortalElement()).classList).toContain(
-                classes.root,
-            );
-        });
-
-        it(`renders an empty portal when closed`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: false,
-                    appendTo: portalContainer.node,
-                }),
-            );
-
-            await eventually(async () => {
-                expect(await driver.getContentElement()).toBeNull();
-            });
-
-            expect((await driver.getPortalElement()).parentElement).toBe(
-                portalContainer.node,
-            );
-            expect((await driver.getPortalElement()).classList).not.toContain(
-                classes.root,
-            );
-        });
-
-        it(`removes the portal on unmount`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: true,
-                    appendTo: portalContainer.node,
-                }),
-            );
-
-            expect(await driver.getPortalElement()).toBeTruthy();
-            container.unmount();
-            expect(await driver.getPortalElement()).toBeNull();
-        });
-
-        it(`adds the portal to the body when appendTo="window"`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: true,
-                    appendTo: 'window',
-                }),
-            );
-
-            expect((await driver.getPortalElement()).parentElement).toBe(
-                document.body,
-            );
-        });
-
-        it(`adds the portal to the closest scrollable element when appendTo="scrollParent"`, async () => {
-            const driver = await createDriver(
-                <div style={{ overflow: 'scroll' }}>
-                    <div style={{ overflow: 'visible' }}>
-                        {popoverWithProps({
-                            placement: 'bottom',
-                            appendTo: 'scrollParent',
-                            shown: true,
-                        })}
-                    </div>
-                </div>,
-            );
-
-            expect((await driver.getPortalElement()).parentElement).toBe(
-                container.node.firstChild,
-            );
-        });
-
-        it(`adds the portal next to the popover's element when appendTo="parent"`, async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    placement: 'bottom',
-                    shown: true,
-                    appendTo: 'parent',
-                }),
-            );
-
-            await eventually(async () => {
-                expect(await driver.getContentElement().parentElement).toBe(
-                    await driver.getTargetElement().parentElement,
-                );
-            });
-        });
-
-        describe('portal styles', () => {
-            const queryPopoverPortal = () =>
-                queryHook<HTMLElement>(document, 'popover-portal');
-            const queryPopoverContent = () =>
-                queryHook<HTMLElement>(document, 'popover-content');
-
-            it(`should update the portal's styles when updated`, async () => {
-                // First render without passing the `className` prop, the <Popover/>
-                // portal should only have the root class applied.
-                await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: true,
-                        appendTo: portalContainer.node,
-                    }),
-                );
-
-                // Second render with a `className` prop. Stylable `style()` function
-                // should apply it.
-                await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: true,
-                        appendTo: portalContainer.node,
-                        className: 'some-class',
-                    }),
-                );
-
-                expect(queryPopoverPortal().classList).toContain('some-class');
-            });
-
-            it(`should not remove styles until unmounted with hideDelay`, async () => {
-                await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: true,
-                        hideDelay: 10,
-                        appendTo: portalContainer.node,
-                    }),
-                );
-
-                await createDriver(
-                    popoverWithProps({
-                        placement: 'bottom',
-                        shown: false,
-                        hideDelay: 10,
-                        appendTo: portalContainer.node,
-                    }),
-                );
-
-                expect(queryPopoverPortal()).toBeTruthy();
-                expect(queryPopoverPortal().classList).toContain(classes.root);
-
-                await delay(10);
-                expect(queryPopoverPortal().classList).not.toContain(classes.root);
-            });
-
-            it(`should add contentClassName to the popover content if passed`, async () => {
-                const contentClassName = 'some-content-classname';
-
-                await createDriver(
-                    popoverWithProps({
-                        shown: true,
-                        appendTo: portalContainer.node,
-                        contentClassName,
-                    }),
-                );
-
-                await createDriver(
-                    popoverWithProps({
-                        shown: true,
-                        appendTo: portalContainer.node,
-                        contentClassName,
-                    }),
-                );
-
-                expect(queryPopoverContent()).toBeTruthy();
-                expect(queryPopoverContent().classList).toContain(contentClassName);
-            });
-        });
-    });
-
-    describe('React <16 compatibility', () => {
-        it('should wrap children in a <div/> if provided as strings to support React 15', async () => {
-            const driver = await createDriver(
-                <Component shown placement="bottom">
-                    <Component.Element>Element</Component.Element>
-                    <Component.Content>Content</Component.Content>
-                </Component>,
-            );
-
-            expect((await driver.getTargetElement()).childNodes[0].nodeName).toEqual(
-                'DIV',
-            );
-
-            await eventually(async () => {
-                expect(
-                    (await driver.getContentElement()).childNodes[0].nodeName,
-                ).toEqual('DIV');
-            });
-        });
-    });
-
-    describe('createModifiers', () => {
-        const defaultProps = {
-            width: undefined,
-            moveBy: undefined,
-            minWidth: undefined,
-            dynamicWidth: undefined,
-            appendTo: undefined,
-            shouldAnimate: false,
-            flip: true,
-            fixed: false,
+    describe('onClickOutside', () => {
+      it('should be triggered when outside of the popover is called', async () => {
+        const onClickOutside = jest.fn();
+
+        const driver = await createDriver(
+          popoverWithProps({
             placement: 'bottom',
-            isTestEnv: false,
-        };
+            shown: true,
+            onClickOutside,
+          }),
+        );
 
-        it('should match default modifiers', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-            });
-
-            expect(modifiers).toEqual({
-                offset: {
-                    offset: '0px, 0px',
-                },
-                computeStyle: {
-                    gpuAcceleration: true,
-                },
-                flip: {
-                    enabled: true,
-                },
-                preventOverflow: {
-                    enabled: true,
-                },
-                hide: {
-                    enabled: true,
-                },
-            });
+        await driver.clickOutside();
+        await eventually(async () => {
+          expect(onClickOutside).toBeCalled();
         });
+      });
 
-        it('should calculate the offset properly using moveBy for the top placement', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                moveBy: { x: 5, y: 10 },
-                placement: 'top',
-            });
+      it('should not trigger onClickOutside when clicking inside with an excluded class', async () => {
+        const onClickOutside = jest.fn();
 
-            expect(modifiers.offset.offset).toEqual('5px, 10px');
-        });
+        const driver = await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: false,
+            onClickOutside,
+            excludeClass: 'excludeClass',
+          }),
+        );
 
-        it('should calculate the offset properly using moveBy for the right placement', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                moveBy: { x: 5, y: 10 },
-                placement: 'right',
-            });
-
-            expect(modifiers.offset.offset).toEqual('10px, 5px');
-        });
-
-        it('should disable gpuAcceleration when animation is enabled', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                shouldAnimate: true,
-            });
-
-            expect(modifiers.computeStyle.gpuAcceleration).toEqual(false);
-        });
-
-        it('should disable the flip modifier if moveBy was provided', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                moveBy: { x: 5, y: 10 },
-                flip: undefined,
-            });
-
-            expect(modifiers.flip.enabled).toEqual(false);
-        });
-
-        it('should enabled the flip modifier is set explicitly regardless of moveBy', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                moveBy: { x: 5, y: 10 },
-                flip: true,
-            });
-
-            expect(modifiers.flip.enabled).toEqual(true);
-        });
-
-        it('should disable the flip modifier when set explicitly', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                flip: false,
-            });
-
-            expect(modifiers.flip.enabled).toEqual(false);
-        });
-
-        it('should disable `preventOverflow` and `hide` when fixed set to `true`', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                fixed: true,
-            });
-
-            expect(modifiers.preventOverflow.enabled).toEqual(false);
-            expect(modifiers.hide.enabled).toEqual(false);
-        });
-
-        it('should disable computeStyle when isTestEnv is set to `true`', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                isTestEnv: true,
-            });
-
-            expect(modifiers.computeStyle.enabled).toEqual(false);
-        });
-
-        it('should set boundariesElement when appendTo is provided', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                appendTo: 'viewport',
-            });
-
-            expect(modifiers.preventOverflow.boundariesElement).toEqual('viewport');
-        });
-
-        it('should enable setPopperWidth [when] given minWidth ', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                minWidth: '500px',
-            });
-
-            expect(modifiers.setPopperWidth.enabled).toEqual(true);
-        });
-
-        it('should enable setPopperWidth [when] given dynamicWidth ', async () => {
-            const modifiers = createModifiers({
-                ...defaultProps,
-                dynamicWidth: true,
-            });
-
-            expect(modifiers.setPopperWidth.enabled).toEqual(true);
-        });
+        await driver.click();
+        expect(onClickOutside).not.toBeCalled();
+      });
     });
 
-    describe('data-hook', () => {
-        it('should be found on target element container', async () => {
-            const driver = await createDriver(
-                <Component
-                    data-hook="random"
-                    appendTo="window"
-                    shown
-                    placement="bottom"
-                >
-                    <Component.Element>Element</Component.Element>
-                    <Component.Content>Content</Component.Content>
-                </Component>,
-            );
-            const target = await driver.getTargetElement();
-            expect(target.parentNode.getAttribute('data-hook')).toBe('random');
+    describe('onClickOutside + disableClickOutsideWhenClosed', () => {
+      it('should be triggered when outside of the popover is called', async () => {
+        const onClickOutside = jest.fn();
+
+        const driver = await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: true,
+            onClickOutside,
+            disableClickOutsideWhenClosed: true,
+          }),
+        );
+
+        await eventually(async () => {
+          await driver.isContentElementExists();
         });
 
-        it('should construct data-content-hook', async () => {
-            const driver = await createDriver(
-                <Component
-                    data-hook="random"
-                    appendTo="window"
-                    shown
-                    placement="bottom"
-                >
-                    <Component.Element>Element</Component.Element>
-                    <Component.Content>Content</Component.Content>
-                </Component>,
-            );
-            const target = await driver.getTargetElement();
-            expect(target.parentNode.getAttribute('data-content-hook')).toMatch(
-                /popover-content-random-/,
-            );
-        });
+        await driver.clickOutside();
 
-        it('should apply data-content-element on content element', async () => {
-            const driver = await createDriver(
-                <Component
-                    data-hook="random"
-                    appendTo="window"
-                    shown
-                    placement="bottom"
-                >
-                    <Component.Element>Element</Component.Element>
-                    <Component.Content>Content</Component.Content>
-                </Component>,
-            );
-            await eventually(async () => {
-                expect(await driver.isContentElementExists()).toBe(true);
-            });
-            const content = await driver.getContentElement();
-            expect(content.getAttribute('data-content-element')).toMatch(
-                /popover-content-random-/,
-            );
+        expect(onClickOutside).toBeCalled();
+      });
+
+      it('should *not* be triggered when outside of the popover is called and the popover is *not* shown', async () => {
+        const onClickOutside = jest.fn();
+
+        const driver = await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: false,
+            onClickOutside,
+            disableClickOutsideWhenClosed: true,
+          }),
+        );
+
+        await driver.clickOutside();
+        expect(onClickOutside).not.toBeCalled();
+      });
+
+      const appendToValues: AppendTo[] = [
+        'parent',
+        'window',
+        'viewport',
+        'scrollParent',
+      ];
+      appendToValues.map(value => {
+        it(`should not be triggered when content is clicked and appended to ${value}`, async () => {
+          const onClickOutside = jest.fn();
+
+          const driver = await createDriver(
+            popoverWithProps({
+              placement: 'bottom',
+              shown: true,
+              onClickOutside,
+              appendTo: value,
+            }),
+          );
+
+          await eventually(async () => {
+            await driver.isContentElementExists();
+          });
+
+          await driver.clickOnContent();
+          expect(onClickOutside).not.toBeCalled();
         });
-        it('should not override portal component data-hook', async () => {
-            const driver = await createDriver(
-                <Component
-                    data-hook="random"
-                    appendTo="window"
-                    shown
-                    placement="bottom"
-                >
-                    <Component.Element>Element</Component.Element>
-                    <Component.Content>Content</Component.Content>
-                </Component>,
-            );
-            await eventually(async () => {
-                expect(await driver.isContentElementExists()).toBe(true);
-            });
-            const content = await driver.getContentElement();
-            expect(content.parentNode.getAttribute('data-hook')).toBe(
-                'popover-portal',
-            );
-        });
+      });
+    });
+  });
+
+  describe('Position', () => {
+    let updatePositionSpy;
+
+    beforeEach(() => {
+      updatePositionSpy = jest.spyOn(Component.prototype, 'updatePosition');
     });
 
-    describe('Arrow', () => {
-        function customArrow(placement, arrowProps) {
-            return <p data-test={`custom-arrow-${placement}`} {...arrowProps} />;
-        }
-
-        it('should display a custom arrow element', async () => {
-            const driver = await createDriver(
-                popoverWithProps({
-                    shown: true,
-                    showArrow: true,
-                    placement: 'top',
-                    customArrow,
-                }),
-            );
-
-            await eventually(async () => {
-                expect(await driver.isContentElementExists()).toBe(true);
-            });
-
-            const arrowElement = await driver.getArrowElement();
-            expect(arrowElement.getAttribute('data-test')).toBe('custom-arrow-top');
-        });
+    afterEach(() => {
+      updatePositionSpy.mockRestore();
     });
 
-    if (!isPopoverNext) {
-        describe('tabIndex', () => {
-            let popoverWrapper;
+    it(`offsets the popup arrow by specified amount`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: true,
+          showArrow: true,
+          moveArrowTo: 10,
+        }),
+      );
 
-            afterEach(() => {
-                popoverWrapper.unmount();
-            });
+      await eventually(async () => {
+        expect((await driver.getArrowOffset()).left).toBe('10px');
+      });
+    });
 
-            it('can focus content element when tabIndex = true', async () => {
-                const role = 'someRoleValue';
-                popoverWrapper = mount(popoverWithProps({
-                    shown: true,
-                    tabIndex: -1,
-                    role,
-                }))
+    it(`should update popper's position when props are chaning`, async () => {
+      await createDriver(
+        popoverWithProps(
+          {
+            placement: 'bottom',
+            shown: true,
+          },
+          'Old Content!',
+        ),
+      );
 
-                // @ts-ignore
-                popoverWrapper.instance().focus()
+      await createDriver(
+        popoverWithProps(
+          {
+            placement: 'bottom',
+            shown: true,
+          },
+          'New content!',
+        ),
+      );
 
-                expect(document.activeElement.getAttribute('role')).toBe(role);
-            });
+      // Should have been called for each update
+      expect(updatePositionSpy).toHaveBeenCalledTimes(2);
+    });
 
-            it("can't focus content element without tabIndex", async () => {
-                const role = 'someRoleValue';
-                popoverWrapper = mount(popoverWithProps({
-                    shown: true,
-                    role,
-                }))
+    it(`should not directly update popper's position when the visibillity hasn't changed`, async () => {
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          showDelay: 10,
+          shown: false,
+        }),
+      );
 
-                // @ts-ignore
-                popoverWrapper.instance().focus()
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          showDelay: 10,
+          shown: true,
+        }),
+      );
 
-                expect(document.activeElement.getAttribute('role')).not.toBe(role);
-            });
-        });
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          showDelay: 10,
+          shown: false,
+        }),
+      );
 
-        describe('contentAriaAttrs', () => {
-            it('should pass aria attrs to content wrapper', async () => {
-                const role = 'someRole'
-                const ariaAttrs = {
-                    ['aria-label']: 'someAriaLabel',
-                    ['aria-labelledby']: 'someAriaLabelledby',
-                    ['aria-describedby']: 'someAriaDescribedby',
-                }
-                const driver = await createDriver(
-                    popoverWithProps({
-                        shown: true,
-                        role,
-                        ...ariaAttrs
-                    }),
-                );
+      expect(updatePositionSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 
-                await eventually(async () => {
-                    expect(await driver.isContentElementExists()).toBe(true);
-                });
+  describe('Animation and delay', () => {
+    // Since Popover.Content can render outside the component's root, let's query
+    // the entire document with the assumption that we don't render more than one
+    // popover at a time.
+    const queryPopoverContent = () =>
+      queryHook<HTMLElement>(document, 'popover-content');
 
-                const contentElement = await driver.getContentElement();
-                const contentWrapper = contentElement.querySelector(`[role="${role}"]`);
+    it('animates on close given a timeout', async () => {
+      await createDriver(
+        popoverWithProps({ placement: 'bottom', shown: true, timeout: 10 }),
+      );
 
-                for (const [ariaAttr, ariaAttrValue] of Object.entries(ariaAttrs)) {
-                    expect(contentWrapper.getAttribute(ariaAttr)).toBe(ariaAttrValue);
-                }
-            })
-        });
+      await createDriver(
+        popoverWithProps({ placement: 'bottom', shown: false, timeout: 10 }),
+      );
+
+      expect(queryPopoverContent()).toBeTruthy();
+      await eventually(
+        () => {
+          expect(queryPopoverContent()).toBeNull();
+        },
+        { interval: 1 },
+      );
+    });
+
+    it(`doesn't animate on close when timeout={0}`, async () => {
+      await createDriver(
+        popoverWithProps({ placement: 'bottom', shown: true, timeout: 0 }),
+      );
+
+      await createDriver(
+        popoverWithProps({ placement: 'bottom', shown: false, timeout: 0 }),
+      );
+
+      expect(queryPopoverContent()).toBeNull();
+    });
+
+    it(`doesn't animate on close when timeout is an object with 0 values`, async () => {
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: true,
+          timeout: { enter: 0, exit: 0 },
+        }),
+      );
+
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: false,
+          timeout: { enter: 0, exit: 0 },
+        }),
+      );
+
+      expect(queryPopoverContent()).toBeNull();
+    });
+
+    it(`should close after hideDelay`, async () => {
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          shown: true,
+        }),
+      );
+
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          shown: false,
+        }),
+      );
+
+      expect(queryPopoverContent()).toBeTruthy();
+      await eventually(
+        () => {
+          expect(queryPopoverContent()).toBeNull();
+        },
+        { interval: 10 },
+      );
+    });
+
+    it(`should open after showDelay`, async () => {
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          showDelay: 10,
+          shown: false,
+        }),
+      );
+
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          showDelay: 10,
+          shown: true,
+        }),
+      );
+
+      expect(queryPopoverContent()).toBeNull();
+      await eventually(
+        () => {
+          expect(queryPopoverContent()).toBeTruthy();
+        },
+        { interval: 10 },
+      );
+    });
+
+    it(`should reset timeout when state has changed`, async () => {
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          showDelay: 10,
+          shown: false,
+        }),
+      );
+
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          showDelay: 10,
+          shown: true,
+        }),
+      );
+
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          showDelay: 10,
+          shown: false,
+        }),
+      );
+
+      expect(queryPopoverContent()).toBeNull();
+      await delay(15);
+      expect(queryPopoverContent()).toBeNull();
+    });
+
+    it(`should not update delay until the popover visibillity has fully changed`, async () => {
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          shown: true,
+        }),
+      );
+
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 10,
+          shown: false,
+        }),
+      );
+
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 1000,
+          shown: false,
+        }),
+      );
+
+      expect(queryPopoverContent()).toBeTruthy();
+
+      // Making sure the popover is closed after the first `hideDelay` (10ms), and not the second
+      // one (1000ms)
+      await delay(10);
+      expect(queryPopoverContent()).toBeNull();
+    });
+
+    it(`should show the popover immediately on first render if needed`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          showDelay: 10,
+          shown: true,
+        }),
+      );
+
+      await eventually(async () => {
+        expect(await driver.isContentElementExists()).toBe(true);
+      });
+    });
+
+    it(`should show the popover immediately when delays are 0`, async () => {
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 0,
+          showDelay: 0,
+          shown: false,
+        }),
+      );
+
+      expect(queryPopoverContent()).toBeNull();
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 0,
+          showDelay: 0,
+          shown: true,
+        }),
+      );
+
+      await eventually(async () => {
+        expect(queryPopoverContent()).toBeTruthy();
+      });
+
+      // Close again the popover
+      await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          hideDelay: 0,
+          showDelay: 0,
+          shown: false,
+        }),
+      );
+
+      expect(queryPopoverContent()).toBeNull();
+    });
+  });
+
+  describe('Portal and containment', () => {
+    const portalContainer = new ReactDOMTestContainer().destroyAfterEachTest();
+
+    it(`renders the popup directly into the popover root by default`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: true,
+        }),
+      );
+      await eventually(async () => {
+        expect((await driver.getContentElement()).parentElement).toBe(
+          container.componentNode,
+        );
+      });
+    });
+
+    it(`renders the popup into a portal when given appendTo prop`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: true,
+          appendTo: portalContainer.node,
+        }),
+      );
+
+      await eventually(async () => {
+        expect((await driver.getContentElement()).parentElement).toBe(
+          await driver.getPortalElement(),
+        );
+      });
+
+      expect((await driver.getPortalElement()).parentElement).toBe(
+        portalContainer.node,
+      );
+      expect((await driver.getPortalElement()).classList).toContain(
+        classes.root,
+      );
+    });
+
+    it(`renders an empty portal when closed`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: false,
+          appendTo: portalContainer.node,
+        }),
+      );
+
+      await eventually(async () => {
+        expect(await driver.getContentElement()).toBeNull();
+      });
+
+      expect((await driver.getPortalElement()).parentElement).toBe(
+        portalContainer.node,
+      );
+      expect((await driver.getPortalElement()).classList).not.toContain(
+        classes.root,
+      );
+    });
+
+    it(`removes the portal on unmount`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: true,
+          appendTo: portalContainer.node,
+        }),
+      );
+
+      expect(await driver.getPortalElement()).toBeTruthy();
+      container.unmount();
+      expect(await driver.getPortalElement()).toBeNull();
+    });
+
+    it(`adds the portal to the body when appendTo="window"`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: true,
+          appendTo: 'window',
+        }),
+      );
+
+      expect((await driver.getPortalElement()).parentElement).toBe(
+        document.body,
+      );
+    });
+
+    it(`adds the portal to the closest scrollable element when appendTo="scrollParent"`, async () => {
+      const driver = await createDriver(
+        <div style={{ overflow: 'scroll' }}>
+          <div style={{ overflow: 'visible' }}>
+            {popoverWithProps({
+              placement: 'bottom',
+              appendTo: 'scrollParent',
+              shown: true,
+            })}
+          </div>
+        </div>,
+      );
+
+      expect((await driver.getPortalElement()).parentElement).toBe(
+        container.node.firstChild,
+      );
+    });
+
+    it(`adds the portal next to the popover's element when appendTo="parent"`, async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          placement: 'bottom',
+          shown: true,
+          appendTo: 'parent',
+        }),
+      );
+
+      await eventually(async () => {
+        expect(await driver.getContentElement().parentElement).toBe(
+          await driver.getTargetElement().parentElement,
+        );
+      });
+    });
+
+    describe('portal styles', () => {
+      const queryPopoverPortal = () =>
+        queryHook<HTMLElement>(document, 'popover-portal');
+      const queryPopoverContent = () =>
+        queryHook<HTMLElement>(document, 'popover-content');
+
+      it(`should update the portal's styles when updated`, async () => {
+        // First render without passing the `className` prop, the <Popover/>
+        // portal should only have the root class applied.
+        await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: true,
+            appendTo: portalContainer.node,
+          }),
+        );
+
+        // Second render with a `className` prop. Stylable `style()` function
+        // should apply it.
+        await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: true,
+            appendTo: portalContainer.node,
+            className: 'some-class',
+          }),
+        );
+
+        expect(queryPopoverPortal().classList).toContain('some-class');
+      });
+
+      it(`should not remove styles until unmounted with hideDelay`, async () => {
+        await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: true,
+            hideDelay: 10,
+            appendTo: portalContainer.node,
+          }),
+        );
+
+        await createDriver(
+          popoverWithProps({
+            placement: 'bottom',
+            shown: false,
+            hideDelay: 10,
+            appendTo: portalContainer.node,
+          }),
+        );
+
+        expect(queryPopoverPortal()).toBeTruthy();
+        expect(queryPopoverPortal().classList).toContain(classes.root);
+
+        await delay(10);
+        expect(queryPopoverPortal().classList).not.toContain(classes.root);
+      });
+
+      it(`should add contentClassName to the popover content if passed`, async () => {
+        const contentClassName = 'some-content-classname';
+
+        await createDriver(
+          popoverWithProps({
+            shown: true,
+            appendTo: portalContainer.node,
+            contentClassName,
+          }),
+        );
+
+        await createDriver(
+          popoverWithProps({
+            shown: true,
+            appendTo: portalContainer.node,
+            contentClassName,
+          }),
+        );
+
+        expect(queryPopoverContent()).toBeTruthy();
+        expect(queryPopoverContent().classList).toContain(contentClassName);
+      });
+    });
+  });
+
+  describe('React <16 compatibility', () => {
+    it('should wrap children in a <div/> if provided as strings to support React 15', async () => {
+      const driver = await createDriver(
+        <Component shown placement="bottom">
+          <Component.Element>Element</Component.Element>
+          <Component.Content>Content</Component.Content>
+        </Component>,
+      );
+
+      expect((await driver.getTargetElement()).childNodes[0].nodeName).toEqual(
+        'DIV',
+      );
+
+      await eventually(async () => {
+        expect(
+          (await driver.getContentElement()).childNodes[0].nodeName,
+        ).toEqual('DIV');
+      });
+    });
+  });
+
+  describe('createModifiers', () => {
+    const defaultProps = {
+      width: undefined,
+      moveBy: undefined,
+      minWidth: undefined,
+      dynamicWidth: undefined,
+      appendTo: undefined,
+      shouldAnimate: false,
+      flip: true,
+      fixed: false,
+      placement: 'bottom',
+      isTestEnv: false,
+    };
+
+    it('should match default modifiers', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+      });
+
+      expect(modifiers).toEqual({
+        offset: {
+          offset: '0px, 0px',
+        },
+        computeStyle: {
+          gpuAcceleration: true,
+        },
+        flip: {
+          enabled: true,
+        },
+        preventOverflow: {
+          enabled: true,
+        },
+        hide: {
+          enabled: true,
+        },
+      });
+    });
+
+    it('should calculate the offset properly using moveBy for the top placement', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        moveBy: { x: 5, y: 10 },
+        placement: 'top',
+      });
+
+      expect(modifiers.offset.offset).toEqual('5px, 10px');
+    });
+
+    it('should calculate the offset properly using moveBy for the right placement', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        moveBy: { x: 5, y: 10 },
+        placement: 'right',
+      });
+
+      expect(modifiers.offset.offset).toEqual('10px, 5px');
+    });
+
+    it('should disable gpuAcceleration when animation is enabled', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        shouldAnimate: true,
+      });
+
+      expect(modifiers.computeStyle.gpuAcceleration).toEqual(false);
+    });
+
+    it('should disable the flip modifier if moveBy was provided', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        moveBy: { x: 5, y: 10 },
+        flip: undefined,
+      });
+
+      expect(modifiers.flip.enabled).toEqual(false);
+    });
+
+    it('should enabled the flip modifier is set explicitly regardless of moveBy', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        moveBy: { x: 5, y: 10 },
+        flip: true,
+      });
+
+      expect(modifiers.flip.enabled).toEqual(true);
+    });
+
+    it('should disable the flip modifier when set explicitly', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        flip: false,
+      });
+
+      expect(modifiers.flip.enabled).toEqual(false);
+    });
+
+    it('should disable `preventOverflow` and `hide` when fixed set to `true`', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        fixed: true,
+      });
+
+      expect(modifiers.preventOverflow.enabled).toEqual(false);
+      expect(modifiers.hide.enabled).toEqual(false);
+    });
+
+    it('should disable computeStyle when isTestEnv is set to `true`', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        isTestEnv: true,
+      });
+
+      expect(modifiers.computeStyle.enabled).toEqual(false);
+    });
+
+    it('should set boundariesElement when appendTo is provided', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        appendTo: 'viewport',
+      });
+
+      expect(modifiers.preventOverflow.boundariesElement).toEqual('viewport');
+    });
+
+    it('should enable setPopperWidth [when] given minWidth ', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        minWidth: '500px',
+      });
+
+      expect(modifiers.setPopperWidth.enabled).toEqual(true);
+    });
+
+    it('should enable setPopperWidth [when] given dynamicWidth ', async () => {
+      const modifiers = createModifiers({
+        ...defaultProps,
+        dynamicWidth: true,
+      });
+
+      expect(modifiers.setPopperWidth.enabled).toEqual(true);
+    });
+  });
+
+  describe('data-hook', () => {
+    it('should be found on target element container', async () => {
+      const driver = await createDriver(
+        <Component
+          data-hook="random"
+          appendTo="window"
+          shown
+          placement="bottom"
+        >
+          <Component.Element>Element</Component.Element>
+          <Component.Content>Content</Component.Content>
+        </Component>,
+      );
+      const target = await driver.getTargetElement();
+      expect(target.parentNode.getAttribute('data-hook')).toBe('random');
+    });
+
+    it('should construct data-content-hook', async () => {
+      const driver = await createDriver(
+        <Component
+          data-hook="random"
+          appendTo="window"
+          shown
+          placement="bottom"
+        >
+          <Component.Element>Element</Component.Element>
+          <Component.Content>Content</Component.Content>
+        </Component>,
+      );
+      const target = await driver.getTargetElement();
+      expect(target.parentNode.getAttribute('data-content-hook')).toMatch(
+        /popover-content-random-/,
+      );
+    });
+
+    it('should apply data-content-element on content element', async () => {
+      const driver = await createDriver(
+        <Component
+          data-hook="random"
+          appendTo="window"
+          shown
+          placement="bottom"
+        >
+          <Component.Element>Element</Component.Element>
+          <Component.Content>Content</Component.Content>
+        </Component>,
+      );
+      await eventually(async () => {
+        expect(await driver.isContentElementExists()).toBe(true);
+      });
+      const content = await driver.getContentElement();
+      expect(content.getAttribute('data-content-element')).toMatch(
+        /popover-content-random-/,
+      );
+    });
+    it('should not override portal component data-hook', async () => {
+      const driver = await createDriver(
+        <Component
+          data-hook="random"
+          appendTo="window"
+          shown
+          placement="bottom"
+        >
+          <Component.Element>Element</Component.Element>
+          <Component.Content>Content</Component.Content>
+        </Component>,
+      );
+      await eventually(async () => {
+        expect(await driver.isContentElementExists()).toBe(true);
+      });
+      const content = await driver.getContentElement();
+      expect(content.parentNode.getAttribute('data-hook')).toBe(
+        'popover-portal',
+      );
+    });
+  });
+
+  describe('Arrow', () => {
+    function customArrow(placement, arrowProps) {
+      return <p data-test={`custom-arrow-${placement}`} {...arrowProps} />;
     }
+
+    it('should display a custom arrow element', async () => {
+      const driver = await createDriver(
+        popoverWithProps({
+          shown: true,
+          showArrow: true,
+          placement: 'top',
+          customArrow,
+        }),
+      );
+
+      await eventually(async () => {
+        expect(await driver.isContentElementExists()).toBe(true);
+      });
+
+      const arrowElement = await driver.getArrowElement();
+      expect(arrowElement.getAttribute('data-test')).toBe('custom-arrow-top');
+    });
+  });
+
+  // Tests that run on Popover.tsx only
+  if (!isPopoverNext) {
+    describe('tabIndex', () => {
+      let popoverWrapper;
+
+      afterEach(() => {
+        popoverWrapper.unmount();
+      });
+
+      it('can focus content element when tabIndex = true', async () => {
+        const role = 'someRoleValue';
+        popoverWrapper = mount(
+          popoverWithProps({
+            shown: true,
+            tabIndex: -1,
+            role,
+          }),
+        );
+
+        popoverWrapper.instance().focus();
+
+        expect(document.activeElement.getAttribute('role')).toBe(role);
+      });
+
+      it('can\'t focus content element without tabIndex', async () => {
+        const role = 'someRoleValue';
+        popoverWrapper = mount(
+          popoverWithProps({
+            shown: true,
+            role,
+          }),
+        );
+
+        popoverWrapper.instance().focus();
+
+        expect(document.activeElement.getAttribute('role')).not.toBe(role);
+      });
+    });
+
+    describe('contentAriaAttrs', () => {
+      it('should pass aria attrs to content wrapper', async () => {
+        const role = 'someRole';
+        const ariaAttrs = {
+          ['aria-label']: 'someAriaLabel',
+          ['aria-labelledby']: 'someAriaLabelledby',
+          ['aria-describedby']: 'someAriaDescribedby',
+        };
+        const driver = await createDriver(
+          popoverWithProps({
+            shown: true,
+            role,
+            ...ariaAttrs,
+          }),
+        );
+
+        await eventually(async () => {
+          expect(await driver.isContentElementExists()).toBe(true);
+        });
+
+        const contentElement = await driver.getContentElement();
+        const contentWrapper = contentElement.querySelector(`[role="${role}"]`);
+
+        for (const [ariaAttr, ariaAttrValue] of Object.entries(ariaAttrs)) {
+          expect(contentWrapper.getAttribute(ariaAttr)).toBe(ariaAttrValue);
+        }
+      });
+    });
+
+    // describe('onPopoverBlur', () => {
+    //   let popoverWrapper;
+    //
+    //   afterEach(() => {
+    //     popoverWrapper.unmount();
+    //   });
+    //
+    //   it('should be triggered when focus is outside of popover', async () => {
+    //     const onPopoverBlur = jest.fn();
+    //     const role = 'someRoleValue';
+    //     popoverWrapper = mount(
+    //       popoverWithProps({
+    //         shown: true,
+    //         tabIndex: -1,
+    //         role,
+    //         onPopoverBlur,
+    //       }),
+    //     );
+    //     const focusableElementForTest = document.createElement('button');
+    //
+    //     document.body.appendChild(focusableElementForTest);
+    //
+    //     popoverWrapper.instance().focus();
+    //
+    //     expect(onPopoverBlur).not.toBeCalled();
+    //
+    //     Simulate.keyPress(document.activeElement, { key: 'Tab' });
+    //
+    //     expect(onPopoverBlur).toBeCalled();
+    //   });
+    // });
+  }
 }

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -1114,37 +1114,5 @@ function runTests(
         }
       });
     });
-
-    // describe('onPopoverBlur', () => {
-    //   let popoverWrapper;
-    //
-    //   afterEach(() => {
-    //     popoverWrapper.unmount();
-    //   });
-    //
-    //   it('should be triggered when focus is outside of popover', async () => {
-    //     const onPopoverBlur = jest.fn();
-    //     const role = 'someRoleValue';
-    //     popoverWrapper = mount(
-    //       popoverWithProps({
-    //         shown: true,
-    //         tabIndex: -1,
-    //         role,
-    //         onPopoverBlur,
-    //       }),
-    //     );
-    //     const focusableElementForTest = document.createElement('button');
-    //
-    //     document.body.appendChild(focusableElementForTest);
-    //
-    //     popoverWrapper.instance().focus();
-    //
-    //     expect(onPopoverBlur).not.toBeCalled();
-    //
-    //     Simulate.keyPress(document.activeElement, { key: 'Tab' });
-    //
-    //     expect(onPopoverBlur).toBeCalled();
-    //   });
-    // });
   }
 }

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -5,7 +5,10 @@ import { queryHook } from 'wix-ui-test-utils/dom';
 import { AppendTo } from './Popover';
 import { createModifiers } from './modifiers';
 
-import { ReactDOMTestContainer } from '../../../test/dom-test-container';
+import {
+  createDOMContainer,
+  ReactDOMTestContainer,
+} from '../../../test/dom-test-container';
 import { Simulate } from 'react-dom/test-utils';
 
 import { Popover, PopoverProps } from './';
@@ -15,6 +18,7 @@ import { classes } from './Popover.st.css';
 
 /** PopoverNext  */
 import { PopoverNext } from '../popover-next/popover-next';
+import { checkboxDriverFactory } from '../checkbox/Checkbox.driver';
 
 function delay(millis: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, millis));
@@ -1050,39 +1054,31 @@ function runTests(
   // Tests that run on Popover.tsx only
   if (!isPopoverNext) {
     describe('tabIndex', () => {
-      let popoverWrapper;
-
-      afterEach(() => {
-        popoverWrapper.unmount();
-      });
+      const role = 'someRoleValue';
+      const mountComponent = new ReactDOMTestContainer().unmountAfterEachTest();
 
       it('can focus content element when tabIndex = true', async () => {
-        const role = 'someRoleValue';
-        popoverWrapper = mount(
+        const popoverWrapper = await mountComponent.renderWithRef(
           popoverWithProps({
             shown: true,
             tabIndex: -1,
             role,
           }),
         );
+        popoverWrapper.focus();
 
-        popoverWrapper.instance().focus();
-
-        await eventually(async () => {
-          expect(document.activeElement.getAttribute('role')).toBe(role);
-        });
+        expect(document.activeElement.getAttribute('role')).toBe(role);
       });
 
       it('can\'t focus content element without tabIndex', async () => {
-        const role = 'someRoleValue';
-        popoverWrapper = mount(
+        const popoverWrapper = await mountComponent.renderWithRef(
           popoverWithProps({
             shown: true,
             role,
           }),
         );
 
-        popoverWrapper.instance().focus();
+        popoverWrapper.focus();
 
         expect(document.activeElement.getAttribute('role')).not.toBe(role);
       });

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -1042,18 +1042,18 @@ function runTests(createDriver, container, popoverWithProps, Component, isPopove
     });
 
     if (!isPopoverNext) {
-        describe('isFocusableContent', () => {
+        describe('withFocusableContent', () => {
             let popoverWrapper;
 
             afterEach(() => {
                 popoverWrapper.unmount();
             });
 
-            it('can focus content element when isFocusableContent = true', async () => {
+            it('can focus content element when withFocusableContent = true', async () => {
                 const role = 'someRoleValue';
                 popoverWrapper = mount(popoverWithProps({
                     shown: true,
-                    isFocusableContent: true,
+                    withFocusableContent: true,
                     role,
                 }))
 
@@ -1063,10 +1063,11 @@ function runTests(createDriver, container, popoverWithProps, Component, isPopove
                 expect(document.activeElement.getAttribute('role')).toBe(role);
             });
 
-            it("can't focus content element when isFocusableContent = false", async () => {
+            it("can't focus content element when withFocusableContent = false", async () => {
                 const role = 'someRoleValue';
                 popoverWrapper = mount(popoverWithProps({
                     shown: true,
+                    withFocusableContent: false,
                     role,
                 }))
 

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -1042,18 +1042,18 @@ function runTests(createDriver, container, popoverWithProps, Component, isPopove
     });
 
     if (!isPopoverNext) {
-        describe('withFocusableContent', () => {
+        describe('tabIndex', () => {
             let popoverWrapper;
 
             afterEach(() => {
                 popoverWrapper.unmount();
             });
 
-            it('can focus content element when withFocusableContent = true', async () => {
+            it('can focus content element when tabIndex = true', async () => {
                 const role = 'someRoleValue';
                 popoverWrapper = mount(popoverWithProps({
                     shown: true,
-                    withFocusableContent: true,
+                    tabIndex: -1,
                     role,
                 }))
 
@@ -1063,11 +1063,10 @@ function runTests(createDriver, container, popoverWithProps, Component, isPopove
                 expect(document.activeElement.getAttribute('role')).toBe(role);
             });
 
-            it("can't focus content element when withFocusableContent = false", async () => {
+            it("can't focus content element without tabIndex", async () => {
                 const role = 'someRoleValue';
                 popoverWrapper = mount(popoverWithProps({
                     shown: true,
-                    withFocusableContent: false,
                     role,
                 }))
 

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { mount } from 'enzyme';
 import * as eventually from 'wix-eventually';
 import { queryHook } from 'wix-ui-test-utils/dom';
 import { AppendTo } from './Popover';
@@ -16,1027 +17,1093 @@ import { classes } from './Popover.st.css';
 import { PopoverNext } from '../popover-next/popover-next';
 
 function delay(millis: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, millis));
+    return new Promise(resolve => setTimeout(resolve, millis));
 }
 
 const renderPopover = (props: PopoverProps, content: string = 'Content') => (
-  <Popover {...props}>
-    <Popover.Element>
-      <div>Element</div>
-    </Popover.Element>
-    <Popover.Content>
-      <div>{content}</div>
-    </Popover.Content>
-  </Popover>
+    <Popover {...props}>
+        <Popover.Element>
+            <div>Element</div>
+        </Popover.Element>
+        <Popover.Content>
+            <div>{content}</div>
+        </Popover.Content>
+    </Popover>
 );
 
 const renderPopoverNext = (
-  props: PopoverProps,
-  content: string = 'Content',
+    props: PopoverProps,
+    content: string = 'Content',
 ) => (
-  <PopoverNext {...props}>
-    <PopoverNext.Element>
-      <div>Element</div>
-    </PopoverNext.Element>
-    <PopoverNext.Content>
-      <div>{content}</div>
-    </PopoverNext.Content>
-  </PopoverNext>
+    <PopoverNext {...props}>
+        <PopoverNext.Element>
+            <div>Element</div>
+        </PopoverNext.Element>
+        <PopoverNext.Content>
+            <div>{content}</div>
+        </PopoverNext.Content>
+    </PopoverNext>
 );
 
 describe('Popover && PopoverNext', () => {
-  const container = new ReactDOMTestContainer().unmountAfterEachTest();
+    const container = new ReactDOMTestContainer().unmountAfterEachTest();
 
-  const regularDriver = container.createLegacyRenderer(
-    popoverPrivateDriverFactory,
-  );
-
-  const uniDriver = container.createUniRendererAsync((base, body) => {
-    const privateDriver = popoverPrivateDriverFactory({
-      element: container.componentNode,
-      eventTrigger: Simulate,
-    });
-
-    return {
-      ...privateDriver,
-      ...testkit(base, body),
-    };
-  });
-
-  describe('[sync] Popover', () => {
-    runTests(regularDriver, container, renderPopover, Popover);
-  });
-
-  describe('[async] Popover', () => {
-    runTests(uniDriver, container, renderPopover, Popover);
-  });
-
-  describe('[sync] PopoverNext', () => {
-    runTests(regularDriver, container, renderPopoverNext, PopoverNext);
-  });
-
-  describe('[async] PopoverNext', () => {
-    runTests(uniDriver, container, renderPopoverNext, PopoverNext);
-  });
-});
-
-function runTests(createDriver, container, popoverWithProps, Component) {
-  it('should render', async () => {
-    const driver = await createDriver(
-      popoverWithProps({
-        placement: 'bottom',
-        shown: false,
-      }),
+    const regularDriver = container.createLegacyRenderer(
+        popoverPrivateDriverFactory,
     );
 
-    expect(await driver.exists()).toBe(true);
-  });
-
-  describe('Display', () => {
-    it(`doesn't display popup when shown={false}`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: false,
-        }),
-      );
-
-      expect(await driver.isTargetElementExists()).toBe(true);
-      expect(await driver.isContentElementExists()).toBe(false);
-    });
-
-    it(`displays popup when shown={true}`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: true,
-        }),
-      );
-
-      await eventually(async () => {
-        expect(await driver.isContentElementExists()).toBe(true);
-      });
-    });
-  });
-
-  describe('Events', () => {
-    it(`calls mouseEnter and mouseLeave callbacks`, async () => {
-      const onMouseEnter = jest.fn();
-      const onMouseLeave = jest.fn();
-
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: false,
-          onMouseEnter,
-          onMouseLeave,
-        }),
-      );
-
-      await driver.mouseEnter();
-      expect(onMouseEnter).toHaveBeenCalled();
-
-      await driver.mouseLeave();
-      expect(onMouseLeave).toBeCalled();
-    });
-
-    describe('onClick', () => {
-      it('should execute onClick callback', async () => {
-        const onClick = jest.fn();
-
-        const driver = await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: false,
-            onClick,
-          }),
-        );
-
-        await driver.click();
-        expect(onClick).toBeCalled();
-      });
-    });
-
-    describe('onClickOutside', () => {
-      it('should be triggered when outside of the popover is called', async () => {
-        const onClickOutside = jest.fn();
-
-        const driver = await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: true,
-            onClickOutside,
-          }),
-        );
-
-        await driver.clickOutside();
-        await eventually(async () => {
-          expect(onClickOutside).toBeCalled();
-        });
-      });
-
-      it('should not trigger onClickOutside when clicking inside with an excluded class', async () => {
-        const onClickOutside = jest.fn();
-
-        const driver = await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: false,
-            onClickOutside,
-            excludeClass: 'excludeClass',
-          }),
-        );
-
-        await driver.click();
-        expect(onClickOutside).not.toBeCalled();
-      });
-    });
-
-    describe('onClickOutside + disableClickOutsideWhenClosed', () => {
-      it('should be triggered when outside of the popover is called', async () => {
-        const onClickOutside = jest.fn();
-
-        const driver = await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: true,
-            onClickOutside,
-            disableClickOutsideWhenClosed: true,
-          }),
-        );
-
-        await eventually(async () => {
-          await driver.isContentElementExists();
+    const uniDriver = container.createUniRendererAsync((base, body) => {
+        const privateDriver = popoverPrivateDriverFactory({
+            element: container.componentNode,
+            eventTrigger: Simulate,
         });
 
-        await driver.clickOutside();
+        return {
+            ...privateDriver,
+            ...testkit(base, body),
+        };
+    });
 
-        expect(onClickOutside).toBeCalled();
-      });
+    describe('[sync] Popover', () => {
+        runTests(regularDriver, container, renderPopover, Popover);
+    });
 
-      it('should *not* be triggered when outside of the popover is called and the popover is *not* shown', async () => {
-        const onClickOutside = jest.fn();
+    describe('[async] Popover', () => {
+        runTests(uniDriver, container, renderPopover, Popover);
+    });
 
+    describe('[sync] PopoverNext', () => {
+        runTests(regularDriver, container, renderPopoverNext, PopoverNext, true);
+    });
+
+    describe('[async] PopoverNext', () => {
+        runTests(uniDriver, container, renderPopoverNext, PopoverNext, true);
+    });
+});
+
+function runTests(createDriver, container, popoverWithProps, Component, isPopoverNext = false) {
+    it('should render', async () => {
         const driver = await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: false,
-            onClickOutside,
-            disableClickOutsideWhenClosed: true,
-          }),
-        );
-
-        await driver.clickOutside();
-        expect(onClickOutside).not.toBeCalled();
-      });
-
-      const appendToValues: AppendTo[] = [
-        'parent',
-        'window',
-        'viewport',
-        'scrollParent',
-      ];
-      appendToValues.map(value => {
-        it(`should not be triggered when content is clicked and appended to ${value}`, async () => {
-          const onClickOutside = jest.fn();
-
-          const driver = await createDriver(
             popoverWithProps({
-              placement: 'bottom',
-              shown: true,
-              onClickOutside,
-              appendTo: value,
+                placement: 'bottom',
+                shown: false,
             }),
-          );
+        );
 
-          await eventually(async () => {
-            await driver.isContentElementExists();
-          });
+        expect(await driver.exists()).toBe(true);
+    });
 
-          await driver.clickOnContent();
-          expect(onClickOutside).not.toBeCalled();
+    describe('Display', () => {
+        it(`doesn't display popup when shown={false}`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: false,
+                }),
+            );
+
+            expect(await driver.isTargetElementExists()).toBe(true);
+            expect(await driver.isContentElementExists()).toBe(false);
         });
-      });
-    });
-  });
 
-  describe('Position', () => {
-    let updatePositionSpy;
+        it(`displays popup when shown={true}`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: true,
+                }),
+            );
 
-    beforeEach(() => {
-      updatePositionSpy = jest.spyOn(Component.prototype, 'updatePosition');
-    });
-
-    afterEach(() => {
-      updatePositionSpy.mockRestore();
-    });
-
-    it(`offsets the popup arrow by specified amount`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: true,
-          showArrow: true,
-          moveArrowTo: 10,
-        }),
-      );
-
-      await eventually(async () => {
-        expect((await driver.getArrowOffset()).left).toBe('10px');
-      });
+            await eventually(async () => {
+                expect(await driver.isContentElementExists()).toBe(true);
+            });
+        });
     });
 
-    it(`should update popper's position when props are chaning`, async () => {
-      await createDriver(
-        popoverWithProps(
-          {
-            placement: 'bottom',
-            shown: true,
-          },
-          'Old Content!',
-        ),
-      );
+    describe('Events', () => {
+        it(`calls mouseEnter and mouseLeave callbacks`, async () => {
+            const onMouseEnter = jest.fn();
+            const onMouseLeave = jest.fn();
 
-      await createDriver(
-        popoverWithProps(
-          {
-            placement: 'bottom',
-            shown: true,
-          },
-          'New content!',
-        ),
-      );
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: false,
+                    onMouseEnter,
+                    onMouseLeave,
+                }),
+            );
 
-      // Should have been called for each update
-      expect(updatePositionSpy).toHaveBeenCalledTimes(2);
+            await driver.mouseEnter();
+            expect(onMouseEnter).toHaveBeenCalled();
+
+            await driver.mouseLeave();
+            expect(onMouseLeave).toBeCalled();
+        });
+
+        describe('onClick', () => {
+            it('should execute onClick callback', async () => {
+                const onClick = jest.fn();
+
+                const driver = await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: false,
+                        onClick,
+                    }),
+                );
+
+                await driver.click();
+                expect(onClick).toBeCalled();
+            });
+        });
+
+        describe('onClickOutside', () => {
+            it('should be triggered when outside of the popover is called', async () => {
+                const onClickOutside = jest.fn();
+
+                const driver = await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: true,
+                        onClickOutside,
+                    }),
+                );
+
+                await driver.clickOutside();
+                await eventually(async () => {
+                    expect(onClickOutside).toBeCalled();
+                });
+            });
+
+            it('should not trigger onClickOutside when clicking inside with an excluded class', async () => {
+                const onClickOutside = jest.fn();
+
+                const driver = await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: false,
+                        onClickOutside,
+                        excludeClass: 'excludeClass',
+                    }),
+                );
+
+                await driver.click();
+                expect(onClickOutside).not.toBeCalled();
+            });
+        });
+
+        describe('onClickOutside + disableClickOutsideWhenClosed', () => {
+            it('should be triggered when outside of the popover is called', async () => {
+                const onClickOutside = jest.fn();
+
+                const driver = await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: true,
+                        onClickOutside,
+                        disableClickOutsideWhenClosed: true,
+                    }),
+                );
+
+                await eventually(async () => {
+                    await driver.isContentElementExists();
+                });
+
+                await driver.clickOutside();
+
+                expect(onClickOutside).toBeCalled();
+            });
+
+            it('should *not* be triggered when outside of the popover is called and the popover is *not* shown', async () => {
+                const onClickOutside = jest.fn();
+
+                const driver = await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: false,
+                        onClickOutside,
+                        disableClickOutsideWhenClosed: true,
+                    }),
+                );
+
+                await driver.clickOutside();
+                expect(onClickOutside).not.toBeCalled();
+            });
+
+            const appendToValues: AppendTo[] = [
+                'parent',
+                'window',
+                'viewport',
+                'scrollParent',
+            ];
+            appendToValues.map(value => {
+                it(`should not be triggered when content is clicked and appended to ${value}`, async () => {
+                    const onClickOutside = jest.fn();
+
+                    const driver = await createDriver(
+                        popoverWithProps({
+                            placement: 'bottom',
+                            shown: true,
+                            onClickOutside,
+                            appendTo: value,
+                        }),
+                    );
+
+                    await eventually(async () => {
+                        await driver.isContentElementExists();
+                    });
+
+                    await driver.clickOnContent();
+                    expect(onClickOutside).not.toBeCalled();
+                });
+            });
+        });
     });
 
-    it(`should not directly update popper's position when the visibillity hasn't changed`, async () => {
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          showDelay: 10,
-          shown: false,
-        }),
-      );
+    describe('Position', () => {
+        let updatePositionSpy;
 
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          showDelay: 10,
-          shown: true,
-        }),
-      );
+        beforeEach(() => {
+            updatePositionSpy = jest.spyOn(Component.prototype, 'updatePosition');
+        });
 
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          showDelay: 10,
-          shown: false,
-        }),
-      );
+        afterEach(() => {
+            updatePositionSpy.mockRestore();
+        });
 
-      expect(updatePositionSpy).toHaveBeenCalledTimes(1);
-    });
-  });
+        it(`offsets the popup arrow by specified amount`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: true,
+                    showArrow: true,
+                    moveArrowTo: 10,
+                }),
+            );
 
-  describe('Animation and delay', () => {
-    // Since Popover.Content can render outside the component's root, let's query
-    // the entire document with the assumption that we don't render more than one
-    // popover at a time.
-    const queryPopoverContent = () =>
-      queryHook<HTMLElement>(document, 'popover-content');
+            await eventually(async () => {
+                expect((await driver.getArrowOffset()).left).toBe('10px');
+            });
+        });
 
-    it('animates on close given a timeout', async () => {
-      await createDriver(
-        popoverWithProps({ placement: 'bottom', shown: true, timeout: 10 }),
-      );
-
-      await createDriver(
-        popoverWithProps({ placement: 'bottom', shown: false, timeout: 10 }),
-      );
-
-      expect(queryPopoverContent()).toBeTruthy();
-      await eventually(
-        () => {
-          expect(queryPopoverContent()).toBeNull();
-        },
-        { interval: 1 },
-      );
-    });
-
-    it(`doesn't animate on close when timeout={0}`, async () => {
-      await createDriver(
-        popoverWithProps({ placement: 'bottom', shown: true, timeout: 0 }),
-      );
-
-      await createDriver(
-        popoverWithProps({ placement: 'bottom', shown: false, timeout: 0 }),
-      );
-
-      expect(queryPopoverContent()).toBeNull();
-    });
-
-    it(`doesn't animate on close when timeout is an object with 0 values`, async () => {
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: true,
-          timeout: { enter: 0, exit: 0 },
-        }),
-      );
-
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: false,
-          timeout: { enter: 0, exit: 0 },
-        }),
-      );
-
-      expect(queryPopoverContent()).toBeNull();
-    });
-
-    it(`should close after hideDelay`, async () => {
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          shown: true,
-        }),
-      );
-
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          shown: false,
-        }),
-      );
-
-      expect(queryPopoverContent()).toBeTruthy();
-      await eventually(
-        () => {
-          expect(queryPopoverContent()).toBeNull();
-        },
-        { interval: 10 },
-      );
-    });
-
-    it(`should open after showDelay`, async () => {
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          showDelay: 10,
-          shown: false,
-        }),
-      );
-
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          showDelay: 10,
-          shown: true,
-        }),
-      );
-
-      expect(queryPopoverContent()).toBeNull();
-      await eventually(
-        () => {
-          expect(queryPopoverContent()).toBeTruthy();
-        },
-        { interval: 10 },
-      );
-    });
-
-    it(`should reset timeout when state has changed`, async () => {
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          showDelay: 10,
-          shown: false,
-        }),
-      );
-
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          showDelay: 10,
-          shown: true,
-        }),
-      );
-
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          showDelay: 10,
-          shown: false,
-        }),
-      );
-
-      expect(queryPopoverContent()).toBeNull();
-      await delay(15);
-      expect(queryPopoverContent()).toBeNull();
-    });
-
-    it(`should not update delay until the popover visibillity has fully changed`, async () => {
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          shown: true,
-        }),
-      );
-
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 10,
-          shown: false,
-        }),
-      );
-
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 1000,
-          shown: false,
-        }),
-      );
-
-      expect(queryPopoverContent()).toBeTruthy();
-
-      // Making sure the popover is closed after the first `hideDelay` (10ms), and not the second
-      // one (1000ms)
-      await delay(10);
-      expect(queryPopoverContent()).toBeNull();
-    });
-
-    it(`should show the popover immediately on first render if needed`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          showDelay: 10,
-          shown: true,
-        }),
-      );
-
-      await eventually(async () => {
-        expect(await driver.isContentElementExists()).toBe(true);
-      });
-    });
-
-    it(`should show the popover immediately when delays are 0`, async () => {
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 0,
-          showDelay: 0,
-          shown: false,
-        }),
-      );
-
-      expect(queryPopoverContent()).toBeNull();
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 0,
-          showDelay: 0,
-          shown: true,
-        }),
-      );
-
-      await eventually(async () => {
-        expect(queryPopoverContent()).toBeTruthy();
-      });
-
-      // Close again the popover
-      await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          hideDelay: 0,
-          showDelay: 0,
-          shown: false,
-        }),
-      );
-
-      expect(queryPopoverContent()).toBeNull();
-    });
-  });
-
-  describe('Portal and containment', () => {
-    const portalContainer = new ReactDOMTestContainer().destroyAfterEachTest();
-
-    it(`renders the popup directly into the popover root by default`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: true,
-        }),
-      );
-      await eventually(async () => {
-        expect((await driver.getContentElement()).parentElement).toBe(
-          container.componentNode,
-        );
-      });
-    });
-
-    it(`renders the popup into a portal when given appendTo prop`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: true,
-          appendTo: portalContainer.node,
-        }),
-      );
-
-      await eventually(async () => {
-        expect((await driver.getContentElement()).parentElement).toBe(
-          await driver.getPortalElement(),
-        );
-      });
-
-      expect((await driver.getPortalElement()).parentElement).toBe(
-        portalContainer.node,
-      );
-      expect((await driver.getPortalElement()).classList).toContain(
-        classes.root,
-      );
-    });
-
-    it(`renders an empty portal when closed`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: false,
-          appendTo: portalContainer.node,
-        }),
-      );
-
-      await eventually(async () => {
-        expect(await driver.getContentElement()).toBeNull();
-      });
-
-      expect((await driver.getPortalElement()).parentElement).toBe(
-        portalContainer.node,
-      );
-      expect((await driver.getPortalElement()).classList).not.toContain(
-        classes.root,
-      );
-    });
-
-    it(`removes the portal on unmount`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: true,
-          appendTo: portalContainer.node,
-        }),
-      );
-
-      expect(await driver.getPortalElement()).toBeTruthy();
-      container.unmount();
-      expect(await driver.getPortalElement()).toBeNull();
-    });
-
-    it(`adds the portal to the body when appendTo="window"`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: true,
-          appendTo: 'window',
-        }),
-      );
-
-      expect((await driver.getPortalElement()).parentElement).toBe(
-        document.body,
-      );
-    });
-
-    it(`adds the portal to the closest scrollable element when appendTo="scrollParent"`, async () => {
-      const driver = await createDriver(
-        <div style={{ overflow: 'scroll' }}>
-          <div style={{ overflow: 'visible' }}>
-            {popoverWithProps({
-              placement: 'bottom',
-              appendTo: 'scrollParent',
-              shown: true,
-            })}
-          </div>
-        </div>,
-      );
-
-      expect((await driver.getPortalElement()).parentElement).toBe(
-        container.node.firstChild,
-      );
-    });
-
-    it(`adds the portal next to the popover's element when appendTo="parent"`, async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          placement: 'bottom',
-          shown: true,
-          appendTo: 'parent',
-        }),
-      );
-
-      await eventually(async () => {
-        expect(await driver.getContentElement().parentElement).toBe(
-          await driver.getTargetElement().parentElement,
-        );
-      });
-    });
-
-    describe('portal styles', () => {
-      const queryPopoverPortal = () =>
-        queryHook<HTMLElement>(document, 'popover-portal');
-      const queryPopoverContent = () =>
-        queryHook<HTMLElement>(document, 'popover-content');
-
-      it(`should update the portal's styles when updated`, async () => {
-        // First render without passing the `className` prop, the <Popover/>
-        // portal should only have the root class applied.
-        await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: true,
-            appendTo: portalContainer.node,
-          }),
-        );
-
-        // Second render with a `className` prop. Stylable `style()` function
-        // should apply it.
-        await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: true,
-            appendTo: portalContainer.node,
-            className: 'some-class',
-          }),
-        );
-
-        expect(queryPopoverPortal().classList).toContain('some-class');
-      });
-
-      it(`should not remove styles until unmounted with hideDelay`, async () => {
-        await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: true,
-            hideDelay: 10,
-            appendTo: portalContainer.node,
-          }),
-        );
-
-        await createDriver(
-          popoverWithProps({
-            placement: 'bottom',
-            shown: false,
-            hideDelay: 10,
-            appendTo: portalContainer.node,
-          }),
-        );
-
-        expect(queryPopoverPortal()).toBeTruthy();
-        expect(queryPopoverPortal().classList).toContain(classes.root);
-
-        await delay(10);
-        expect(queryPopoverPortal().classList).not.toContain(classes.root);
-      });
-
-        it(`should add contentClassName to the popover content if passed`, async () => {
-            const contentClassName = 'some-content-classname';
+        it(`should update popper's position when props are chaning`, async () => {
+            await createDriver(
+                popoverWithProps(
+                    {
+                        placement: 'bottom',
+                        shown: true,
+                    },
+                    'Old Content!',
+                ),
+            );
 
             await createDriver(
+                popoverWithProps(
+                    {
+                        placement: 'bottom',
+                        shown: true,
+                    },
+                    'New content!',
+                ),
+            );
+
+            // Should have been called for each update
+            expect(updatePositionSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it(`should not directly update popper's position when the visibillity hasn't changed`, async () => {
+            await createDriver(
                 popoverWithProps({
-                    shown: true,
-                    appendTo: portalContainer.node,
-                    contentClassName,
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    showDelay: 10,
+                    shown: false,
                 }),
             );
 
             await createDriver(
                 popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    showDelay: 10,
                     shown: true,
-                    appendTo: portalContainer.node,
-                    contentClassName,
+                }),
+            );
+
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    showDelay: 10,
+                    shown: false,
+                }),
+            );
+
+            expect(updatePositionSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Animation and delay', () => {
+        // Since Popover.Content can render outside the component's root, let's query
+        // the entire document with the assumption that we don't render more than one
+        // popover at a time.
+        const queryPopoverContent = () =>
+            queryHook<HTMLElement>(document, 'popover-content');
+
+        it('animates on close given a timeout', async () => {
+            await createDriver(
+                popoverWithProps({ placement: 'bottom', shown: true, timeout: 10 }),
+            );
+
+            await createDriver(
+                popoverWithProps({ placement: 'bottom', shown: false, timeout: 10 }),
+            );
+
+            expect(queryPopoverContent()).toBeTruthy();
+            await eventually(
+                () => {
+                    expect(queryPopoverContent()).toBeNull();
+                },
+                { interval: 1 },
+            );
+        });
+
+        it(`doesn't animate on close when timeout={0}`, async () => {
+            await createDriver(
+                popoverWithProps({ placement: 'bottom', shown: true, timeout: 0 }),
+            );
+
+            await createDriver(
+                popoverWithProps({ placement: 'bottom', shown: false, timeout: 0 }),
+            );
+
+            expect(queryPopoverContent()).toBeNull();
+        });
+
+        it(`doesn't animate on close when timeout is an object with 0 values`, async () => {
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: true,
+                    timeout: { enter: 0, exit: 0 },
+                }),
+            );
+
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: false,
+                    timeout: { enter: 0, exit: 0 },
+                }),
+            );
+
+            expect(queryPopoverContent()).toBeNull();
+        });
+
+        it(`should close after hideDelay`, async () => {
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    shown: true,
+                }),
+            );
+
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    shown: false,
                 }),
             );
 
             expect(queryPopoverContent()).toBeTruthy();
-            expect(queryPopoverContent().classList).toContain(contentClassName);
+            await eventually(
+                () => {
+                    expect(queryPopoverContent()).toBeNull();
+                },
+                { interval: 10 },
+            );
+        });
+
+        it(`should open after showDelay`, async () => {
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    showDelay: 10,
+                    shown: false,
+                }),
+            );
+
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    showDelay: 10,
+                    shown: true,
+                }),
+            );
+
+            expect(queryPopoverContent()).toBeNull();
+            await eventually(
+                () => {
+                    expect(queryPopoverContent()).toBeTruthy();
+                },
+                { interval: 10 },
+            );
+        });
+
+        it(`should reset timeout when state has changed`, async () => {
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    showDelay: 10,
+                    shown: false,
+                }),
+            );
+
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    showDelay: 10,
+                    shown: true,
+                }),
+            );
+
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    showDelay: 10,
+                    shown: false,
+                }),
+            );
+
+            expect(queryPopoverContent()).toBeNull();
+            await delay(15);
+            expect(queryPopoverContent()).toBeNull();
+        });
+
+        it(`should not update delay until the popover visibillity has fully changed`, async () => {
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    shown: true,
+                }),
+            );
+
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 10,
+                    shown: false,
+                }),
+            );
+
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 1000,
+                    shown: false,
+                }),
+            );
+
+            expect(queryPopoverContent()).toBeTruthy();
+
+            // Making sure the popover is closed after the first `hideDelay` (10ms), and not the second
+            // one (1000ms)
+            await delay(10);
+            expect(queryPopoverContent()).toBeNull();
+        });
+
+        it(`should show the popover immediately on first render if needed`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    showDelay: 10,
+                    shown: true,
+                }),
+            );
+
+            await eventually(async () => {
+                expect(await driver.isContentElementExists()).toBe(true);
+            });
+        });
+
+        it(`should show the popover immediately when delays are 0`, async () => {
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 0,
+                    showDelay: 0,
+                    shown: false,
+                }),
+            );
+
+            expect(queryPopoverContent()).toBeNull();
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 0,
+                    showDelay: 0,
+                    shown: true,
+                }),
+            );
+
+            await eventually(async () => {
+                expect(queryPopoverContent()).toBeTruthy();
+            });
+
+            // Close again the popover
+            await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    hideDelay: 0,
+                    showDelay: 0,
+                    shown: false,
+                }),
+            );
+
+            expect(queryPopoverContent()).toBeNull();
         });
     });
-  });
 
-  describe('React <16 compatibility', () => {
-    it('should wrap children in a <div/> if provided as strings to support React 15', async () => {
-      const driver = await createDriver(
-        <Component shown placement="bottom">
-          <Component.Element>Element</Component.Element>
-          <Component.Content>Content</Component.Content>
-        </Component>,
-      );
+    describe('Portal and containment', () => {
+        const portalContainer = new ReactDOMTestContainer().destroyAfterEachTest();
 
-      expect((await driver.getTargetElement()).childNodes[0].nodeName).toEqual(
-        'DIV',
-      );
+        it(`renders the popup directly into the popover root by default`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: true,
+                }),
+            );
+            await eventually(async () => {
+                expect((await driver.getContentElement()).parentElement).toBe(
+                    container.componentNode,
+                );
+            });
+        });
 
-      await eventually(async () => {
-        expect(
-          (await driver.getContentElement()).childNodes[0].nodeName,
-        ).toEqual('DIV');
-      });
+        it(`renders the popup into a portal when given appendTo prop`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: true,
+                    appendTo: portalContainer.node,
+                }),
+            );
+
+            await eventually(async () => {
+                expect((await driver.getContentElement()).parentElement).toBe(
+                    await driver.getPortalElement(),
+                );
+            });
+
+            expect((await driver.getPortalElement()).parentElement).toBe(
+                portalContainer.node,
+            );
+            expect((await driver.getPortalElement()).classList).toContain(
+                classes.root,
+            );
+        });
+
+        it(`renders an empty portal when closed`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: false,
+                    appendTo: portalContainer.node,
+                }),
+            );
+
+            await eventually(async () => {
+                expect(await driver.getContentElement()).toBeNull();
+            });
+
+            expect((await driver.getPortalElement()).parentElement).toBe(
+                portalContainer.node,
+            );
+            expect((await driver.getPortalElement()).classList).not.toContain(
+                classes.root,
+            );
+        });
+
+        it(`removes the portal on unmount`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: true,
+                    appendTo: portalContainer.node,
+                }),
+            );
+
+            expect(await driver.getPortalElement()).toBeTruthy();
+            container.unmount();
+            expect(await driver.getPortalElement()).toBeNull();
+        });
+
+        it(`adds the portal to the body when appendTo="window"`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: true,
+                    appendTo: 'window',
+                }),
+            );
+
+            expect((await driver.getPortalElement()).parentElement).toBe(
+                document.body,
+            );
+        });
+
+        it(`adds the portal to the closest scrollable element when appendTo="scrollParent"`, async () => {
+            const driver = await createDriver(
+                <div style={{ overflow: 'scroll' }}>
+                    <div style={{ overflow: 'visible' }}>
+                        {popoverWithProps({
+                            placement: 'bottom',
+                            appendTo: 'scrollParent',
+                            shown: true,
+                        })}
+                    </div>
+                </div>,
+            );
+
+            expect((await driver.getPortalElement()).parentElement).toBe(
+                container.node.firstChild,
+            );
+        });
+
+        it(`adds the portal next to the popover's element when appendTo="parent"`, async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    placement: 'bottom',
+                    shown: true,
+                    appendTo: 'parent',
+                }),
+            );
+
+            await eventually(async () => {
+                expect(await driver.getContentElement().parentElement).toBe(
+                    await driver.getTargetElement().parentElement,
+                );
+            });
+        });
+
+        describe('portal styles', () => {
+            const queryPopoverPortal = () =>
+                queryHook<HTMLElement>(document, 'popover-portal');
+            const queryPopoverContent = () =>
+                queryHook<HTMLElement>(document, 'popover-content');
+
+            it(`should update the portal's styles when updated`, async () => {
+                // First render without passing the `className` prop, the <Popover/>
+                // portal should only have the root class applied.
+                await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: true,
+                        appendTo: portalContainer.node,
+                    }),
+                );
+
+                // Second render with a `className` prop. Stylable `style()` function
+                // should apply it.
+                await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: true,
+                        appendTo: portalContainer.node,
+                        className: 'some-class',
+                    }),
+                );
+
+                expect(queryPopoverPortal().classList).toContain('some-class');
+            });
+
+            it(`should not remove styles until unmounted with hideDelay`, async () => {
+                await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: true,
+                        hideDelay: 10,
+                        appendTo: portalContainer.node,
+                    }),
+                );
+
+                await createDriver(
+                    popoverWithProps({
+                        placement: 'bottom',
+                        shown: false,
+                        hideDelay: 10,
+                        appendTo: portalContainer.node,
+                    }),
+                );
+
+                expect(queryPopoverPortal()).toBeTruthy();
+                expect(queryPopoverPortal().classList).toContain(classes.root);
+
+                await delay(10);
+                expect(queryPopoverPortal().classList).not.toContain(classes.root);
+            });
+
+            it(`should add contentClassName to the popover content if passed`, async () => {
+                const contentClassName = 'some-content-classname';
+
+                await createDriver(
+                    popoverWithProps({
+                        shown: true,
+                        appendTo: portalContainer.node,
+                        contentClassName,
+                    }),
+                );
+
+                await createDriver(
+                    popoverWithProps({
+                        shown: true,
+                        appendTo: portalContainer.node,
+                        contentClassName,
+                    }),
+                );
+
+                expect(queryPopoverContent()).toBeTruthy();
+                expect(queryPopoverContent().classList).toContain(contentClassName);
+            });
+        });
     });
-  });
 
-  describe('createModifiers', () => {
-    const defaultProps = {
-      width: undefined,
-      moveBy: undefined,
-      minWidth: undefined,
-      dynamicWidth: undefined,
-      appendTo: undefined,
-      shouldAnimate: false,
-      flip: true,
-      fixed: false,
-      placement: 'bottom',
-      isTestEnv: false,
-    };
+    describe('React <16 compatibility', () => {
+        it('should wrap children in a <div/> if provided as strings to support React 15', async () => {
+            const driver = await createDriver(
+                <Component shown placement="bottom">
+                    <Component.Element>Element</Component.Element>
+                    <Component.Content>Content</Component.Content>
+                </Component>,
+            );
 
-    it('should match default modifiers', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-      });
+            expect((await driver.getTargetElement()).childNodes[0].nodeName).toEqual(
+                'DIV',
+            );
 
-      expect(modifiers).toEqual({
-        offset: {
-          offset: '0px, 0px',
-        },
-        computeStyle: {
-          gpuAcceleration: true,
-        },
-        flip: {
-          enabled: true,
-        },
-        preventOverflow: {
-          enabled: true,
-        },
-        hide: {
-          enabled: true,
-        },
-      });
+            await eventually(async () => {
+                expect(
+                    (await driver.getContentElement()).childNodes[0].nodeName,
+                ).toEqual('DIV');
+            });
+        });
     });
 
-    it('should calculate the offset properly using moveBy for the top placement', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        moveBy: { x: 5, y: 10 },
-        placement: 'top',
-      });
+    describe('createModifiers', () => {
+        const defaultProps = {
+            width: undefined,
+            moveBy: undefined,
+            minWidth: undefined,
+            dynamicWidth: undefined,
+            appendTo: undefined,
+            shouldAnimate: false,
+            flip: true,
+            fixed: false,
+            placement: 'bottom',
+            isTestEnv: false,
+        };
 
-      expect(modifiers.offset.offset).toEqual('5px, 10px');
+        it('should match default modifiers', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+            });
+
+            expect(modifiers).toEqual({
+                offset: {
+                    offset: '0px, 0px',
+                },
+                computeStyle: {
+                    gpuAcceleration: true,
+                },
+                flip: {
+                    enabled: true,
+                },
+                preventOverflow: {
+                    enabled: true,
+                },
+                hide: {
+                    enabled: true,
+                },
+            });
+        });
+
+        it('should calculate the offset properly using moveBy for the top placement', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                moveBy: { x: 5, y: 10 },
+                placement: 'top',
+            });
+
+            expect(modifiers.offset.offset).toEqual('5px, 10px');
+        });
+
+        it('should calculate the offset properly using moveBy for the right placement', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                moveBy: { x: 5, y: 10 },
+                placement: 'right',
+            });
+
+            expect(modifiers.offset.offset).toEqual('10px, 5px');
+        });
+
+        it('should disable gpuAcceleration when animation is enabled', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                shouldAnimate: true,
+            });
+
+            expect(modifiers.computeStyle.gpuAcceleration).toEqual(false);
+        });
+
+        it('should disable the flip modifier if moveBy was provided', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                moveBy: { x: 5, y: 10 },
+                flip: undefined,
+            });
+
+            expect(modifiers.flip.enabled).toEqual(false);
+        });
+
+        it('should enabled the flip modifier is set explicitly regardless of moveBy', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                moveBy: { x: 5, y: 10 },
+                flip: true,
+            });
+
+            expect(modifiers.flip.enabled).toEqual(true);
+        });
+
+        it('should disable the flip modifier when set explicitly', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                flip: false,
+            });
+
+            expect(modifiers.flip.enabled).toEqual(false);
+        });
+
+        it('should disable `preventOverflow` and `hide` when fixed set to `true`', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                fixed: true,
+            });
+
+            expect(modifiers.preventOverflow.enabled).toEqual(false);
+            expect(modifiers.hide.enabled).toEqual(false);
+        });
+
+        it('should disable computeStyle when isTestEnv is set to `true`', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                isTestEnv: true,
+            });
+
+            expect(modifiers.computeStyle.enabled).toEqual(false);
+        });
+
+        it('should set boundariesElement when appendTo is provided', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                appendTo: 'viewport',
+            });
+
+            expect(modifiers.preventOverflow.boundariesElement).toEqual('viewport');
+        });
+
+        it('should enable setPopperWidth [when] given minWidth ', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                minWidth: '500px',
+            });
+
+            expect(modifiers.setPopperWidth.enabled).toEqual(true);
+        });
+
+        it('should enable setPopperWidth [when] given dynamicWidth ', async () => {
+            const modifiers = createModifiers({
+                ...defaultProps,
+                dynamicWidth: true,
+            });
+
+            expect(modifiers.setPopperWidth.enabled).toEqual(true);
+        });
     });
 
-    it('should calculate the offset properly using moveBy for the right placement', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        moveBy: { x: 5, y: 10 },
-        placement: 'right',
-      });
+    describe('data-hook', () => {
+        it('should be found on target element container', async () => {
+            const driver = await createDriver(
+                <Component
+                    data-hook="random"
+                    appendTo="window"
+                    shown
+                    placement="bottom"
+                >
+                    <Component.Element>Element</Component.Element>
+                    <Component.Content>Content</Component.Content>
+                </Component>,
+            );
+            const target = await driver.getTargetElement();
+            expect(target.parentNode.getAttribute('data-hook')).toBe('random');
+        });
 
-      expect(modifiers.offset.offset).toEqual('10px, 5px');
+        it('should construct data-content-hook', async () => {
+            const driver = await createDriver(
+                <Component
+                    data-hook="random"
+                    appendTo="window"
+                    shown
+                    placement="bottom"
+                >
+                    <Component.Element>Element</Component.Element>
+                    <Component.Content>Content</Component.Content>
+                </Component>,
+            );
+            const target = await driver.getTargetElement();
+            expect(target.parentNode.getAttribute('data-content-hook')).toMatch(
+                /popover-content-random-/,
+            );
+        });
+
+        it('should apply data-content-element on content element', async () => {
+            const driver = await createDriver(
+                <Component
+                    data-hook="random"
+                    appendTo="window"
+                    shown
+                    placement="bottom"
+                >
+                    <Component.Element>Element</Component.Element>
+                    <Component.Content>Content</Component.Content>
+                </Component>,
+            );
+            await eventually(async () => {
+                expect(await driver.isContentElementExists()).toBe(true);
+            });
+            const content = await driver.getContentElement();
+            expect(content.getAttribute('data-content-element')).toMatch(
+                /popover-content-random-/,
+            );
+        });
+        it('should not override portal component data-hook', async () => {
+            const driver = await createDriver(
+                <Component
+                    data-hook="random"
+                    appendTo="window"
+                    shown
+                    placement="bottom"
+                >
+                    <Component.Element>Element</Component.Element>
+                    <Component.Content>Content</Component.Content>
+                </Component>,
+            );
+            await eventually(async () => {
+                expect(await driver.isContentElementExists()).toBe(true);
+            });
+            const content = await driver.getContentElement();
+            expect(content.parentNode.getAttribute('data-hook')).toBe(
+                'popover-portal',
+            );
+        });
     });
 
-    it('should disable gpuAcceleration when animation is enabled', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        shouldAnimate: true,
-      });
+    describe('Arrow', () => {
+        function customArrow(placement, arrowProps) {
+            return <p data-test={`custom-arrow-${placement}`} {...arrowProps} />;
+        }
 
-      expect(modifiers.computeStyle.gpuAcceleration).toEqual(false);
+        it('should display a custom arrow element', async () => {
+            const driver = await createDriver(
+                popoverWithProps({
+                    shown: true,
+                    showArrow: true,
+                    placement: 'top',
+                    customArrow,
+                }),
+            );
+
+            await eventually(async () => {
+                expect(await driver.isContentElementExists()).toBe(true);
+            });
+
+            const arrowElement = await driver.getArrowElement();
+            expect(arrowElement.getAttribute('data-test')).toBe('custom-arrow-top');
+        });
     });
 
-    it('should disable the flip modifier if moveBy was provided', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        moveBy: { x: 5, y: 10 },
-        flip: undefined,
-      });
+    if (!isPopoverNext) {
+        describe('isFocusableContent', () => {
+            let popoverWrapper;
 
-      expect(modifiers.flip.enabled).toEqual(false);
-    });
+            afterEach(() => {
+                popoverWrapper.unmount();
+            });
 
-    it('should enabled the flip modifier is set explicitly regardless of moveBy', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        moveBy: { x: 5, y: 10 },
-        flip: true,
-      });
+            it('can focus content element when isFocusableContent = true', async () => {
+                const role = 'someRoleValue';
+                popoverWrapper = mount(popoverWithProps({
+                    shown: true,
+                    isFocusableContent: true,
+                    role,
+                }))
 
-      expect(modifiers.flip.enabled).toEqual(true);
-    });
+                // @ts-ignore
+                popoverWrapper.instance().focus()
 
-    it('should disable the flip modifier when set explicitly', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        flip: false,
-      });
+                expect(document.activeElement.getAttribute('role')).toBe(role);
+            });
 
-      expect(modifiers.flip.enabled).toEqual(false);
-    });
+            it("can't focus content element when isFocusableContent = false", async () => {
+                const role = 'someRoleValue';
+                popoverWrapper = mount(popoverWithProps({
+                    shown: true,
+                    role,
+                }))
 
-    it('should disable `preventOverflow` and `hide` when fixed set to `true`', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        fixed: true,
-      });
+                // @ts-ignore
+                popoverWrapper.instance().focus()
 
-      expect(modifiers.preventOverflow.enabled).toEqual(false);
-      expect(modifiers.hide.enabled).toEqual(false);
-    });
+                expect(document.activeElement.getAttribute('role')).not.toBe(role);
+            });
+        });
 
-    it('should disable computeStyle when isTestEnv is set to `true`', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        isTestEnv: true,
-      });
+        describe('contentAriaAttrs', () => {
+            it('should pass aria attrs to content wrapper', async () => {
+                const role = 'someRole'
+                const ariaAttrs = {
+                    ['aria-label']: 'someAriaLabel',
+                    ['aria-labelledby']: 'someAriaLabelledby',
+                    ['aria-describedby']: 'someAriaDescribedby',
+                }
+                const driver = await createDriver(
+                    popoverWithProps({
+                        shown: true,
+                        role,
+                        ...ariaAttrs
+                    }),
+                );
 
-      expect(modifiers.computeStyle.enabled).toEqual(false);
-    });
+                await eventually(async () => {
+                    expect(await driver.isContentElementExists()).toBe(true);
+                });
 
-    it('should set boundariesElement when appendTo is provided', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        appendTo: 'viewport',
-      });
+                const contentElement = await driver.getContentElement();
+                const contentWrapper = contentElement.querySelector(`[role="${role}"]`);
 
-      expect(modifiers.preventOverflow.boundariesElement).toEqual('viewport');
-    });
-
-    it('should enable setPopperWidth [when] given minWidth ', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        minWidth: '500px',
-      });
-
-      expect(modifiers.setPopperWidth.enabled).toEqual(true);
-    });
-
-    it('should enable setPopperWidth [when] given dynamicWidth ', async () => {
-      const modifiers = createModifiers({
-        ...defaultProps,
-        dynamicWidth: true,
-      });
-
-      expect(modifiers.setPopperWidth.enabled).toEqual(true);
-    });
-  });
-
-  describe('data-hook', () => {
-    it('should be found on target element container', async () => {
-      const driver = await createDriver(
-        <Component
-          data-hook="random"
-          appendTo="window"
-          shown
-          placement="bottom"
-        >
-          <Component.Element>Element</Component.Element>
-          <Component.Content>Content</Component.Content>
-        </Component>,
-      );
-      const target = await driver.getTargetElement();
-      expect(target.parentNode.getAttribute('data-hook')).toBe('random');
-    });
-
-    it('should construct data-content-hook', async () => {
-      const driver = await createDriver(
-        <Component
-          data-hook="random"
-          appendTo="window"
-          shown
-          placement="bottom"
-        >
-          <Component.Element>Element</Component.Element>
-          <Component.Content>Content</Component.Content>
-        </Component>,
-      );
-      const target = await driver.getTargetElement();
-      expect(target.parentNode.getAttribute('data-content-hook')).toMatch(
-        /popover-content-random-/,
-      );
-    });
-
-    it('should apply data-content-element on content element', async () => {
-      const driver = await createDriver(
-        <Component
-          data-hook="random"
-          appendTo="window"
-          shown
-          placement="bottom"
-        >
-          <Component.Element>Element</Component.Element>
-          <Component.Content>Content</Component.Content>
-        </Component>,
-      );
-      await eventually(async () => {
-        expect(await driver.isContentElementExists()).toBe(true);
-      });
-      const content = await driver.getContentElement();
-      expect(content.getAttribute('data-content-element')).toMatch(
-        /popover-content-random-/,
-      );
-    });
-    it('should not override portal component data-hook', async () => {
-      const driver = await createDriver(
-        <Component
-          data-hook="random"
-          appendTo="window"
-          shown
-          placement="bottom"
-        >
-          <Component.Element>Element</Component.Element>
-          <Component.Content>Content</Component.Content>
-        </Component>,
-      );
-      await eventually(async () => {
-        expect(await driver.isContentElementExists()).toBe(true);
-      });
-      const content = await driver.getContentElement();
-      expect(content.parentNode.getAttribute('data-hook')).toBe(
-        'popover-portal',
-      );
-    });
-  });
-
-  describe('Arrow', () => {
-    function customArrow(placement, arrowProps) {
-      return <p data-test={`custom-arrow-${placement}`} {...arrowProps} />;
+                for (const [ariaAttr, ariaAttrValue] of Object.entries(ariaAttrs)) {
+                    expect(contentWrapper.getAttribute(ariaAttr)).toBe(ariaAttrValue);
+                }
+            })
+        });
     }
-
-    it('should display a custom arrow element', async () => {
-      const driver = await createDriver(
-        popoverWithProps({
-          shown: true,
-          showArrow: true,
-          placement: 'top',
-          customArrow,
-        }),
-      );
-
-      await eventually(async () => {
-        expect(await driver.isContentElementExists()).toBe(true);
-      });
-
-      const arrowElement = await driver.getArrowElement();
-      expect(arrowElement.getAttribute('data-test')).toBe('custom-arrow-top');
-    });
-  });
 }

--- a/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.spec.tsx
@@ -1068,7 +1068,9 @@ function runTests(
 
         popoverWrapper.instance().focus();
 
-        expect(document.activeElement.getAttribute('role')).toBe(role);
+        await eventually(async () => {
+          expect(document.activeElement.getAttribute('role')).toBe(role);
+        });
       });
 
       it('can\'t focus content element without tabIndex', async () => {

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -249,7 +249,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
   _onKeyDown = e => {
     const { onEscPress } = this.props;
 
-    if (onEscPress && e.keyCode === 27) {
+    if (onEscPress && e.key === 'Escape') {
       onEscPress(e);
     }
   };
@@ -442,14 +442,17 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
   }
 
   componentDidMount() {
-    const { shown } = this.props;
+    const { shown, onTabOut } = this.props;
     this.initAppendToNode();
-    if (shown) {
+    if (onTabOut && shown) {
       this._setBlurByKeyboardListener();
     }
     this.setState({ isMounted: true });
   }
 
+  /**
+   * Checks to see if the focused element is outside the Popover content
+   */
   _onDocumentKeyUp = e => {
     const { onTabOut } = this.props;
 

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -235,7 +235,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     this.contentHook = `popover-content-${props['data-hook'] || ''}-${testId}`;
   }
 
-  _handleClickOutside = (event) => {
+  _handleClickOutside = event => {
     const {
       onClickOutside: onClickOutsideCallback,
       shown,
@@ -246,7 +246,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     }
   };
 
-  _onKeyDown = (e) => {
+  _onKeyDown = e => {
     const { onEscPress } = this.props;
 
     if (onEscPress && e.keyCode === 27) {
@@ -450,7 +450,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     this.setState({ isMounted: true });
   }
 
-  _onDocumentKeyUp = (e) => {
+  _onDocumentKeyUp = e => {
     const { onTabOut } = this.props;
 
     if (
@@ -637,7 +637,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
             id={id}
             {...filterDataProps(this.props)}
           >
-            <Reference innerRef={(r) => (this.targetRef = r)}>
+            <Reference innerRef={r => (this.targetRef = r)}>
               {({ ref }) => (
                 <div
                   ref={ref}

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -131,9 +131,9 @@ export interface PopoverProps {
    */
   contentClassName?: string;
   /**
-   * can focus on popover content element
+   * tabindex for popover content element
    */
-  withFocusableContent?: boolean;
+  tabIndex?: number;
   /**
    * can focus on popover content element
    */
@@ -281,7 +281,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       excludeClass = this.clickOutsideClass,
       contentClassName,
       onEscPress,
-      withFocusableContent,
+      tabIndex,
       ['aria-label']: ariaLabel,
       ['aria-labelledby']: ariaLabelledby,
       ['aria-describedby']: ariaDescribedBy,
@@ -343,7 +343,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                       key="popover-content"
                       id={id}
                       role={role}
-                      tabIndex={withFocusableContent ? -1 : undefined}
+                      tabIndex={tabIndex}
                       ref={this.popoverContentRef}
                       className={showArrow ? classes.popoverContent : ''}
                       onKeyDown={shown && onEscPress ? this._onKeyDown : undefined}

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -126,6 +126,16 @@ export interface PopoverProps {
    * the classname to be passed to the popover's content container
    */
   contentClassName?: string;
+  /**
+   * can focus on popover content element
+   */
+  isFocusableContent?: boolean;
+  /**
+   * can focus on popover content element
+   */
+  ['aria-label']?: string;
+  ['aria-labelledby']?: string;
+  ['aria-describedby']?: string;
 }
 
 export interface PopoverState {
@@ -194,6 +204,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
   portalClasses: string;
   appendToNode: HTMLElement = null;
   clickOutsideRef: any = null;
+  popoverContentRef: React.RefObject<HTMLDivElement>;
   clickOutsideClass: string;
   contentHook: string;
 
@@ -215,6 +226,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     }
 
     this.clickOutsideRef = React.createRef();
+    this.popoverContentRef = React.createRef();
     this.clickOutsideClass = uniqueId('clickOutside');
     this.contentHook = `popover-content-${props['data-hook'] || ''}-${testId}`;
   }
@@ -229,6 +241,12 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       onClickOutsideCallback(event);
     }
   };
+
+  focus() {
+    if (this.popoverContentRef.current) {
+      this.popoverContentRef.current.focus();
+    }
+  }
 
   getPopperContentStructure(childrenObject) {
     const {
@@ -249,6 +267,10 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       dynamicWidth,
       excludeClass = this.clickOutsideClass,
       contentClassName,
+      isFocusableContent,
+      ['aria-label']: ariaLabel,
+      ['aria-labelledby']: ariaLabelledby,
+      ['aria-describedby']: ariaDescribedBy,
     } = this.props;
     const shouldAnimate = shouldAnimatePopover(this.props);
 
@@ -307,7 +329,12 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                       key="popover-content"
                       id={id}
                       role={role}
+                      tabIndex={isFocusableContent ? -1 : undefined}
+                      ref={this.popoverContentRef}
                       className={showArrow ? classes.popoverContent : ''}
+                      aria-label={ariaLabel}
+                      aria-labelledby={ariaLabelledby}
+                      aria-describedby={ariaDescribedBy}
                     >
                       <PopoverContext.Provider
                         value={{

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -45,7 +45,7 @@ export interface PopoverProps {
   /** Provides callback to invoke when clicked outside of the popover */
   onClickOutside?: Function;
   /** Provides callback to invoke when popover loses focus */
-  onPopoverBlur?: Function;
+  onTabOut?: Function;
   /** Provides callback to invoke when popover loses focus */
   onEscPress?: Function;
   /**
@@ -235,23 +235,18 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     this.contentHook = `popover-content-${props['data-hook'] || ''}-${testId}`;
   }
 
-  _handleClickOutside = event => {
+  _handleClickOutside = (event) => {
     const {
       onClickOutside: onClickOutsideCallback,
       shown,
       disableClickOutsideWhenClosed,
-      onPopoverBlur,
     } = this.props;
     if (onClickOutsideCallback && !(disableClickOutsideWhenClosed && !shown)) {
       onClickOutsideCallback(event);
-
-      if (onPopoverBlur) {
-        onPopoverBlur(event);
-      }
     }
   };
 
-  _onKeyDown = e => {
+  _onKeyDown = (e) => {
     const { onEscPress } = this.props;
 
     if (onEscPress && e.keyCode === 27) {
@@ -455,15 +450,15 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     this.setState({ isMounted: true });
   }
 
-  _onDocumentKeyUp = e => {
-    const { onPopoverBlur } = this.props;
+  _onDocumentKeyUp = (e) => {
+    const { onTabOut } = this.props;
 
     if (
       typeof document !== 'undefined' &&
       this.popoverContentRef.current &&
       !this.popoverContentRef.current.contains(document.activeElement)
     ) {
-      onPopoverBlur(e);
+      onTabOut(e);
     }
   };
 
@@ -505,7 +500,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
 
   hidePopover() {
     const { isMounted } = this.state;
-    const { hideDelay, onPopoverBlur } = this.props;
+    const { hideDelay, onTabOut } = this.props;
 
     if (!isMounted || this._hideTimeout) {
       return;
@@ -516,7 +511,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       this._showTimeout = null;
     }
 
-    if (onPopoverBlur) {
+    if (onTabOut) {
       this._removeBlurListener();
     }
 
@@ -531,7 +526,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
 
   showPopover() {
     const { isMounted } = this.state;
-    const { showDelay, onPopoverBlur } = this.props;
+    const { showDelay, onTabOut } = this.props;
 
     if (!isMounted || this._showTimeout) {
       return;
@@ -542,7 +537,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       this._hideTimeout = null;
     }
 
-    if (onPopoverBlur) {
+    if (onTabOut) {
       this._setBlurByKeyboardListener();
     }
 
@@ -642,7 +637,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
             id={id}
             {...filterDataProps(this.props)}
           >
-            <Reference innerRef={r => (this.targetRef = r)}>
+            <Reference innerRef={(r) => (this.targetRef = r)}>
               {({ ref }) => (
                 <div
                   ref={ref}

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -246,11 +246,11 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     }
   };
 
-  _onKeyDown = (e) => {
+  _onKeyDown = e => {
     const { onEscPress } = this.props;
 
-    if (e.keyCode === 27) {
-      onEscPress();
+    if (onEscPress && e.keyCode === 27) {
+      onEscPress(e);
     }
   };
 
@@ -258,7 +258,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     if (this.popoverContentRef.current) {
       this.popoverContentRef.current.focus();
     }
-  };
+  }
 
   getPopperContentStructure(childrenObject) {
     const { shown } = this.state;
@@ -346,7 +346,9 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                       tabIndex={tabIndex}
                       ref={this.popoverContentRef}
                       className={showArrow ? classes.popoverContent : ''}
-                      onKeyDown={shown && onEscPress ? this._onKeyDown : undefined}
+                      onKeyDown={
+                        shown && onEscPress ? this._onKeyDown : undefined
+                      }
                       aria-label={ariaLabel}
                       aria-labelledby={ariaLabelledby}
                       aria-describedby={ariaDescribedBy}
@@ -443,28 +445,32 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     const { shown } = this.props;
     this.initAppendToNode();
     if (shown) {
-      this._setBlurListener()
+      this._setBlurByKeyboardListener();
     }
     this.setState({ isMounted: true });
   }
 
-  _blurListener = () => {
+  _onDocumentKeyUp = e => {
     const { onPopoverBlur } = this.props;
 
-    if (this.popoverContentRef.current && !this.popoverContentRef.current.contains(document.activeElement)) {
-      onPopoverBlur();
+    if (
+      typeof document !== 'undefined' &&
+      this.popoverContentRef.current &&
+      !this.popoverContentRef.current.contains(document.activeElement)
+    ) {
+      onPopoverBlur(e);
     }
-  }
+  };
 
-  _setBlurListener() {
+  _setBlurByKeyboardListener() {
     if (typeof document !== 'undefined') {
-      document.addEventListener('keyup', this._blurListener);
+      document.addEventListener('keyup', this._onDocumentKeyUp, true);
     }
   }
 
   _removeBlurListener() {
     if (typeof document !== 'undefined') {
-      document.addEventListener('keyup', this._blurListener);
+      document.removeEventListener('keyup', this._onDocumentKeyUp, true);
     }
   }
 
@@ -506,7 +512,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     }
 
     if (onPopoverBlur) {
-      this._removeBlurListener()
+      this._removeBlurListener();
     }
 
     if (hideDelay) {
@@ -532,7 +538,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     }
 
     if (onPopoverBlur) {
-      this._setBlurListener()
+      this._setBlurByKeyboardListener();
     }
 
     if (showDelay) {

--- a/packages/wix-ui-core/src/components/popover/Popover.tsx
+++ b/packages/wix-ui-core/src/components/popover/Popover.tsx
@@ -240,9 +240,14 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       onClickOutside: onClickOutsideCallback,
       shown,
       disableClickOutsideWhenClosed,
+      onPopoverBlur,
     } = this.props;
     if (onClickOutsideCallback && !(disableClickOutsideWhenClosed && !shown)) {
       onClickOutsideCallback(event);
+
+      if (onPopoverBlur) {
+        onPopoverBlur(event);
+      }
     }
   };
 

--- a/packages/wix-ui-core/src/components/popover/docs/examples.ts
+++ b/packages/wix-ui-core/src/components/popover/docs/examples.ts
@@ -16,8 +16,8 @@ export const simple = `
              onClick={() => setShown(!shown)} 
              placement="top" 
              showArrow 
-             withFocusableContent
-             onPopoverBlur={onRequestClose}
+             tabIndex={-1}
+             onTabOut={onRequestClose}
              onEscPress={onRequestClose} 
              ref={ref}>
       <Popover.Element>The Element</Popover.Element>

--- a/packages/wix-ui-core/src/components/popover/docs/examples.ts
+++ b/packages/wix-ui-core/src/components/popover/docs/examples.ts
@@ -1,10 +1,27 @@
 export const simple = `
 () => {
   const [shown, setShown] = React.useState(true)
+  const ref = React.useRef()
+  
+  if (ref.current) {
+    ref.current.focus()
+  }
+  
+  const onRequestClose = () => {
+    setShown(false)
+  }
+  
   return (
-    <Popover shown={shown} onClick={() => setShown(!shown)} placement="top" showArrow>
+    <Popover shown={shown} 
+             onClick={() => setShown(!shown)} 
+             placement="top" 
+             showArrow 
+             withFocusableContent
+             onPopoverBlur={onRequestClose}
+             onEscPress={onRequestClose} 
+             ref={ref}>
       <Popover.Element>The Element</Popover.Element>
-      <Popover.Content>The content</Popover.Content>
+      <Popover.Content><input /></Popover.Content>
     </Popover>
   )
 }

--- a/packages/wix-ui-core/src/components/popover/tests/A11yPopoverTestFixture.tsx
+++ b/packages/wix-ui-core/src/components/popover/tests/A11yPopoverTestFixture.tsx
@@ -14,7 +14,7 @@ export class A11yPopoverTestFixture extends React.PureComponent {
     this.setState({ escPress: true });
   };
 
-  _onPopoverBlur = () => {
+  _onTabOut = () => {
     this.setState({ blurred: true });
   };
 
@@ -54,7 +54,7 @@ export class A11yPopoverTestFixture extends React.PureComponent {
           role={'dialog'}
           tabIndex={-1}
           onEscPress={this._onEscPress}
-          onPopoverBlur={this._onPopoverBlur}
+          onTabOut={this._onTabOut}
           ref={this._setPopoverRef}
         >
           <Popover.Element>
@@ -66,7 +66,7 @@ export class A11yPopoverTestFixture extends React.PureComponent {
           </Popover.Content>
         </Popover>
         <br />
-        <input id={'focus-catcher'} style={{ margin: 60 }} type="text" /> {/* To catch focus */}
+        <input id={'focus-catcher'} style={{ marginTop: 60 }} type="text" />
         <br />
         <div
           id="blurred-hook"

--- a/packages/wix-ui-core/src/components/popover/tests/A11yPopoverTestFixture.tsx
+++ b/packages/wix-ui-core/src/components/popover/tests/A11yPopoverTestFixture.tsx
@@ -18,11 +18,11 @@ export class A11yPopoverTestFixture extends React.PureComponent {
     this.setState({ blurred: true });
   };
 
-  _setPopoverRef = (el) => {
+  _setPopoverRef = el => {
     this._popoverRef = el;
   };
 
-  _setInputRef = (el) => {
+  _setInputRef = el => {
     this._inputRef = el;
   };
 

--- a/packages/wix-ui-core/src/components/popover/tests/A11yPopoverTestFixture.tsx
+++ b/packages/wix-ui-core/src/components/popover/tests/A11yPopoverTestFixture.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { Popover } from '../Popover';
+
+export class A11yPopoverTestFixture extends React.PureComponent {
+  _popoverRef;
+  _inputRef;
+
+  state = {
+    escPress: false,
+    blurred: false,
+  };
+
+  _onEscPress = () => {
+    this.setState({ escPress: true });
+  };
+
+  _onPopoverBlur = () => {
+    this.setState({ blurred: true });
+  };
+
+  _setPopoverRef = (el) => {
+    this._popoverRef = el;
+  };
+
+  _setInputRef = (el) => {
+    this._inputRef = el;
+  };
+
+  _focusPopover = () => {
+    if (this._popoverRef) {
+      this._popoverRef.focus();
+    }
+  };
+
+  _focusInput = () => {
+    if (this._inputRef) {
+      this._inputRef.focus();
+    }
+  };
+
+  render() {
+    const { escPress, blurred } = this.state;
+
+    return (
+      <div>
+        <button onClick={this._focusPopover}>Focus Popover</button>
+        <br />
+        <button onClick={this._focusInput}>Focus Input</button>
+        <br />
+        <Popover
+          data-hook={'storybook-popover-a11y'}
+          placement={'bottom'}
+          shown
+          role={'dialog'}
+          tabIndex={-1}
+          onEscPress={this._onEscPress}
+          onPopoverBlur={this._onPopoverBlur}
+          ref={this._setPopoverRef}
+        >
+          <Popover.Element>
+            <div>Element</div>
+          </Popover.Element>
+          <Popover.Content>
+            <div>Content</div>
+            <input type="text" ref={this._setInputRef} />
+          </Popover.Content>
+        </Popover>
+        <br />
+        <input style={{ margin: 60 }} type="text" /> {/* To catch focus */}
+        <br />
+        <div
+          id="blurred-hook"
+          style={{ visibility: blurred ? 'visible' : 'hidden' }}
+        >
+          Blurred Popover!
+        </div>
+        <div
+          id="escape-hook"
+          style={{ visibility: escPress ? 'visible' : 'hidden' }}
+        >
+          Escape Pressed!
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/wix-ui-core/src/components/popover/tests/A11yPopoverTestFixture.tsx
+++ b/packages/wix-ui-core/src/components/popover/tests/A11yPopoverTestFixture.tsx
@@ -66,7 +66,7 @@ export class A11yPopoverTestFixture extends React.PureComponent {
           </Popover.Content>
         </Popover>
         <br />
-        <input style={{ margin: 60 }} type="text" /> {/* To catch focus */}
+        <input id={'focus-catcher'} style={{ margin: 60 }} type="text" /> {/* To catch focus */}
         <br />
         <div
           id="blurred-hook"

--- a/packages/wix-ui-core/stories/index.tsx
+++ b/packages/wix-ui-core/stories/index.tsx
@@ -13,6 +13,7 @@ import { FilePickerButtonTestFixture } from '../src/components/file-picker-butto
 import { FocusableHOCTestFixture } from '../src/hocs/Focusable/test/FocusableHOCTestFixture';
 import { InputWithOptionsTestFixture } from '../src/components/input-with-options/InputWithOptionsTestFixture';
 import { NestedPopoverTestFixture } from '../src/components/popover/tests/NestedPopoverTestFixture';
+import { A11yPopoverTestFixture } from '../src/components/popover/tests/A11yPopoverTestFixture';
 import { RadioButtonTestFixture } from '../src/components/radio-button/tests/RadioButtonTestFixture';
 import { CheckboxTestFixture } from '../src/components/checkbox/tests/CheckboxTestFixture';
 import { SignatureInputTestFixture } from '../src/components/signature-input/test/SignatureInputTestFixture';
@@ -82,6 +83,7 @@ Tests.add('RadioButton', () => <RadioButtonTestFixture />);
 Tests.add('Checkbox', () => <CheckboxTestFixture />);
 Tests.add('InputWithOptions', () => <InputWithOptionsTestFixture />);
 Tests.add('Popover - Nested', () => <NestedPopoverTestFixture />);
+Tests.add('Popover - A11Y', () => <A11yPopoverTestFixture />);
 Tests.add(SIGNATURE_INPUT_METADATA.displayName, () => (
   <SignatureInputTestFixture />
 ));


### PR DESCRIPTION
This PR includes several needed features in order to fix some a11y issues

1. Pass `aria-*` attributes to Popover content container (where the `role` is being passed to)
2. Add the ~`withFocusableContent`~ `tabIndex` prop to enable focusing the Popover content. This passes the `tabindex` to the content's container, which isn't needed all the time, that's why it's under a prop.
3. Add an on Esc key press event listener
4. Add an on blur popover (goes along with `withFocusableContent`) to notify when the focus has left the popup, so that it can be closed

The implementation was taken from @NeilWix 's example [here](https://codepen.io/WW3/pen/xxgvWeV?editors=1010).

Naming is pretty bad here, so I'm open for suggestions.
We can also think of adding an `onRequestClose` prop, that will fire on click-outside, press-esc, and blur.

I haven't yet added tests for the onBlur and onEscPress props, so this is still WIP.

Thanks 🙏 