### PR TITLE
react-autodocs-utils: fix testkit parser failure

### DIFF
--- a/packages/react-autodocs-utils/src/testkit-parser/get-object-descriptor.js
+++ b/packages/react-autodocs-utils/src/testkit-parser/get-object-descriptor.js
@@ -57,8 +57,13 @@ const getObjectProperties = async ({ node, ast, cwd }) => {
 const getMemberProperty = async ({ node, ast, cwd }) => {
   const object = await reduceToObject({ node: node.object, ast, cwd });
   const properties = await getObjectProperties({ node: object, ast, cwd });
-  const property = properties.find(property => property.key.name === node.property.name);
-  return property.value;
+  const property = properties.find((property) => property.key.name === node.property.name);
+  return (
+    (property && property.value) || {
+      type: 'NumericLiteral',
+      value: -1,
+    }
+  );
 };
 
 const createDescriptor = async ({ node, ast, cwd }) => {


### PR DESCRIPTION
this is a hack to prevent testkit parser to crash, when unknown node
type is reached.

unknown node type can be reached due to numerous reasons and
implementing all of them is much more costly than allowing to silently
fail.

silent failure in this case is okay, because we can still get useful
information about not failed items, whereas if parser fails entirely, we
get no information at all
