### PR TITLE
Input - add input ref props

### DIFF
--- a/packages/wix-ui-core/src/components/input/Input.spec.tsx
+++ b/packages/wix-ui-core/src/components/input/Input.spec.tsx
@@ -80,6 +80,15 @@ describe('Input', () => {
     expect(input.suffix.textContent).toBe('SUFFIX');
   });
 
+  it('should pass ref attribute to native input', async () => {
+    const expectedType = 'password';
+    const ref = React.createRef<HTMLInputElement>();
+
+    await render(<Input inputRef={ref} type={expectedType} />);
+
+    expect(ref.current.type).toEqual(expectedType);
+  });
+
   describe('Imperative API', () => {
     it('should support focus() and blur() methods', async () => {
       const { input, instance } = await render(<Input />);

--- a/packages/wix-ui-core/src/components/input/Input.tsx
+++ b/packages/wix-ui-core/src/components/input/Input.tsx
@@ -18,6 +18,7 @@ export interface InputProps
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
   value?: string;
+  inputRef?: React.MutableRefObject<HTMLInputElement>;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
@@ -51,6 +52,15 @@ export class Input extends React.Component<InputProps, InputState> {
 
   private input: HTMLInputElement;
 
+  _extractRef = (ref) => {
+    const { inputRef } = this.props;
+
+    this.input = ref;
+    if (inputRef) {
+      inputRef.current = ref;
+    }
+  };
+
   render() {
     const { focus } = this.state;
     const {
@@ -69,6 +79,7 @@ export class Input extends React.Component<InputProps, InputState> {
       suffix: suffixProp,
       inputClassName,
       className,
+      inputRef,
       ...allOtherProps
     } = this.props;
 
@@ -86,7 +97,7 @@ export class Input extends React.Component<InputProps, InputState> {
         <input
           id={id}
           {...allOtherProps}
-          ref={(input) => (this.input = input)}
+          ref={this._extractRef}
           className={classnames(classes.nativeInput, inputClassName)}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}


### PR DESCRIPTION
In order to get the native input ref from component using wix-ui-tpa Input field