### PR TITLE
wix-ui-core: remove `postinstall` script

### DIFF
--- a/packages/wix-ui-core/package.json
+++ b/packages/wix-ui-core/package.json
@@ -40,7 +40,6 @@
     "url": "git+https://github.com/wix/wix-ui.git"
   },
   "scripts": {
-    "postinstall": "npm install @stylable/dom-test-kit@3 --no-save",
     "prebuild": "npm run update-components && npm run update-components-standalone",
     "build": "npm run transpile && npm run import-path && npm run build:named-exports && build-storybook && npm run build-standalone && npm run build-puppeteer-testkits",
     "transpile": "npm run build:named-exports && yoshi build && npm run patch-stylable && npm run transpile-mixins",


### PR DESCRIPTION
this was added to ensure correct version of `@stylable/dom-test-kit` to
be present in the root of `node_modules` at the user site.

hopefully by now all users have updated their stylable versions and this
is no longer needed