### PR TITLE
wix-ui-core: add `--force` to `postinstall` of `@stylable/dom-test-kit`

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -40,7 +40,7 @@
     "url": "git+https://github.com/wix/wix-ui.git"
   },
   "scripts": {
-    "postinstall": "npm install @stylable/dom-test-kit@3 --no-save",
+    "postinstall": "npm install @stylable/dom-test-kit@3 --no-save --force",
     "prebuild": "npm run update-components && npm run update-components-standalone",
     "build": "npm run transpile && npm run import-path && npm run build:named-exports && build-storybook && npm run build-standalone && npm run build-puppeteer-testkits",
     "transpile": "npm run build:named-exports && yoshi build && npm run patch-stylable && npm run transpile-mixins",


### PR DESCRIPTION
This PR adds `--force` to ensure `@stylable/dom-test-kit@3` is installed in users `node_modules`.

it is to ensure that at the root level of users `node_modules` they get `@stylable/dom-test-kit` version 3, and not some other version.