### PR TITLE
Dropdown  - add additional dropdown behaviour for better A11y support

### DIFF
--- a/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
+++ b/packages/wix-ui-core/src/components/dropdown/Dropdown.spec.tsx
@@ -31,6 +31,9 @@ describe('Dropdown', () => {
     </Dropdown>
   );
 
+  const getDropdownButton = () =>
+    document.querySelector('[data-hook="open-dropdown-button"]');
+
   it('should render default dropdown', () => {
     const driver = createDriver(createDropdown());
 
@@ -62,22 +65,45 @@ describe('Dropdown', () => {
       );
     });
 
+    it('should show content on `Enter`', () => {
+      const driver = createDriver(
+        createDropdown({ options, dropdownA11yFixes: true }),
+      );
+
+      expect(driver.dropdownContentDisplayed()).toBeFalsy();
+      Simulate.keyDown(getDropdownButton(), { key: 'Enter' });
+      expect(driver.dropdownContentDisplayed()).toBeTruthy();
+    });
+
+    it('should show and close dropdown with `Space` when dropdownA11yFixes is true', () => {
+      const driver = createDriver(
+        createDropdown({ options, dropdownA11yFixes: true }),
+      );
+
+      expect(driver.dropdownContentDisplayed()).toBeFalsy();
+      Simulate.keyDown(getDropdownButton(), { key: ' ' });
+      expect(driver.dropdownContentDisplayed()).toBeTruthy();
+
+      Simulate.keyDown(getDropdownButton(), { key: ' ' });
+      expect(driver.dropdownContentDisplayed()).toBeFalsy();
+    });
+
     it('should preventDefault on up/down arrows key press inside dropdown content in order to prevent outer scroll', () => {
       const driver = createDriver(createDropdown({ options }));
       const preventDefaultSpy = jest.fn();
       driver.click();
 
-      Simulate.keyDown(
-        document.querySelector('[data-hook="open-dropdown-button"]'),
-        { key: 'ArrowDown', preventDefault: preventDefaultSpy },
-      );
+      Simulate.keyDown(getDropdownButton(), {
+        key: 'ArrowDown',
+        preventDefault: preventDefaultSpy,
+      });
       expect(preventDefaultSpy).toHaveBeenCalled();
       preventDefaultSpy.mockClear();
 
-      Simulate.keyDown(
-        document.querySelector('[data-hook="open-dropdown-button"]'),
-        { key: 'ArrowUp', preventDefault: preventDefaultSpy },
-      );
+      Simulate.keyDown(getDropdownButton(), {
+        key: 'ArrowUp',
+        preventDefault: preventDefaultSpy,
+      });
       expect(preventDefaultSpy).toHaveBeenCalled();
       preventDefaultSpy.mockClear();
     });
@@ -103,6 +129,33 @@ describe('Dropdown', () => {
       driver.click();
       driver.optionAt(0).click();
       expect(onSelect).toHaveBeenCalledWith(options[0]);
+    });
+
+    it('should select option on `Space` in case that dropdownA11yFixes is true', async () => {
+      const onSelect = jest.fn();
+      const driver = createDriver(
+        createDropdown({ options, dropdownA11yFixes: true, onSelect }),
+      );
+
+      expect(driver.dropdownContentDisplayed()).toBeFalsy();
+      Simulate.keyDown(getDropdownButton(), {
+        key: ' ',
+      });
+
+      expect(driver.dropdownContentDisplayed()).toBeTruthy();
+
+      Simulate.keyDown(getDropdownButton(), {
+        key: 'ArrowDown',
+      });
+
+      Simulate.keyDown(getDropdownButton(), {
+        key: ' ',
+      });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        ...options[0],
+        _DOMid: null,
+      });
     });
 
     it('should not be called when selecting disabled item', () => {

--- a/packages/wix-ui-core/stories/Dropdown.story.tsx
+++ b/packages/wix-ui-core/stories/Dropdown.story.tsx
@@ -1,4 +1,3 @@
-import {InputWithOptions} from '../src/components/input-with-options';
 import {Option} from '../src/components/dropdown-option';
 import {generateOptions} from '../src/components/dropdown-option/OptionsExample';
 import {Dropdown} from '../src/components/dropdown';
@@ -18,12 +17,12 @@ export default {
     openTrigger: 'click',
     fixedFooter: 'Fixed Footer',
     fixedHeader: 'Fixed Header',
-    children: <button>Choose</button>
+    children: <button>Choose</button>,
   },
 
   exampleProps: {
-    onSelect: (option: Option) => option.value,
-    onDeselect: (option: Option) => option.value,
+    onSelect: (option: Option | null) => option?.value,
+    onDeselect: (option: Option | null) => option?.value,
     placement: [
       'auto-start',
       'auto',
@@ -39,18 +38,18 @@ export default {
       'bottom-start',
       'left-end',
       'left',
-      'left-start'
+      'left-start',
     ],
 
     options: [
-      {value: options.slice(0, 1), label: '1 example option'},
-      {value: options.slice(0, 5), label: '5 example options'},
-      {value: options, label: '20 example options'}
+      { value: options.slice(0, 1), label: '1 example option' },
+      { value: options.slice(0, 5), label: '5 example options' },
+      { value: options, label: '20 example options' },
     ],
 
     initialSelectedIds: [
-      {value: [1], label: '[1]'},
-      {value: [1, 3, 4], label: '[1, 3, 4]'}
-    ]
-  }
+      { value: [1], label: '[1]' },
+      { value: [1, 3, 4], label: '[1, 3, 4]' },
+    ],
+  },
 };


### PR DESCRIPTION
Main issue was that trying to open dropdown using space key, would open it and automatically close it immediately. This is due to not preventing default behaviour when handling key down, so the space key would also trigger onClick handler, which controls state of dropdown..

Also Removed callback in open method, it was used only in onKeyDown method and it's usage doesn't really depend on running after setting the open state, but it just depends on the state being open. So made that explicit.
