### PR TITLE
Checkbox - add accessibility aria-invalid and aria-describedby to checkbox's input

### DIFF
--- a/packages/wix-ui-core/src/components/checkbox/Checkbox.spec.tsx
+++ b/packages/wix-ui-core/src/components/checkbox/Checkbox.spec.tsx
@@ -102,6 +102,18 @@ describe('Checkbox', () => {
 
       expect(checkbox.input().getAttribute('aria-controls')).toBe('123,345');
     });
+
+    it('passes "aria-invalid" value to the input', () => {
+      const checkbox = createDriver(<Checkbox aria-invalid={'true'} />);
+
+      expect(checkbox.input().getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('passes "aria-describedby" value to the input', () => {
+      const checkbox = createDriver(<Checkbox aria-describedby={'described-by'} />);
+
+      expect(checkbox.input().getAttribute('aria-describedby')).toBe('described-by');
+    });
   });
 
   describe('Form element', () => {

--- a/packages/wix-ui-core/src/components/checkbox/Checkbox.tsx
+++ b/packages/wix-ui-core/src/components/checkbox/Checkbox.tsx
@@ -26,6 +26,8 @@ export interface CheckboxProps extends React.InputHTMLAttributes<HTMLElement> {
   error?: boolean;
   /** Whether the checkbox is indeterminate */
   indeterminate?: boolean;
+  'aria-invalid'?: React.AriaAttributes['aria-invalid'];
+  'aria-describedby'?: React.AriaAttributes['aria-describedby'];
 }
 
 export interface CheckboxState {
@@ -101,6 +103,8 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
           name={this.props.name}
           aria-controls={this.props['aria-controls']}
           aria-label={this.props['aria-label']}
+          aria-invalid={this.props['aria-invalid']}
+          aria-describedby={this.props['aria-describedby']}
         />
 
         <span className={classes.box}>


### PR DESCRIPTION
In order bo add error icon to checkbox in wix-ui-tpa, we need aria-invalid and aria-describedby on checkbox input