### PR TITLE
skipPropsWithoutDoc

### DIFF
--- a/packages/react-autodocs-utils/src/parser/react-docgen-parse.js
+++ b/packages/react-autodocs-utils/src/parser/react-docgen-parse.js
@@ -7,11 +7,11 @@ const componentResolve = require('./component-resolve');
 
 const ensurePropsKey = object => ({ props: {}, ...object });
 
-const parseTypescript = path => ensurePropsKey(typescriptParser.parse(path)[0] || {
+const parseTypescript = path => ensurePropsKey(typescriptParser.parse(path, {
   propFilter: {
     skipPropsWithoutDoc: true,
   }
-}); // react-docgen-typescript returns array, so
+})[0] || {}); // react-docgen-typescript returns array, so
 
 const parseJavascript = (source = '', sourcePath = '') => {
   let parsed;

--- a/packages/react-autodocs-utils/src/parser/react-docgen-parse.js
+++ b/packages/react-autodocs-utils/src/parser/react-docgen-parse.js
@@ -7,7 +7,11 @@ const componentResolve = require('./component-resolve');
 
 const ensurePropsKey = object => ({ props: {}, ...object });
 
-const parseTypescript = path => ensurePropsKey(typescriptParser.parse(path)[0] || {}); // react-docgen-typescript returns array, so
+const parseTypescript = path => ensurePropsKey(typescriptParser.parse(path)[0] || {
+  propFilter: {
+    skipPropsWithoutDoc: true,
+  }
+}); // react-docgen-typescript returns array, so
 
 const parseJavascript = (source = '', sourcePath = '') => {
   let parsed;


### PR DESCRIPTION
We use `react-storybook-utils` with TypeScript, and we would like to filter out props that don't have a description