### PR TITLE
remove Menu and MenuSmall icons

### DIFF
--- a/Menu.svg
+++ b/Menu.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <path d="M20,17 L20,18 L4,18 L4,17 L20,17 Z M20,12 L20,13 L4,13 L4,12 L20,12 Z M20,7 L20,8 L4,8 L4,7 L20,7 Z"/>
-</svg>

--- a/MenuSmall.svg
+++ b/MenuSmall.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
-  <path d="M15,13 L15,14 L3,14 L3,13 L15,13 Z M15,9 L15,10 L3,10 L3,9 L15,9 Z M15,5 L15,6 L3,6 L3,5 L15,5 Z"/>
-</svg>


### PR DESCRIPTION
These files were added by mistake and since have been placed in appropriate location under wix-ui-icons-common/src/generic/raw
