### PR TITLE
Checkbox - add input ref props 

### DIFF
--- a/packages/wix-ui-core/src/components/checkbox/Checkbox.spec.tsx
+++ b/packages/wix-ui-core/src/components/checkbox/Checkbox.spec.tsx
@@ -59,6 +59,16 @@ describe('Checkbox', () => {
         'custom-tickmark',
       );
     });
+
+    it('should pass ref attribute to native checkbox', async () => {
+      const expectedType = 'checkbox';
+      let ref;
+      const inputRef = (input) => (ref = input);
+
+      createDriver(<Checkbox inputRef={inputRef} />);
+
+      expect(ref.type).toEqual(expectedType);
+    });
   });
 
   describe('Indeterminate', () => {

--- a/packages/wix-ui-core/src/components/checkbox/Checkbox.tsx
+++ b/packages/wix-ui-core/src/components/checkbox/Checkbox.tsx
@@ -28,6 +28,7 @@ export interface CheckboxProps extends React.InputHTMLAttributes<HTMLElement> {
   indeterminate?: boolean;
   'aria-invalid'?: React.AriaAttributes['aria-invalid'];
   'aria-describedby'?: React.AriaAttributes['aria-describedby'];
+  inputRef?(input: HTMLInputElement): void;
 }
 
 export interface CheckboxState {
@@ -52,6 +53,15 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
 
   focus() {
     this.checkbox?.focus();
+  };
+
+  _extractRef = (ref) => {
+    const { inputRef } = this.props;
+
+    this.checkbox = ref;
+    if (inputRef) {
+      inputRef(ref);
+    }
   };
 
   public render() {
@@ -91,7 +101,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
           onKeyDown={this.handleInputKeyDown}
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}
-          ref={(ref) => (this.checkbox = ref)}
+          ref={this._extractRef}
           //temp fix
           checked={checked}
           disabled={disabled}


### PR DESCRIPTION
In order to get the native input ref from a component using wix-ui-tpa Checkbox field