### PR TITLE
Testkit import supported environments

### DIFF
--- a/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
@@ -36,7 +36,7 @@ const makeUnifiedTestkitImportCode = ({ metadata, storyConfig }: Props) => {
         } = storyConfig;
         return testkits[type]?.template;
       })
-      .join('\n')
+      .join('\n');
   } else {
     template = `import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit';
 import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit/enzyme';

--- a/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
@@ -29,7 +29,7 @@ export const UnifiedTestkitDocumentation: React.FunctionComponent<Props> = ({
   metadata,
   storyConfig,
 }) => {
-  const driver = metadata.drivers.filter(d =>
+  const driver = metadata.drivers.filter((d) =>
     d.file.endsWith('.uni.driver.js'),
   );
 
@@ -51,9 +51,15 @@ export const UnifiedTestkitDocumentation: React.FunctionComponent<Props> = ({
       <Code dataHook="auto-testkit-driver-import-code">
         {makeImportCode({
           testkit: {
-            template: `import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit';
-import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit/enzyme';
-import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit/puppeteer';`,
+            template: ['vanilla', 'enzyme', 'puppeteer']
+              .filter((type) => storyConfig.config.testkits[type]?.template)
+              .map((type) => {
+                const {
+                  config: { testkits },
+                } = storyConfig;
+                return testkits[type]?.template;
+              })
+              .join('\n'),
           },
           metadata,
         })}

--- a/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
@@ -24,6 +24,33 @@ const extractNested = (descriptors: Descriptor[]) =>
     { flat: [], nested: [] },
   );
 
+const makeUnifiedTestkitImportCode = ({ metadata, storyConfig }: Props) => {
+  let template;
+
+  if (storyConfig.config.testkits) {
+    template = ['vanilla', 'enzyme', 'puppeteer']
+      .filter((type) => storyConfig.config.testkits[type]?.template)
+      .map((type) => {
+        const {
+          config: { testkits },
+        } = storyConfig;
+        return testkits[type]?.template;
+      })
+      .join('\n')
+  } else {
+    template = `import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit';
+import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit/enzyme';
+import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit/puppeteer';`;
+  }
+
+  return makeImportCode({
+    testkit: {
+      template,
+    },
+    metadata,
+  });
+};
+
 export const UnifiedTestkitDocumentation: React.FunctionComponent<Props> = ({
   dataHook,
   metadata,
@@ -49,20 +76,7 @@ export const UnifiedTestkitDocumentation: React.FunctionComponent<Props> = ({
       <h2 data-hook="auto-testkit-driver-name">Import</h2>
 
       <Code dataHook="auto-testkit-driver-import-code">
-        {makeImportCode({
-          testkit: {
-            template: ['vanilla', 'enzyme', 'puppeteer']
-              .filter((type) => storyConfig.config.testkits[type]?.template)
-              .map((type) => {
-                const {
-                  config: { testkits },
-                } = storyConfig;
-                return testkits[type]?.template;
-              })
-              .join('\n'),
-          },
-          metadata,
-        })}
+        {makeUnifiedTestkitImportCode({ storyConfig, metadata })}
       </Code>
 
       <h2 data-hook="auto-testkit-descriptor-title">API</h2>

--- a/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
@@ -32,9 +32,9 @@ const makeUnifiedTestkitImportCode = ({ metadata, storyConfig }: Props) => {
     template = ['vanilla', 'enzyme', 'puppeteer']
       .map((type) => storyConfig.config.testkits?.[type])
       .filter(
-        (testkitConfig): testkitConfig is Testkit => !!testkitConfig.template,
+        (testkit): testkit is Testkit => !!testkit?.template,
       )
-      .map((testkitConfig) => testkitConfig.template)
+      .map((testkit) => testkit.template)
       .join('\n');
   } else {
     template = `import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit';

--- a/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
@@ -6,6 +6,7 @@ import { Metadata } from '../typings/metadata';
 import { FieldsDocumentation } from './fields-documentation';
 import { Descriptor } from './typings';
 import { StoryConfig } from '../typings/story-config';
+import { Testkit } from '../typings/config';
 
 interface Props {
   dataHook?: string;
@@ -29,13 +30,11 @@ const makeUnifiedTestkitImportCode = ({ metadata, storyConfig }: Props) => {
 
   if (storyConfig.config.testkits) {
     template = ['vanilla', 'enzyme', 'puppeteer']
-      .filter((type) => storyConfig.config.testkits[type]?.template)
-      .map((type) => {
-        const {
-          config: { testkits },
-        } = storyConfig;
-        return testkits[type]?.template;
-      })
+      .map((type) => storyConfig.config.testkits?.[type])
+      .filter(
+        (testkitConfig): testkitConfig is Testkit => !!testkitConfig.template,
+      )
+      .map((testkitConfig) => testkitConfig.template)
       .join('\n');
   } else {
     template = `import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit';

--- a/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
@@ -30,11 +30,9 @@ const makeUnifiedTestkitImportCode = ({ metadata, storyConfig }: Props) => {
 
   if (storyConfig.config.testkits) {
     template = ['vanilla', 'enzyme', 'puppeteer']
-      .map((type) => storyConfig.config.testkits?.[type])
-      .filter(
-        (testkit): testkit is Testkit => !!testkit?.template,
-      )
-      .map((testkit) => testkit.template)
+      .map(type => storyConfig.config.testkits?.[type])
+      .filter((testkit): testkit is Testkit => !!testkit?.template)
+      .map(testkit => testkit.template)
       .join('\n');
   } else {
     template = `import { <%= component.displayName %>Testkit } from '${storyConfig.config.importTestkitPath}/testkit';
@@ -55,8 +53,8 @@ export const UnifiedTestkitDocumentation: React.FunctionComponent<Props> = ({
   metadata,
   storyConfig,
 }) => {
-  const driver = metadata.drivers.filter((d) =>
-    d.file.endsWith('.uni.driver.js'),
+  const driver = metadata.drivers.filter(d =>
+    d.file.endsWith('.uni.driver.js')
   );
 
   let error;

--- a/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
+++ b/packages/wix-storybook-utils/src/AutoTestkit/unified-testkit-documentation.tsx
@@ -54,7 +54,7 @@ export const UnifiedTestkitDocumentation: React.FunctionComponent<Props> = ({
   storyConfig,
 }) => {
   const driver = metadata.drivers.filter(d =>
-    d.file.endsWith('.uni.driver.js')
+    d.file.endsWith('.uni.driver.js'),
   );
 
   let error;


### PR DESCRIPTION
We would like to specify which environments our uni driver testkit supports.

We can achieve that by using the existing `testkits` config.

When it exists, we will use it for the `Import` section in the `Testkit` tab.

When it doesn't exist, use the hardcoded `Import` section.